### PR TITLE
Restore firmware prerelease fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fetchtastic"
-version = "0.10.7"
+version = "0.10.8"
 authors = [{ name = "Jeremiah K", email = "jeremiahk@gmx.com" }]
 description = "Meshtastic Firmware and APK Downloader"
 readme = "README.md"

--- a/src/fetchtastic/cli.py
+++ b/src/fetchtastic/cli.py
@@ -373,7 +373,7 @@ def main() -> None:
     Fetchtastic files, display version information, or interact with the repository).
     """
     parser = argparse.ArgumentParser(
-        description="Fetchtastic - Meshtastic Firmware and APK Downloader"
+        description="Fetchtastic - Meshtastic Firmware and Client App Downloader"
     )
     subparsers = parser.add_subparsers(dest="command")
 

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1800,7 +1800,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
 
         logger.debug("Expected prerelease version: %s", expected_version)
 
-        active_dir, history_entries = (
+        latest_active_dir, history_entries = (
             prerelease_manager.get_latest_active_prerelease_from_history(
                 expected_version,
                 cache_manager=self.cache_manager,
@@ -1817,9 +1817,14 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 "expected_version": expected_version,
             }
 
-        if active_dir:
+        active_dirs = self._get_active_prerelease_dirs_from_history(history_entries)
+        if latest_active_dir and latest_active_dir not in active_dirs:
+            active_dirs.append(latest_active_dir)
+
+        if active_dirs:
             logger.info("Using commit history for prerelease detection")
         else:
+            fallback_dir = None
             # Fallback: scan repo root for prerelease directories
             try:
                 dirs = self.cache_manager.get_repo_directories(
@@ -1846,40 +1851,43 @@ class FirmwareReleaseDownloader(BaseDownloader):
                         ),
                         reverse=True,
                     )
-                    active_dir = f"{FIRMWARE_DIR_PREFIX}{matches[0]}"
+                    fallback_dir = f"{FIRMWARE_DIR_PREFIX}{matches[0]}"
             except (requests.RequestException, OSError, ValueError, TypeError) as exc:
                 logger.debug(
                     "Fallback prerelease directory scan failed; skipping prerelease detection: %s",
                     exc,
                 )
-                active_dir = None
+                fallback_dir = None
+            if fallback_dir:
+                active_dirs = [fallback_dir]
 
-        if active_dir:
+        if active_dirs:
             repo_dirs = self.cache_manager.get_repo_directories(
                 "",
                 force_refresh=True,
                 github_token=self.config.get("GITHUB_TOKEN"),
                 allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
             )
-            if active_dir not in repo_dirs:
-                fallback_dir = self._select_existing_active_prerelease_dir(
-                    history_entries or [], repo_dirs
-                )
-                if fallback_dir:
+            repo_dir_set = set(repo_dirs)
+            missing_dirs = [
+                directory for directory in active_dirs if directory not in repo_dir_set
+            ]
+            active_dirs = [
+                directory for directory in active_dirs if directory in repo_dir_set
+            ]
+            for missing_dir in missing_dirs:
+                if active_dirs:
                     logger.info(
-                        "Prerelease directory %s no longer exists; using active prerelease %s",
-                        active_dir,
-                        fallback_dir,
+                        "Prerelease directory %s no longer exists; continuing with remaining active prereleases",
+                        missing_dir,
                     )
-                    active_dir = fallback_dir
                 else:
                     logger.info(
                         "Prerelease directory %s no longer exists; skipping prerelease download",
-                        active_dir,
+                        missing_dir,
                     )
-                    return [], [], None, prerelease_summary
 
-        if not active_dir:
+        if not active_dirs:
             logger.info("No pre-release firmware available")
             return [], [], None, prerelease_summary
 
@@ -1901,42 +1909,65 @@ class FirmwareReleaseDownloader(BaseDownloader):
         except FileNotFoundError:
             pass
 
-        successes, failures, any_downloaded = self._download_prerelease_assets(
-            active_dir,
-            selected_patterns=selected_patterns,
-            exclude_patterns=exclude_patterns,
-            force_refresh=force_refresh,
-        )
-
-        if not any_downloaded and active_dir in existing_dirs and not failures:
-            logger.info("Found an existing pre-release, but no new files to download.")
+        successes: list[DownloadResult] = []
+        failures: list[DownloadResult] = []
+        any_downloaded = False
+        downloaded_dirs: list[str] = []
+        for active_dir in active_dirs:
+            (
+                prerelease_successes,
+                prerelease_failures,
+                prerelease_downloaded,
+            ) = self._download_prerelease_assets(
+                active_dir,
+                selected_patterns=selected_patterns,
+                exclude_patterns=exclude_patterns,
+                force_refresh=force_refresh,
+            )
+            successes.extend(prerelease_successes)
+            failures.extend(prerelease_failures)
+            if prerelease_downloaded:
+                any_downloaded = True
+                downloaded_dirs.append(active_dir)
+            if (
+                not prerelease_downloaded
+                and active_dir in existing_dirs
+                and not prerelease_failures
+            ):
+                logger.info(
+                    "Found existing pre-release %s, but no new files to download.",
+                    active_dir,
+                )
 
         if any_downloaded or force_refresh:
-            prerelease_manager.update_prerelease_tracking(
-                latest_release_tag, active_dir, cache_manager=self.cache_manager
-            )
+            for active_dir in downloaded_dirs or active_dirs:
+                prerelease_manager.update_prerelease_tracking(
+                    latest_release_tag, active_dir, cache_manager=self.cache_manager
+                )
 
         # Consolidate skipped messages
         skipped_count = sum(1 for result in successes if result.was_skipped)
         if skipped_count > 0:
             logger.debug(f"Skipped {skipped_count} existing pre-release files.")
 
-        return successes, failures, active_dir, prerelease_summary
+        return successes, failures, active_dirs[-1], prerelease_summary
 
-    def _select_existing_active_prerelease_dir(
-        self, history_entries: List[Dict[str, Any]], repo_dirs: List[str]
-    ) -> Optional[str]:
-        """Return the newest active prerelease directory that still exists upstream."""
-        repo_dir_set = set(repo_dirs)
-        for entry in reversed(history_entries):
+    def _get_active_prerelease_dirs_from_history(
+        self, history_entries: List[Dict[str, Any]]
+    ) -> list[str]:
+        """Return active prerelease directories from history in history order."""
+        active_dirs: list[str] = []
+        seen: set[str] = set()
+        for entry in history_entries:
             directory = entry.get("directory")
             if (
                 entry.get("status") == "active"
                 and isinstance(directory, str)
-                and directory in repo_dir_set
+                and directory not in seen
             ):
-                return directory
-        return None
+                active_dirs.append(directory)
+                seen.add(directory)
+        return active_dirs
 
     def log_prerelease_summary(
         self,

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1862,11 +1862,22 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
             )
             if active_dir not in repo_dirs:
-                logger.info(
-                    "Prerelease directory %s no longer exists; skipping prerelease download",
-                    active_dir,
+                fallback_dir = self._select_existing_active_prerelease_dir(
+                    history_entries or [], repo_dirs
                 )
-                return [], [], None, prerelease_summary
+                if fallback_dir:
+                    logger.info(
+                        "Prerelease directory %s no longer exists; using active prerelease %s",
+                        active_dir,
+                        fallback_dir,
+                    )
+                    active_dir = fallback_dir
+                else:
+                    logger.info(
+                        "Prerelease directory %s no longer exists; skipping prerelease download",
+                        active_dir,
+                    )
+                    return [], [], None, prerelease_summary
 
         if not active_dir:
             logger.info("No pre-release firmware available")
@@ -1911,6 +1922,21 @@ class FirmwareReleaseDownloader(BaseDownloader):
             logger.debug(f"Skipped {skipped_count} existing pre-release files.")
 
         return successes, failures, active_dir, prerelease_summary
+
+    def _select_existing_active_prerelease_dir(
+        self, history_entries: List[Dict[str, Any]], repo_dirs: List[str]
+    ) -> Optional[str]:
+        """Return the newest active prerelease directory that still exists upstream."""
+        repo_dir_set = set(repo_dirs)
+        for entry in reversed(history_entries):
+            directory = entry.get("directory")
+            if (
+                entry.get("status") == "active"
+                and isinstance(directory, str)
+                and directory in repo_dir_set
+            ):
+                return directory
+        return None
 
     def log_prerelease_summary(
         self,

--- a/src/fetchtastic/notifications.py
+++ b/src/fetchtastic/notifications.py
@@ -14,6 +14,11 @@ from fetchtastic.constants import NTFY_REQUEST_TIMEOUT
 from fetchtastic.log_utils import logger
 
 
+def _dedupe_preserving_order(items: List[str]) -> List[str]:
+    """Return unique non-empty items while preserving their first-seen order."""
+    return list(dict.fromkeys(item for item in items if item))
+
+
 def send_ntfy_notification(
     ntfy_server: Optional[str],
     ntfy_topic: Optional[str],
@@ -75,11 +80,11 @@ def send_download_completion_notification(
     Parameters:
         config (Dict[str, Any]): Configuration containing NTFY settings.
         downloaded_firmwares (List[str]): List of firmware versions that were downloaded.
-        downloaded_apks (List[str]): List of APK versions that were downloaded.
+        downloaded_apks (List[str]): Legacy list of client app APK versions that were downloaded.
         downloaded_firmware_prereleases (Optional[List[str]]): List of firmware prerelease versions that were downloaded.
-        downloaded_apk_prereleases (Optional[List[str]]): List of APK prerelease versions that were downloaded.
-        downloaded_desktop (Optional[List[str]]): List of desktop versions that were downloaded.
-        downloaded_desktop_prereleases (Optional[List[str]]): List of desktop prerelease versions that were downloaded.
+        downloaded_apk_prereleases (Optional[List[str]]): Legacy list of client app APK prerelease versions that were downloaded.
+        downloaded_desktop (Optional[List[str]]): Legacy list of client app desktop versions that were downloaded.
+        downloaded_desktop_prereleases (Optional[List[str]]): Legacy list of client app desktop prerelease versions that were downloaded.
 
     Side effects:
         - Sends notification to configured NTFY server/topic if downloads occurred.
@@ -91,6 +96,12 @@ def send_download_completion_notification(
     downloaded_apk_prereleases = downloaded_apk_prereleases or []
     downloaded_desktop = downloaded_desktop or []
     downloaded_desktop_prereleases = downloaded_desktop_prereleases or []
+    downloaded_client_apps = _dedupe_preserving_order(
+        [*downloaded_apks, *downloaded_desktop]
+    )
+    downloaded_client_app_prereleases = _dedupe_preserving_order(
+        [*downloaded_apk_prereleases, *downloaded_desktop_prereleases]
+    )
 
     if (
         not downloaded_firmwares
@@ -112,20 +123,18 @@ def send_download_completion_notification(
         message = f"Downloaded Firmware prerelease versions: {', '.join(downloaded_firmware_prereleases)}"
         notification_messages.append(message)
 
-    if downloaded_apks:
-        message = f"Downloaded Android APK versions: {', '.join(downloaded_apks)}"
+    if downloaded_client_apps:
+        message = (
+            "Downloaded Meshtastic Client versions: "
+            f"{', '.join(downloaded_client_apps)}"
+        )
         notification_messages.append(message)
 
-    if downloaded_apk_prereleases:
-        message = f"Downloaded Android APK prerelease versions: {', '.join(downloaded_apk_prereleases)}"
-        notification_messages.append(message)
-
-    if downloaded_desktop:
-        message = f"Downloaded Desktop versions: {', '.join(downloaded_desktop)}"
-        notification_messages.append(message)
-
-    if downloaded_desktop_prereleases:
-        message = f"Downloaded Desktop prerelease versions: {', '.join(downloaded_desktop_prereleases)}"
+    if downloaded_client_app_prereleases:
+        message = (
+            "Downloaded Meshtastic Client prerelease versions: "
+            f"{', '.join(downloaded_client_app_prereleases)}"
+        )
         notification_messages.append(message)
 
     timestamp = datetime.now().astimezone().isoformat(timespec="seconds")
@@ -147,7 +156,7 @@ def send_new_releases_available_notification(
     downloads_skipped_reason: Optional[str] = None,
 ) -> None:
     """
-    Notify the configured NTFY topic about new firmware or APK releases when downloads were skipped.
+    Notify the configured NTFY topic about new firmware or client app releases when downloads were skipped.
 
     Parameters:
         config (Dict[str, Any]): Configuration dictionary. Recognized keys:
@@ -155,12 +164,12 @@ def send_new_releases_available_notification(
             - "NTFY_TOPIC": NTFY topic to post the notification to.
             - "NOTIFY_ON_DOWNLOAD_ONLY": if True, suppresses this notification.
         new_firmware_versions (List[str]): Available firmware version identifiers to report.
-        new_apk_versions (List[str]): Available Android APK version identifiers to report.
+        new_apk_versions (List[str]): Available client app version identifiers to report.
         downloads_skipped_reason (Optional[str]): Human-readable reason why downloads were skipped;
             if provided it is included as the first line of the notification.
 
     Behavior:
-        If "NOTIFY_ON_DOWNLOAD_ONLY" is True or there are no new firmware/APK versions, no notification is sent.
+        If "NOTIFY_ON_DOWNLOAD_ONLY" is True or there are no new firmware/client app versions, no notification is sent.
     """
     ntfy_server = config.get("NTFY_SERVER", "")
     ntfy_topic = config.get("NTFY_TOPIC", "")
@@ -188,7 +197,7 @@ def send_new_releases_available_notification(
 
     if new_apk_versions:
         message_lines.append(
-            f"Android APK versions available: {', '.join(new_apk_versions)}"
+            f"Meshtastic Client versions available: {', '.join(new_apk_versions)}"
         )
 
     timestamp = datetime.now().astimezone().isoformat(timespec="seconds")

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -2736,10 +2736,10 @@ class TestFirmwareUncoveredBranches:
         assert result[2] is None  # active_dir
         assert result[3] is not None  # prerelease_summary
 
-    def test_download_repo_prerelease_firmware_falls_back_to_existing_active_dir(
+    def test_download_repo_prerelease_firmware_skips_missing_active_dirs(
         self, downloader, tmp_path
     ):
-        """When latest active history dir is gone, use an older active dir still in repo."""
+        """When latest active history dir is gone, use active dirs still in repo."""
         downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
         downloader.download_dir = str(tmp_path)
         history_entries = [
@@ -2776,6 +2776,52 @@ class TestFirmwareUncoveredBranches:
         assert result[2] == "firmware-2.7.23.7be5426"
         download_assets.assert_called_once()
         assert download_assets.call_args.args[0] == "firmware-2.7.23.7be5426"
+
+    def test_download_repo_prerelease_firmware_backfills_all_existing_active_dirs(
+        self, downloader, tmp_path
+    ):
+        """Download every active history prerelease directory that still exists upstream."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+        history_entries = [
+            {
+                "identifier": "7be5426",
+                "directory": "firmware-2.7.23.7be5426",
+                "status": "active",
+            },
+            {
+                "identifier": "2a858be",
+                "directory": "firmware-2.7.23.2a858be",
+                "status": "active",
+            },
+        ]
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[
+                    "firmware-2.7.23.7be5426",
+                    "firmware-2.7.23.2a858be",
+                ],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ) as download_assets,
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=("firmware-2.7.23.2a858be", history_entries),
+            ),
+        ):
+            result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+
+        assert result[2] == "firmware-2.7.23.2a858be"
+        assert [call.args[0] for call in download_assets.call_args_list] == [
+            "firmware-2.7.23.7be5426",
+            "firmware-2.7.23.2a858be",
+        ]
 
     # Lines 1797-1835: Release notes logging
     def test_log_prerelease_summary(self, downloader):

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -2736,6 +2736,47 @@ class TestFirmwareUncoveredBranches:
         assert result[2] is None  # active_dir
         assert result[3] is not None  # prerelease_summary
 
+    def test_download_repo_prerelease_firmware_falls_back_to_existing_active_dir(
+        self, downloader, tmp_path
+    ):
+        """When latest active history dir is gone, use an older active dir still in repo."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+        history_entries = [
+            {
+                "identifier": "7be5426",
+                "directory": "firmware-2.7.23.7be5426",
+                "status": "active",
+            },
+            {
+                "identifier": "2a858be",
+                "directory": "firmware-2.7.23.2a858be",
+                "status": "active",
+            },
+        ]
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=["firmware-2.7.23.7be5426"],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ) as download_assets,
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=("firmware-2.7.23.2a858be", history_entries),
+            ),
+        ):
+            result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+
+        assert result[2] == "firmware-2.7.23.7be5426"
+        download_assets.assert_called_once()
+        assert download_assets.call_args.args[0] == "firmware-2.7.23.7be5426"
+
     # Lines 1797-1835: Release notes logging
     def test_log_prerelease_summary(self, downloader):
         """Test log_prerelease_summary with various entry statuses."""

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -131,7 +131,7 @@ class TestSendDownloadCompletionNotification:
         )
 
         expected_message = (
-            "Downloaded Android APK versions: 1.2.3, 1.3.0\n2024-01-01T12:00:00"
+            "Downloaded Meshtastic Client versions: 1.2.3, 1.3.0\n2024-01-01T12:00:00"
         )
         mock_send.assert_called_once_with(
             "https://ntfy.sh",
@@ -153,7 +153,7 @@ class TestSendDownloadCompletionNotification:
             config, ["2.7.4"], ["1.2.3"]
         )
 
-        expected_message = "Downloaded Firmware versions: 2.7.4\nDownloaded Android APK versions: 1.2.3\n2024-01-01T12:00:00"
+        expected_message = "Downloaded Firmware versions: 2.7.4\nDownloaded Meshtastic Client versions: 1.2.3\n2024-01-01T12:00:00"
         mock_send.assert_called_once_with(
             "https://ntfy.sh",
             "test",
@@ -209,7 +209,7 @@ class TestSendNewReleasesAvailableNotification:
         )
 
         expected_message = (
-            "Android APK versions available: 1.2.3, 1.3.0\n2024-01-01T12:00:00"
+            "Meshtastic Client versions available: 1.2.3, 1.3.0\n2024-01-01T12:00:00"
         )
         mock_send.assert_called_once_with(
             "https://ntfy.sh",
@@ -347,8 +347,8 @@ class TestNotificationEdgeCases:
         expected_message = (
             "Downloaded Firmware versions: 2.7.4\n"
             "Downloaded Firmware prerelease versions: 2.8.0-alpha\n"
-            "Downloaded Android APK versions: 1.2.3\n"
-            "Downloaded Android APK prerelease versions: 1.3.0-beta\n"
+            "Downloaded Meshtastic Client versions: 1.2.3\n"
+            "Downloaded Meshtastic Client prerelease versions: 1.3.0-beta\n"
             "2024-01-01T12:00:00"
         )
         mock_send.assert_called_once_with(
@@ -379,7 +379,7 @@ class TestNotificationEdgeCases:
         expected_message = (
             "Downloads skipped due to rate limiting\n"
             "Firmware versions available: 2.7.4\n"
-            "Android APK versions available: 1.2.3\n"
+            "Meshtastic Client versions available: 1.2.3\n"
             "2024-01-01T12:00:00"
         )
         mock_send.assert_called_once_with(
@@ -387,6 +387,38 @@ class TestNotificationEdgeCases:
             "test",
             expected_message,
             title="Fetchtastic Downloads Skipped",
+        )
+
+    @patch("fetchtastic.notifications.send_ntfy_notification")
+    @patch("fetchtastic.notifications.datetime")
+    def test_send_completion_notification_combines_client_app_assets(
+        self, mock_datetime, mock_send
+    ):
+        """APK and Desktop reports for the same release should share one client line."""
+        mock_datetime.now.return_value.astimezone.return_value.isoformat.return_value = (
+            "2024-01-01T12:00:00"
+        )
+
+        config = {"NTFY_SERVER": "https://ntfy.sh", "NTFY_TOPIC": "test"}
+        notifications.send_download_completion_notification(
+            config,
+            [],
+            ["v2.7.14"],
+            downloaded_desktop=["v2.7.14", "v2.7.13"],
+            downloaded_apk_prereleases=["v2.7.15-open.1"],
+            downloaded_desktop_prereleases=["v2.7.15-open.1"],
+        )
+
+        expected_message = (
+            "Downloaded Meshtastic Client versions: v2.7.14, v2.7.13\n"
+            "Downloaded Meshtastic Client prerelease versions: v2.7.15-open.1\n"
+            "2024-01-01T12:00:00"
+        )
+        mock_send.assert_called_once_with(
+            "https://ntfy.sh",
+            "test",
+            expected_message,
+            title="Fetchtastic Download Completed",
         )
 
     def test_send_notification_empty_config(self):


### PR DESCRIPTION
Summary:

- Falls back to the newest active firmware prerelease directory that still exists upstream when the latest tracked active directory has been removed.
- Preserves the existing skip behavior when no active prerelease directory exists.
- Adds regression coverage for the fallback path.