### PR TITLE
Add meshtastic repo functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Fetchtastic is a utility for downloading and managing the latest Meshtastic Andr
   - [Files and Directories](#files-and-directories)
   - [Scheduling with Cron](#scheduling-with-cron)
   - [Notifications via NTFY](#notifications-via-ntfy)
+  - [Repository Browser](#repository-browser)
 - [Contributing](#contributing)
 
 ## Installation
@@ -87,7 +88,10 @@ During setup, you will be able to:
 ### Command List
 
 - **setup**: Run the setup process.
-- **download**: Download firmware and APKs.
+- **download**: Download firmware and APKs from GitHub releases.
+- **repo**: Interact with the meshtastic.github.io repository.
+  - **repo download**: Browse and download files from the meshtastic.github.io repository.
+  - **repo clean**: Clean the repository download directory.
 - **topic**: Display the current NTFY topic.
 - **clean**: Remove configuration, downloads, and cron jobs.
 - **version**: Display Fetchtastic version.
@@ -101,6 +105,8 @@ By default, Fetchtastic saves files and configuration in the `Downloads/Meshtast
 - **Log File**: `Downloads/Meshtastic/fetchtastic.log`
 - **APKs**: `Downloads/Meshtastic/apks`
 - **Firmware**: `Downloads/Meshtastic/firmware`
+  - **GitHub Releases**: `Downloads/Meshtastic/firmware/<version>` (managed by `download` command)
+  - **Repository Files**: `Downloads/Meshtastic/firmware/repo` (managed by `repo download` command)
 
 You can manually edit the configuration file to change the settings.
 
@@ -122,6 +128,35 @@ If you choose to set up notifications, Fetchtastic will send updates to your spe
 
 - You can subscribe to the topic using the ntfy app or by visiting the topic URL in a browser.
 - You can choose to receive notifications **only when new files are downloaded**.
+
+### Repository Browser
+
+Fetchtastic can browse and download files directly from the [meshtastic.github.io](https://github.com/meshtastic/meshtastic.github.io/) repository.
+
+#### Using the Repository Browser
+
+1. Run the repository browser:
+
+   ```bash
+   fetchtastic repo download
+   ```
+
+2. Navigate through the menu:
+
+   - First, select a firmware directory (e.g., `firmware-2.6.8.ef9d0d7`)
+   - Then, select one or more files to download (press SPACE to select, ENTER to confirm)
+
+3. The selected files will be downloaded to the `Downloads/Meshtastic/firmware/repo/<directory>` folder.
+
+4. To clean the repository download directory:
+   ```bash
+   fetchtastic repo clean
+   ```
+
+#### Differences from Regular Downloads
+
+- The `download` command gets firmware and APKs from GitHub releases and manages version rotation.
+- The `repo download` command gets specific files from the meshtastic.github.io repository and keeps them until manually deleted.
 
 ## Contributing
 

--- a/app/menu_repo.py
+++ b/app/menu_repo.py
@@ -1,0 +1,147 @@
+# app/menu_repo.py
+
+
+import requests
+from pick import pick
+
+
+def fetch_repo_directories():
+    """
+    Fetches directories from the meshtastic.github.io repository that start with 'firmware-'.
+    Returns a list of directory names.
+    """
+    # GitHub API URL for the repository contents
+    api_url = "https://api.github.com/repos/meshtastic/meshtastic.github.io/contents"
+
+    try:
+        response = requests.get(api_url, timeout=10)
+        response.raise_for_status()
+        contents = response.json()
+
+        # Filter for directories that start with 'firmware-'
+        firmware_dirs = []
+        for item in contents:
+            if item["type"] == "dir" and item["name"].startswith("firmware-"):
+                firmware_dirs.append(item["name"])
+
+        # Sort directories by version (assuming format firmware-x.y.z.commit)
+        firmware_dirs.sort(reverse=True)
+
+        return firmware_dirs
+    except Exception as e:
+        print(f"Error fetching repository directories: {e}")
+        return []
+
+
+def fetch_directory_contents(directory):
+    """
+    Fetches the contents of a specific directory in the repository.
+    Returns a list of file names and their download URLs.
+    """
+    api_url = f"https://api.github.com/repos/meshtastic/meshtastic.github.io/contents/{directory}"
+
+    try:
+        response = requests.get(api_url, timeout=10)
+        response.raise_for_status()
+        contents = response.json()
+
+        files = []
+        for item in contents:
+            if item["type"] == "file":
+                files.append(
+                    {
+                        "name": item["name"],
+                        "download_url": item["download_url"],
+                        "path": item["path"],
+                    }
+                )
+
+        # Sort files alphabetically
+        files.sort(key=lambda x: x["name"])
+
+        return files
+    except Exception as e:
+        print(f"Error fetching directory contents: {e}")
+        return []
+
+
+def select_directory(directories):
+    """
+    Displays a menu for the user to select a firmware directory.
+    Returns the selected directory name.
+    """
+    if not directories:
+        print("No firmware directories found in the repository.")
+        return None
+
+    title = "Select a firmware directory to browse (press ENTER to confirm):"
+    option, index = pick(directories, title, indicator="*")
+    return option
+
+
+def select_files(files):
+    """
+    Displays a menu for the user to select files to download.
+    Returns a list of selected file information.
+    """
+    if not files:
+        print("No files found in the selected directory.")
+        return None
+
+    # Create a list of file names for the menu
+    file_names = [file["name"] for file in files]
+
+    title = """Select the files you want to download (press SPACE to select, ENTER to confirm):
+Note: Selected files will be downloaded to the repo directory."""
+
+    selected_options = pick(
+        file_names, title, multiselect=True, min_selection_count=0, indicator="*"
+    )
+
+    if not selected_options:
+        print("No files selected for download.")
+        return None
+
+    # Get the full file information for selected files
+    selected_files = []
+    for option in selected_options:
+        file_name = option[0]
+        for file in files:
+            if file["name"] == file_name:
+                selected_files.append(file)
+                break
+
+    return selected_files
+
+
+def run_menu():
+    """
+    Runs the repository browsing menu and returns the selected files.
+    """
+    try:
+        print("Fetching firmware directories from meshtastic.github.io repository...")
+        directories = fetch_repo_directories()
+
+        if not directories:
+            print("No firmware directories found. Exiting.")
+            return None
+
+        selected_dir = select_directory(directories)
+        if not selected_dir:
+            return None
+
+        print(f"Fetching files from {selected_dir}...")
+        files = fetch_directory_contents(selected_dir)
+
+        if not files:
+            print(f"No files found in {selected_dir}. Exiting.")
+            return None
+
+        selected_files = select_files(files)
+        if not selected_files:
+            return None
+
+        return {"directory": selected_dir, "files": selected_files}
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        return None

--- a/app/repo_downloader.py
+++ b/app/repo_downloader.py
@@ -1,0 +1,160 @@
+# app/repo_downloader.py
+
+import os
+import shutil
+
+import requests
+
+
+def download_repo_files(selected_files, download_dir, log_message_func=None):
+    """
+    Downloads selected files from the meshtastic.github.io repository.
+
+    Args:
+        selected_files: Dictionary containing directory and files information
+        download_dir: Base download directory
+        log_message_func: Function to log messages (optional)
+
+    Returns:
+        List of downloaded file paths
+    """
+    if log_message_func is None:
+
+        def log_message_func(message):
+            print(message)
+
+    if (
+        not selected_files
+        or "directory" not in selected_files
+        or "files" not in selected_files
+    ):
+        log_message_func("No files selected for download.")
+        return []
+
+    directory = selected_files["directory"]
+    files = selected_files["files"]
+
+    # Create repo directory if it doesn't exist
+    repo_dir = os.path.join(download_dir, "firmware", "repo")
+    if not os.path.exists(repo_dir):
+        os.makedirs(repo_dir)
+
+    # Create directory-specific folder
+    dir_path = os.path.join(repo_dir, directory)
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
+
+    downloaded_files = []
+
+    for file in files:
+        file_name = file["name"]
+        download_url = file["download_url"]
+        file_path = os.path.join(dir_path, file_name)
+
+        try:
+            log_message_func(f"Downloading {file_name} from {directory}...")
+            response = requests.get(download_url, stream=True, timeout=30)
+            response.raise_for_status()
+
+            with open(file_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+
+            # Set executable permissions for .sh files
+            if file_name.endswith(".sh"):
+                os.chmod(file_path, 0o755)
+                log_message_func(f"Set executable permissions for {file_name}")
+
+            log_message_func(f"Downloaded {file_name} to {file_path}")
+            downloaded_files.append(file_path)
+
+        except Exception as e:
+            log_message_func(f"Error downloading {file_name}: {e}")
+
+    return downloaded_files
+
+
+def clean_repo_directory(download_dir, log_message_func=None):
+    """
+    Cleans the repo directory by removing all files and subdirectories.
+
+    Args:
+        download_dir: Base download directory
+        log_message_func: Function to log messages (optional)
+
+    Returns:
+        Boolean indicating success
+    """
+    if log_message_func is None:
+
+        def log_message_func(message):
+            print(message)
+
+    repo_dir = os.path.join(download_dir, "firmware", "repo")
+
+    if not os.path.exists(repo_dir):
+        log_message_func("Repo directory does not exist. Nothing to clean.")
+        return True
+
+    try:
+        # Remove all contents of the repo directory
+        for item in os.listdir(repo_dir):
+            item_path = os.path.join(repo_dir, item)
+            if os.path.isfile(item_path) or os.path.islink(item_path):
+                os.remove(item_path)
+                log_message_func(f"Removed file: {item_path}")
+            elif os.path.isdir(item_path):
+                shutil.rmtree(item_path)
+                log_message_func(f"Removed directory: {item_path}")
+
+        log_message_func(f"Successfully cleaned the repo directory: {repo_dir}")
+        return True
+    except Exception as e:
+        log_message_func(f"Error cleaning repo directory: {e}")
+        return False
+
+
+def main(config, log_message_func=None):
+    """
+    Main function to run the repository downloader.
+
+    Args:
+        config: Configuration dictionary
+        log_message_func: Function to log messages (optional)
+
+    Returns:
+        None
+    """
+    if log_message_func is None:
+
+        def log_message_func(message):
+            print(message)
+
+    from . import menu_repo
+
+    download_dir = config.get("DOWNLOAD_DIR")
+    if not download_dir:
+        log_message_func("Download directory not configured.")
+        return
+
+    log_message_func("Starting Repository File Browser...")
+
+    # Run the menu to select files
+    selected_files = menu_repo.run_menu()
+
+    if not selected_files:
+        log_message_func("No files selected for download. Exiting.")
+        return
+
+    # Download the selected files
+    downloaded_files = download_repo_files(
+        selected_files, download_dir, log_message_func
+    )
+
+    if downloaded_files:
+        log_message_func(f"Successfully downloaded {len(downloaded_files)} files.")
+        for file_path in downloaded_files:
+            log_message_func(f"  - {os.path.basename(file_path)}")
+    else:
+        log_message_func("No files were downloaded.")


### PR DESCRIPTION
Add repository browser for meshtastic.github.io files

This PR adds a new feature to fetchtastic that allows users to browse and download files from the meshtastic.github.io repository. The feature is implemented as a new subcommand `repo download` that presents a menu interface similar to the existing firmware selection.

Key features:
- Browse directories in the meshtastic.github.io repository that start with 'firmware-'
- Select and download specific files from these directories
- Files are saved to a 'repo' directory that won't be automatically cleaned
- Clean the repo directory with the new `repo clean` command

Implementation details:
- Added new menu_repo.py module for repository browsing
- Added new repo_downloader.py module for downloading repository files
- Updated cli.py to add the new repo subcommand
- Updated README.md with documentation for the new feature