### PR TITLE
Improve upgrade instructions based on environment

### DIFF
--- a/src/fetchtastic/cli.py
+++ b/src/fetchtastic/cli.py
@@ -9,7 +9,7 @@ import sys
 
 from fetchtastic import downloader, repo_downloader, setup_config
 from fetchtastic.log_utils import log_error, log_info, setup_logging
-from fetchtastic.setup_config import display_version_info
+from fetchtastic.setup_config import display_version_info, get_upgrade_command
 
 
 def main():
@@ -74,12 +74,12 @@ def main():
 
         # Remind about updates at the end if available
         if update_available:
-            print("\n" + "=" * 80)
-            print(
-                f"Reminder: A newer version (v{latest_version}) of Fetchtastic is available!"
+            upgrade_cmd = get_upgrade_command()
+            log_info("\nUpdate Available")
+            log_info(
+                f"A newer version (v{latest_version}) of Fetchtastic is available!"
             )
-            print("Run 'pipx upgrade fetchtastic' to upgrade.")
-            print("=" * 80)
+            log_info(f"Run '{upgrade_cmd}' to upgrade.")
     elif args.command == "download":
         # Check if configuration exists
         exists, config_path = setup_config.config_exists()
@@ -158,8 +158,9 @@ def main():
         # Log version information
         log_info(f"Fetchtastic v{current_version}")
         if update_available and latest_version:
+            upgrade_cmd = get_upgrade_command()
             log_info(f"A newer version (v{latest_version}) is available!")
-            log_info("Run 'pipx upgrade fetchtastic' to upgrade.")
+            log_info(f"Run '{upgrade_cmd}' to upgrade.")
     elif args.command == "help":
         # Check if a subcommand was specified
         if len(sys.argv) > 2:
@@ -215,24 +216,24 @@ def main():
 
             # Remind about updates at the end if available
             if update_available:
-                print("\n" + "=" * 80)
-                print(
-                    f"Reminder: A newer version (v{latest_version}) of Fetchtastic is available!"
+                upgrade_cmd = get_upgrade_command()
+                log_info("\nUpdate Available")
+                log_info(
+                    f"A newer version (v{latest_version}) of Fetchtastic is available!"
                 )
-                print("Run 'pipx upgrade fetchtastic' to upgrade.")
-                print("=" * 80)
+                log_info(f"Run '{upgrade_cmd}' to upgrade.")
         elif args.repo_command == "clean":
             # Clean the repository directory
             run_repo_clean(config)
 
             # Remind about updates at the end if available
             if update_available:
-                print("\n" + "=" * 80)
-                print(
-                    f"Reminder: A newer version (v{latest_version}) of Fetchtastic is available!"
+                upgrade_cmd = get_upgrade_command()
+                log_info("\nUpdate Available")
+                log_info(
+                    f"A newer version (v{latest_version}) of Fetchtastic is available!"
                 )
-                print("Run 'pipx upgrade fetchtastic' to upgrade.")
-                print("=" * 80)
+                log_info(f"Run '{upgrade_cmd}' to upgrade.")
         else:
             # No repo subcommand provided
             repo_parser.print_help()

--- a/src/fetchtastic/downloader.py
+++ b/src/fetchtastic/downloader.py
@@ -17,7 +17,7 @@ from fetchtastic.log_utils import (
     log_info,
     setup_logging,
 )
-from fetchtastic.setup_config import display_version_info
+from fetchtastic.setup_config import display_version_info, get_upgrade_command
 
 
 def compare_versions(version1, version2):
@@ -309,7 +309,8 @@ def main():
     log_info(f"Fetchtastic v{current_version}")
     if update_available and latest_version:
         log_info(f"A newer version (v{latest_version}) is available!")
-        log_info("Run 'pipx upgrade fetchtastic' to upgrade.")
+        upgrade_cmd = get_upgrade_command()
+        log_info(f"Run '{upgrade_cmd}' to upgrade.")
 
     # Configuration file location is already displayed in cli.py
 
@@ -927,12 +928,11 @@ def main():
 
     # Display version information again at the end of the run
     if update_available:
-        print("\n" + "=" * 80)
-        print(
-            f"Reminder: A newer version (v{latest_version}) of Fetchtastic is available!"
-        )
-        print("Run 'pipx upgrade fetchtastic' to upgrade.")
-        print("=" * 80)
+        upgrade_cmd = get_upgrade_command()
+        # Add a newline before the message to separate it from previous output
+        log_info("\nUpdate Available")
+        log_info(f"A newer version (v{latest_version}) of Fetchtastic is available!")
+        log_info(f"Run '{upgrade_cmd}' to upgrade.")
 
     if downloads_skipped:
         log_message("Not connected to Wi-Fi. Skipping all downloads.")

--- a/src/fetchtastic/setup_config.py
+++ b/src/fetchtastic/setup_config.py
@@ -815,6 +815,19 @@ def check_for_updates():
             return "unknown", None, False
 
 
+def get_upgrade_command():
+    """
+    Returns the appropriate upgrade command based on the environment.
+
+    Returns:
+        str: The command to upgrade fetchtastic
+    """
+    if is_termux():
+        return "pip install --upgrade fetchtastic"
+    else:
+        return "pipx upgrade fetchtastic"
+
+
 def display_version_info(show_update_message=True):
     """
     Display version information and update message if a newer version is available.


### PR DESCRIPTION
## Description
This PR improves the upgrade instructions displayed to users by detecting their environment and providing the appropriate command:
- For Termux users: `pip install --upgrade fetchtastic`
- For all other users: `pipx upgrade fetchtastic`

## Changes
1. Added a new `get_upgrade_command()` function in `setup_config.py` that returns the appropriate upgrade command based on the environment
2. Updated all upgrade message displays in `downloader.py` and `cli.py` to use the new function
3. Improved the formatting of upgrade messages to use the standard logging system instead of raw print statements with separator lines
4. Made the upgrade messages more consistent across all commands