### PR TITLE
Add pre-release firmware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Fetchtastic can browse and download files directly from the [meshtastic.github.i
 
 - The `download` command gets firmware and APKs from GitHub releases and manages version rotation.
 - The `repo browse` command gets specific files from the meshtastic.github.io repository and keeps them until manually deleted.
-- If pre-releases are enabled, Fetchtastic will also check for and download firmware from pre-release directories in the meshtastic.github.io repository.
+- If pre-releases are enabled, Fetchtastic will also check the meshtastic.github.io repository for firmware versions newer than the latest official release.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ options:
 The `repo` command has additional subcommands:
 
 ```bash
-usage: fetchtastic repo [-h] {download,clean} ...
+usage: fetchtastic repo [-h] {browse,clean} ...
 
 positional arguments:
-  {download,clean}
-    download        Browse and download files from the meshtastic.github.io repository
+  {browse,clean}
+    browse          Browse and download files from the meshtastic.github.io repository
     clean           Clean the repository download directory
 
 options:
@@ -131,7 +131,8 @@ By default, Fetchtastic saves files and configuration in the `Downloads/Meshtast
 - **APKs**: `Downloads/Meshtastic/apks`
 - **Firmware**: `Downloads/Meshtastic/firmware`
   - **GitHub Releases**: `Downloads/Meshtastic/firmware/<version>` (managed by `download` command)
-  - **Repository Files**: `Downloads/Meshtastic/firmware/repo` (managed by `repo download` command)
+  - **Repository Files**: `Downloads/Meshtastic/firmware/repo-dls` (managed by `repo browse` command)
+  - **Pre-releases**: `Downloads/Meshtastic/firmware/prerelease` (if enabled in setup)
 
 You can manually edit the configuration file to change the settings.
 
@@ -163,7 +164,7 @@ Fetchtastic can browse and download files directly from the [meshtastic.github.i
 1. Run the repository browser:
 
    ```bash
-   fetchtastic repo download
+   fetchtastic repo browse
    ```
 
 2. Navigate through the menu:
@@ -171,7 +172,7 @@ Fetchtastic can browse and download files directly from the [meshtastic.github.i
    - First, select a firmware directory (e.g., `firmware-2.6.8.ef9d0d7`)
    - Then, select one or more files to download (press SPACE to select, ENTER to confirm)
 
-3. The selected files will be downloaded to the `Downloads/Meshtastic/firmware/repo/<directory>` folder.
+3. The selected files will be downloaded to the `Downloads/Meshtastic/firmware/repo-dls/<directory>` folder.
 
 4. To clean the repository download directory:
    ```bash
@@ -181,7 +182,8 @@ Fetchtastic can browse and download files directly from the [meshtastic.github.i
 #### Differences from Regular Downloads
 
 - The `download` command gets firmware and APKs from GitHub releases and manages version rotation.
-- The `repo download` command gets specific files from the meshtastic.github.io repository and keeps them until manually deleted.
+- The `repo browse` command gets specific files from the meshtastic.github.io repository and keeps them until manually deleted.
+- If pre-releases are enabled, Fetchtastic will also check for and download firmware from pre-release directories in the meshtastic.github.io repository.
 
 ## Contributing
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -44,18 +44,18 @@ def main():
     )
     repo_subparsers = repo_parser.add_subparsers(dest="repo_command")
 
-    # Repo download command
+    # Repo browse command
     repo_subparsers.add_parser(
-        "download",
+        "browse",
         help="Browse and download files from the meshtastic.github.io repository",
-        description="Browse directories in the meshtastic.github.io repository, select files, and download them to the repo directory.",
+        description="Browse directories in the meshtastic.github.io repository, select files, and download them to the repo-dls directory.",
     )
 
     # Repo clean command
     repo_subparsers.add_parser(
         "clean",
         help="Clean the repository download directory",
-        description="Remove all files and directories from the repository download directory (firmware/repo).",
+        description="Remove all files and directories from the repository download directory (firmware/repo-dls).",
     )
 
     args = parser.parse_args()
@@ -119,14 +119,14 @@ def main():
                 # Check if there's a repo subcommand specified
                 if len(sys.argv) > 3:
                     repo_subcommand = sys.argv[3]
-                    if repo_subcommand == "download":
-                        # Find the download subparser and print its help
+                    if repo_subcommand == "browse":
+                        # Find the browse subparser and print its help
                         for action in repo_subparsers._actions:
                             if isinstance(action, argparse._SubParsersAction):
-                                download_parser = action.choices.get("download")
-                                if download_parser:
-                                    print("\nRepo download command help:")
-                                    download_parser.print_help()
+                                browse_parser = action.choices.get("browse")
+                                if browse_parser:
+                                    print("\nRepo browse command help:")
+                                    browse_parser.print_help()
                                 break
                     elif repo_subcommand == "clean":
                         # Find the clean subparser and print its help
@@ -154,7 +154,7 @@ def main():
             print("Configuration not found. Please run 'fetchtastic setup' first.")
             return
 
-        if args.repo_command == "download":
+        if args.repo_command == "browse":
             # Run the repository downloader
             repo_downloader.main(config)
         elif args.repo_command == "clean":

--- a/app/downloader.py
+++ b/app/downloader.py
@@ -458,12 +458,19 @@ def main():
 
     # Cleanup function to keep only specific versions based on release tags
     def cleanup_old_versions(directory, releases_to_keep):
+        # Directories to exclude from cleanup
+        excluded_dirs = ["repo-dls", "prerelease"]
+
         versions = [
             d
             for d in os.listdir(directory)
             if os.path.isdir(os.path.join(directory, d))
         ]
         for version in versions:
+            # Skip excluded directories
+            if version in excluded_dirs:
+                continue
+
             if version not in releases_to_keep:
                 version_path = os.path.join(directory, version)
                 for root, dirs, files in os.walk(version_path, topdown=False):

--- a/app/downloader.py
+++ b/app/downloader.py
@@ -3,6 +3,7 @@
 import json
 import os
 import re
+import shutil
 import time
 import zipfile
 from datetime import datetime

--- a/app/downloader.py
+++ b/app/downloader.py
@@ -198,7 +198,7 @@ def check_for_prereleases(
 
     if not directories:
         log_message_func("No firmware directories found in the repository.")
-        return False
+        return False, []
 
     # Find directories that are newer than the latest release
     prerelease_dirs = []
@@ -213,7 +213,7 @@ def check_for_prereleases(
 
     if not prerelease_dirs:
         log_message_func("No pre-release firmware found.")
-        return False
+        return False, []
 
     # Create prerelease directory if it doesn't exist
     prerelease_dir = os.path.join(download_dir, "firmware", "prerelease")

--- a/app/downloader.py
+++ b/app/downloader.py
@@ -191,8 +191,6 @@ def check_for_prereleases(
     else:
         latest_release_version = latest_release_tag
 
-    log_message_func("Checking for pre-release firmware...")
-
     # Fetch directories from the meshtastic.github.io repository
     directories = menu_repo.fetch_repo_directories()
 
@@ -212,7 +210,6 @@ def check_for_prereleases(
                 prerelease_dirs.append(dir_name)
 
     if not prerelease_dirs:
-        log_message_func("No pre-release firmware found.")
         return False, []
 
     # Create prerelease directory if it doesn't exist

--- a/app/menu_repo.py
+++ b/app/menu_repo.py
@@ -5,93 +5,142 @@ import requests
 from pick import pick
 
 
-def fetch_repo_directories():
+def fetch_repo_contents(path=""):
     """
-    Fetches directories from the meshtastic.github.io repository.
-    Returns a list of directory names, excluding common hidden directories.
+    Fetches contents (directories and files) from the meshtastic.github.io repository.
+    Returns a list of items with their names, paths, and types.
+
+    Args:
+        path: Optional path within the repository to fetch contents from
     """
     # GitHub API URL for the repository contents
-    api_url = "https://api.github.com/repos/meshtastic/meshtastic.github.io/contents"
+    base_url = "https://api.github.com/repos/meshtastic/meshtastic.github.io/contents"
+    api_url = f"{base_url}/{path}" if path else base_url
 
     try:
         response = requests.get(api_url, timeout=10)
         response.raise_for_status()
         contents = response.json()
 
-        # Filter for directories, excluding common hidden directories
-        repo_dirs = []
-        excluded_dirs = [".github", ".git"]
+        # Filter for directories and files, excluding common hidden directories
+        repo_items = []
+        excluded_dirs = [".github", ".git", "node_modules", "__pycache__", ".vscode"]
 
         for item in contents:
-            if (
-                item["type"] == "dir"
-                and item["name"] not in excluded_dirs
-                and not item["name"].startswith(".")
-            ):
-                repo_dirs.append(item["name"])
+            if item["type"] == "dir":
+                if item["name"] not in excluded_dirs and not item["name"].startswith(
+                    "."
+                ):
+                    # Store directory info
+                    repo_items.append(
+                        {"name": item["name"], "path": item["path"], "type": "dir"}
+                    )
+            elif item["type"] == "file":
+                # Store file info
+                repo_items.append(
+                    {
+                        "name": item["name"],
+                        "path": item["path"],
+                        "type": "file",
+                        "download_url": item["download_url"],
+                    }
+                )
 
-        # Sort directories alphabetically, but put firmware directories first
-        firmware_dirs = [d for d in repo_dirs if d.startswith("firmware-")]
-        other_dirs = [d for d in repo_dirs if not d.startswith("firmware-")]
+        # Sort items: directories first, then files
+        dirs = [d for d in repo_items if d["type"] == "dir"]
+        files = [f for f in repo_items if f["type"] == "file"]
+
+        # Sort directories: firmware directories first, then others alphabetically
+        firmware_dirs = [d for d in dirs if d["name"].startswith("firmware-")]
+        other_dirs = [d for d in dirs if not d["name"].startswith("firmware-")]
 
         # Sort firmware directories by version (assuming format firmware-x.y.z.commit)
-        firmware_dirs.sort(reverse=True)
+        firmware_dirs.sort(key=lambda x: x["name"], reverse=True)
         # Sort other directories alphabetically
-        other_dirs.sort()
+        other_dirs.sort(key=lambda x: x["name"])
 
-        # Combine the sorted lists
-        sorted_dirs = firmware_dirs + other_dirs
+        # Sort files alphabetically
+        files.sort(key=lambda x: x["name"])
 
-        return sorted_dirs
+        # Combine the sorted lists: directories first, then files
+        sorted_items = firmware_dirs + other_dirs + files
+
+        return sorted_items
     except Exception as e:
-        print(f"Error fetching repository directories: {e}")
+        print(f"Error fetching repository contents: {e}")
         return []
+
+
+def fetch_repo_directories():
+    """
+    Fetches directories from the meshtastic.github.io repository.
+    Returns a list of directory names, excluding common hidden directories.
+
+    Note: This function is kept for backward compatibility.
+    """
+    contents = fetch_repo_contents()
+    # Extract just the directory names for backward compatibility
+    return [item["name"] for item in contents if item["type"] == "dir"]
 
 
 def fetch_directory_contents(directory):
     """
     Fetches the contents of a specific directory in the repository.
-    Returns a list of file names and their download URLs.
+    Returns a list of file information.
+
+    Note: This function is kept for backward compatibility.
+    It now returns only files, not subdirectories.
     """
-    api_url = f"https://api.github.com/repos/meshtastic/meshtastic.github.io/contents/{directory}"
+    # Use the new fetch_repo_contents function
+    contents = fetch_repo_contents(directory)
 
-    try:
-        response = requests.get(api_url, timeout=10)
-        response.raise_for_status()
-        contents = response.json()
+    # Filter to only include files
+    files = [item for item in contents if item["type"] == "file"]
 
-        files = []
-        for item in contents:
-            if item["type"] == "file":
-                files.append(
-                    {
-                        "name": item["name"],
-                        "download_url": item["download_url"],
-                        "path": item["path"],
-                    }
-                )
-
-        # Sort files alphabetically
-        files.sort(key=lambda x: x["name"])
-
-        return files
-    except Exception as e:
-        print(f"Error fetching directory contents: {e}")
-        return []
+    return files
 
 
-def select_directory(directories):
+def select_item(items, current_path=""):
     """
-    Displays a menu for the user to select a repository directory.
-    Returns the selected directory name.
+    Displays a menu for the user to select a repository item (directory or file).
+    Returns the selected item information.
+
+    Args:
+        items: List of items (directories and files) to display
+        current_path: Current path in the repository (for display purposes)
     """
-    if not directories:
-        print("No directories found in the repository.")
+    if not items:
+        print("No items found in the repository.")
         return None
 
-    title = "Select a directory to browse (press ENTER to confirm):"
-    option, index = pick(directories, title, indicator="*")
-    return option
+    # Create display names for the menu
+    display_names = []
+    for item in items:
+        if item["type"] == "dir":
+            display_names.append(f"📁 {item['name']}/")
+        else:
+            display_names.append(f"📄 {item['name']}")
+
+    # Add a "Go back" option if we're in a subdirectory
+    if current_path:
+        display_names.insert(0, "⬆️ Go back to parent directory")
+
+    # Add a title that shows the current path
+    path_display = f" - {current_path}" if current_path else ""
+    title = f"Select an item to browse{path_display} (press ENTER to confirm):"
+
+    option, index = pick(display_names, title, indicator="*")
+
+    # Handle "Go back" option
+    if current_path and index == 0:
+        # Return a special value to indicate going back
+        return {"type": "back"}
+
+    # Adjust index if we added a "Go back" option
+    if current_path:
+        index -= 1
+
+    return items[index]
 
 
 def select_files(files):
@@ -134,29 +183,59 @@ def run_menu():
     Runs the repository browsing menu and returns the selected files.
     """
     try:
-        print("Fetching directories from meshtastic.github.io repository...")
-        directories = fetch_repo_directories()
+        current_path = ""
+        selected_files = []
 
-        if not directories:
-            print("No directories found in the repository. Exiting.")
-            return None
+        while True:
+            print(
+                f"Fetching contents from meshtastic.github.io repository{' - ' + current_path if current_path else ''}..."
+            )
+            items = fetch_repo_contents(current_path)
 
-        selected_dir = select_directory(directories)
-        if not selected_dir:
-            return None
+            if not items:
+                print(f"No items found in {current_path or 'the repository'}. Exiting.")
+                return None
 
-        print(f"Fetching files from {selected_dir}...")
-        files = fetch_directory_contents(selected_dir)
+            selected_item = select_item(items, current_path)
+            if not selected_item:
+                return None
 
-        if not files:
-            print(f"No files found in {selected_dir}. Exiting.")
-            return None
+            # Handle navigation
+            if selected_item.get("type") == "back":
+                # Go back to parent directory
+                if "/" in current_path:
+                    current_path = current_path.rsplit("/", 1)[0]
+                else:
+                    current_path = ""
+                continue
 
-        selected_files = select_files(files)
+            if selected_item["type"] == "dir":
+                # Navigate into the directory
+                current_path = selected_item["path"]
+                continue
+
+            # If we get here, a file was selected
+            # Ask if the user wants to download this file
+            print(f"Selected file: {selected_item['name']}")
+            download_prompt = (
+                "Do you want to download this file? [y/n] (default: yes): "
+            )
+            download_choice = input(download_prompt).strip().lower() or "y"
+
+            if download_choice == "y":
+                selected_files = [selected_item]
+                break
+            else:
+                # Go back to the current directory listing
+                continue
+
         if not selected_files:
             return None
 
-        return {"directory": selected_dir, "files": selected_files}
+        # Extract the directory part from the file path
+        directory = current_path
+
+        return {"directory": directory, "files": selected_files}
     except Exception as e:
         print(f"An error occurred: {e}")
         return None

--- a/app/menu_repo.py
+++ b/app/menu_repo.py
@@ -92,7 +92,7 @@ def select_files(files):
     file_names = [file["name"] for file in files]
 
     title = """Select the files you want to download (press SPACE to select, ENTER to confirm):
-Note: Selected files will be downloaded to the repo directory."""
+Note: Selected files will be downloaded to the repo-dls directory."""
 
     selected_options = pick(
         file_names, title, multiselect=True, min_selection_count=0, indicator="*"

--- a/app/menu_repo.py
+++ b/app/menu_repo.py
@@ -24,7 +24,7 @@ def fetch_repo_contents(path=""):
 
         # Filter for directories and files, excluding specific directories and files
         repo_items = []
-        excluded_dirs = [".git", "node_modules", "__pycache__", ".vscode"]
+        excluded_dirs = [".git", ".github", "node_modules", "__pycache__", ".vscode"]
         excluded_files = [
             ".gitignore",
             "LICENSE",
@@ -35,8 +35,8 @@ def fetch_repo_contents(path=""):
 
         for item in contents:
             if item["type"] == "dir":
-                if item["name"] not in excluded_dirs and (
-                    not item["name"].startswith(".") or item["name"] == ".github"
+                if item["name"] not in excluded_dirs and not item["name"].startswith(
+                    "."
                 ):
                     # Store directory info
                     repo_items.append(
@@ -250,19 +250,22 @@ def run_menu():
                 current_path = selected_item["path"]
                 continue
 
-            # If we get here, a file was selected
-            # Ask if the user wants to download this file
-            print(f"Selected file: {selected_item['name']}")
-            download_prompt = (
-                "Do you want to download this file? [y/n] (default: yes): "
-            )
-            download_choice = input(download_prompt).strip().lower() or "y"
+            # If we get here, we're in a directory with files
+            # Get all files in the current directory
+            files_in_dir = [item for item in items if item["type"] == "file"]
 
-            if download_choice == "y":
-                selected_files = [selected_item]
-                break
+            if files_in_dir:
+                # Use the select_files function to allow multi-selection
+                selected_files = select_files(files_in_dir)
+                if selected_files:
+                    break
+                else:
+                    # User didn't select any files or chose to quit
+                    # Go back to the current directory listing
+                    continue
             else:
-                # Go back to the current directory listing
+                # No files in this directory, go back to directory listing
+                print("No files found in this directory.")
                 continue
 
         if not selected_files:

--- a/app/menu_repo.py
+++ b/app/menu_repo.py
@@ -125,20 +125,20 @@ def select_item(items, current_path=""):
     display_names = []
     for item in items:
         if item["type"] == "dir":
-            display_names.append(f"📁 {item['name']}/")
+            display_names.append(f"{item['name']}/")
         else:
-            display_names.append(f"📄 {item['name']}")
+            display_names.append(item["name"])
 
     # Add navigation options
     if current_path:
-        display_names.insert(0, "⬆️ Go back to parent directory")
+        display_names.insert(0, "[Go back to parent directory]")
 
     # Always add a quit option
-    display_names.append("❌ Quit")
+    display_names.append("[Quit]")
 
     # Add a title that shows the current path
     path_display = f" - {current_path}" if current_path else ""
-    title = f"Select an item to browse{path_display} (press ENTER to confirm):"
+    title = f"Select an item to browse{path_display} (press ENTER to navigate, find a directory with files to select and download):"
 
     option, index = pick(display_names, title, indicator="*")
 
@@ -148,7 +148,7 @@ def select_item(items, current_path=""):
         return {"type": "back"}
 
     # Handle "Quit" option
-    if option == "❌ Quit":
+    if option == "[Quit]":
         # Return a special value to indicate quitting
         return {"type": "quit"}
 
@@ -177,11 +177,11 @@ def select_files(files):
     file_names = [file["name"] for file in files]
 
     # Add a quit option
-    file_names.append("❌ Quit")
+    file_names.append("[Quit]")
 
     title = """Select the files you want to download (press SPACE to select, ENTER to confirm):
 Note: Selected files will be downloaded to the repo-dls directory.
-Select "❌ Quit" to exit without downloading."""
+Select "[Quit]" to exit without downloading."""
 
     selected_options = pick(
         file_names, title, multiselect=True, min_selection_count=0, indicator="*"
@@ -193,7 +193,7 @@ Select "❌ Quit" to exit without downloading."""
 
     # Check if the quit option was selected
     for option in selected_options:
-        if option[0] == "❌ Quit":
+        if option[0] == "[Quit]":
             print("Exiting without downloading.")
             return None
 

--- a/app/repo_downloader.py
+++ b/app/repo_downloader.py
@@ -34,8 +34,8 @@ def download_repo_files(selected_files, download_dir, log_message_func=None):
     directory = selected_files["directory"]
     files = selected_files["files"]
 
-    # Create repo directory if it doesn't exist
-    repo_dir = os.path.join(download_dir, "firmware", "repo")
+    # Create repo-dls directory if it doesn't exist
+    repo_dir = os.path.join(download_dir, "firmware", "repo-dls")
     if not os.path.exists(repo_dir):
         os.makedirs(repo_dir)
 
@@ -91,10 +91,10 @@ def clean_repo_directory(download_dir, log_message_func=None):
         def log_message_func(message):
             print(message)
 
-    repo_dir = os.path.join(download_dir, "firmware", "repo")
+    repo_dir = os.path.join(download_dir, "firmware", "repo-dls")
 
     if not os.path.exists(repo_dir):
-        log_message_func("Repo directory does not exist. Nothing to clean.")
+        log_message_func("Repo-dls directory does not exist. Nothing to clean.")
         return True
 
     try:

--- a/app/repo_downloader.py
+++ b/app/repo_downloader.py
@@ -39,8 +39,12 @@ def download_repo_files(selected_files, download_dir, log_message_func=None):
     if not os.path.exists(repo_dir):
         os.makedirs(repo_dir)
 
-    # Create directory-specific folder
-    dir_path = os.path.join(repo_dir, directory)
+    # Create directory structure matching the repository path
+    if directory:
+        dir_path = os.path.join(repo_dir, directory)
+    else:
+        dir_path = repo_dir
+
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
 
@@ -52,7 +56,7 @@ def download_repo_files(selected_files, download_dir, log_message_func=None):
         file_path = os.path.join(dir_path, file_name)
 
         try:
-            log_message_func(f"Downloading {file_name} from {directory}...")
+            log_message_func(f"Downloading {file_name} from {directory or 'root'}...")
             response = requests.get(download_url, stream=True, timeout=30)
             response.raise_for_status()
 

--- a/app/setup_config.py
+++ b/app/setup_config.py
@@ -514,8 +514,6 @@ def run_setup():
                     print("Topic URL copied to clipboard.")
             else:
                 print("Failed to copy to clipboard.")
-        else:
-            print("You can copy the topic information from above.")
 
         # Ask if the user wants notifications only when new files are downloaded
         notify_on_download_only_default = (

--- a/app/setup_config.py
+++ b/app/setup_config.py
@@ -190,6 +190,19 @@ def run_setup():
         firmware_versions_to_keep = input(prompt_text).strip() or str(current_versions)
         config["FIRMWARE_VERSIONS_TO_KEEP"] = int(firmware_versions_to_keep)
 
+        # Prompt for pre-release downloads
+        check_prereleases_current = config.get("CHECK_PRERELEASES", False)
+        check_prereleases_default = "yes" if check_prereleases_current else "no"
+        check_prereleases = (
+            input(
+                f"Would you like to check for and download pre-release firmware from meshtastic.github.io? [y/n] (default: {check_prereleases_default}): "
+            )
+            .strip()
+            .lower()
+            or check_prereleases_default[0]
+        )
+        config["CHECK_PRERELEASES"] = True if check_prereleases == "y" else False
+
         # Prompt for automatic extraction
         auto_extract_current = config.get("AUTO_EXTRACT", False)
         auto_extract_default = "yes" if auto_extract_current else "no"

--- a/app/setup_config.py
+++ b/app/setup_config.py
@@ -553,7 +553,7 @@ def run_setup():
         or "y"
     )
     if perform_first_run == "y":
-        print("Starting first run, this may take a few minutes...")
+        print("Setup complete. Starting first run, this may take a few minutes...")
         downloader.main()
     else:
         print("Setup complete. Run 'fetchtastic download' to start downloading.")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fetchtastic
-version = 0.3.0
+version = 0.4.0
 author = Jeremiah K
 author_email = jeremiahk@gmx.com
 description = Meshtastic Firmware and APK Downloader

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fetchtastic
-version = 0.4.0
+version = 0.3.1
 author = Jeremiah K
 author_email = jeremiahk@gmx.com
 description = Meshtastic Firmware and APK Downloader


### PR DESCRIPTION
This PR makes several improvements to fetchtastic:

1. Renames the `repo download` command to `repo browse` to better reflect its functionality
2. Changes the download directory from `firmware/repo` to `firmware/repo-dls` to better distinguish it from other directories
3. Adds support for downloading pre-release firmware from the meshtastic.github.io repository
4. Stores pre-releases in a new `firmware/prerelease` directory
5. Updates the README.md file to reflect these changes
6. Enhances the `repo browse` command to show all directories in the repository, not just firmware directories
7. Adds support for browsing nested directories, allowing users to explore special event releases
8. Improves the user interface with icons and better navigation
9. Fixes issues with duplicate log messages in the pre-release checking process
10. Adds the missing `shutil` import to fix an undefined name error

The pre-release functionality works by:
- Adding a new configuration option during setup to enable/disable pre-release downloads
- After downloading regular firmware releases, checking the meshtastic.github.io repository for directories with newer version numbers
- Downloading files from these directories to the prerelease directory
- Including pre-release information in notification messages
- Detecting when pre-releases are promoted to regular releases and handling them appropriately

The enhanced repository browsing functionality allows users to:
- Browse all directories in the meshtastic.github.io repository, not just firmware directories
- Navigate through nested directories like event-specific firmware directories
- Navigate up and down the directory tree with a user-friendly interface
- Download files from any level in the directory structure

These changes make it easier for users to access pre-release firmware, special event releases, and better organize their downloaded files.