### PR TITLE
Fix Version Comparison and Latest Release Tag Updates

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fetchtastic
-version = 0.4.4
+version = 0.4.5
 author = Jeremiah K
 author_email = jeremiahk@gmx.com
 description = Meshtastic Firmware and APK Downloader

--- a/src/fetchtastic/downloader.py
+++ b/src/fetchtastic/downloader.py
@@ -835,10 +835,15 @@ def main():
             # Set permissions on .sh files if needed
             set_permissions_on_sh_files(release_dir)
 
-        # Only update latest_release_file if downloads occurred
-        if downloaded_versions:
-            with open(latest_release_file, "w") as f:
-                f.write(downloaded_versions[0])
+        # Always update latest_release_file with the most recent release tag
+        # This ensures we have the correct latest release for pre-release comparisons
+        if releases_to_download:
+            latest_release_tag = releases_to_download[0]["tag_name"]
+            # Only write if it's different from what's already there
+            if latest_release_tag != saved_release_tag:
+                with open(latest_release_file, "w") as f:
+                    f.write(latest_release_tag)
+                log_message(f"Updated latest release tag to {latest_release_tag}")
 
         # Create a list of all release tags to keep
         release_tags_to_keep = [release["tag_name"] for release in releases_to_download]


### PR DESCRIPTION
This PR addresses several issues with pre-release firmware handling and version tracking:

1. Fixed version comparison function
   - Now correctly compares only the major.minor.patch parts of version strings
   - Ignores commit hashes when determining version order
   - Properly identifies which versions are newer than others
   - Fixes the issue where 2.6.7 was incorrectly considered newer than 2.6.8

2. Fixed latest release tag update logic
   - Now always updates the latest_firmware_release.txt file with the most recent release tag from GitHub
   - Previously, the file was only updated when new firmware was downloaded
   - This ensures we have the correct latest release for pre-release comparisons
   - Only updates if the tag is different from what's already in the file
   - Adds a log message when the tag is updated

3. Fixed file filtering for pre-release downloads
   - Now only downloads files that match the selected patterns
   - Uses the same pattern matching logic as regular firmware downloads
   - Prevents downloading unnecessary files

These changes fix the inconsistency between platforms and ensure that the latest release
tag is always up-to-date, which is critical for proper pre-release detection and handling.