### PR TITLE
Improve directory discovery with deletion metadata filtering

### DIFF
--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -2026,11 +2026,15 @@ class FirmwareReleaseDownloader(BaseDownloader):
                     active_dir,
                 )
 
-        if any_downloaded or force_refresh or (active_dirs and not failures):
-            for active_dir in downloaded_dirs or active_dirs:
-                prerelease_manager.update_prerelease_tracking(
-                    latest_release_tag, active_dir, cache_manager=self.cache_manager
-                )
+        dirs_to_track: list[str] = []
+        if force_refresh or (active_dirs and not failures):
+            dirs_to_track = active_dirs
+        elif any_downloaded:
+            dirs_to_track = downloaded_dirs
+        for active_dir in dirs_to_track:
+            prerelease_manager.update_prerelease_tracking(
+                latest_release_tag, active_dir, cache_manager=self.cache_manager
+            )
 
         # Consolidate skipped messages
         skipped_count = sum(1 for result in successes if result.was_skipped)

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1927,21 +1927,28 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 ]
 
             if prerelease_summary is not None:
-                available_history_entries = list(history_entries)
+                available_dirs = set(active_dirs)
+                available_history_entries = [
+                    entry
+                    for entry in history_entries
+                    if entry.get("status") == "deleted"
+                    or bool(entry.get("removed_at"))
+                    or entry.get("directory") in available_dirs
+                ]
                 available_dirs_in_history = {
                     entry.get("directory")
-                    for entry in history_entries
+                    for entry in available_history_entries
                     if entry.get("directory")
                 }
-                for active_dir_dir in active_dirs:
-                    if active_dir_dir not in available_dirs_in_history:
-                        identifier = active_dir_dir.removeprefix(FIRMWARE_DIR_PREFIX)
+                for active_dir in active_dirs:
+                    if active_dir not in available_dirs_in_history:
+                        identifier = active_dir.removeprefix(FIRMWARE_DIR_PREFIX)
                         base_version = (
                             ".".join(identifier.split(".")[:3]) if identifier else ""
                         )
                         available_history_entries.append(
                             {
-                                "directory": active_dir_dir,
+                                "directory": active_dir,
                                 "identifier": identifier,
                                 "base_version": base_version,
                                 "status": "active",

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1889,9 +1889,11 @@ class FirmwareReleaseDownloader(BaseDownloader):
                     repo_dirs, expected_version
                 )
             ]
+            active_dirs_set = set(active_dirs)
             for repo_dir in matching_repo_dirs:
-                if repo_dir not in deleted_dirs and repo_dir not in active_dirs:
+                if repo_dir not in deleted_dirs and repo_dir not in active_dirs_set:
                     active_dirs.append(repo_dir)
+                    active_dirs_set.add(repo_dir)
 
             missing_dirs = [
                 directory for directory in active_dirs if directory not in repo_dir_set

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1888,6 +1888,13 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 for directory in active_dirs
                 if directory in repo_dir_set and directory not in deleted_dirs
             ]
+            if prerelease_summary is not None:
+                prerelease_summary["available_history_entries"] = [
+                    entry
+                    for entry in history_entries
+                    if entry.get("status") == "deleted"
+                    or entry.get("directory") in active_dirs
+                ]
             for missing_dir in missing_dirs:
                 if active_dirs:
                     logger.info(
@@ -1952,7 +1959,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
                     active_dir,
                 )
 
-        if any_downloaded or force_refresh:
+        if any_downloaded or force_refresh or (active_dirs and not failures):
             for active_dir in downloaded_dirs or active_dirs:
                 prerelease_manager.update_prerelease_tracking(
                     latest_release_tag, active_dir, cache_manager=self.cache_manager

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1859,13 +1859,26 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 )
 
         if active_dirs:
-            repo_dirs = self.cache_manager.get_repo_directories(
-                "",
-                force_refresh=True,
-                github_token=self.config.get("GITHUB_TOKEN"),
-                allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
-            )
-            repo_dirs = [d for d in repo_dirs if isinstance(d, str)]
+            try:
+                repo_dirs = self.cache_manager.get_repo_directories(
+                    "",
+                    force_refresh=True,
+                    github_token=self.config.get("GITHUB_TOKEN"),
+                    allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
+                )
+                if not isinstance(repo_dirs, list):
+                    logger.debug(
+                        "Expected list of repo directories from cache manager, got %s",
+                        type(repo_dirs),
+                    )
+                    repo_dirs = []
+                repo_dirs = [d for d in repo_dirs if isinstance(d, str)]
+            except (requests.RequestException, OSError, ValueError, TypeError) as exc:
+                logger.debug(
+                    "Repo availability scan failed; continuing with best history-derived active dirs: %s",
+                    exc,
+                )
+                repo_dirs = []
             repo_dir_set = set(repo_dirs)
             deleted_dirs = self._get_deleted_prerelease_dirs_from_history(
                 history_entries
@@ -1889,12 +1902,34 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 if directory in repo_dir_set and directory not in deleted_dirs
             ]
             if prerelease_summary is not None:
-                prerelease_summary["available_history_entries"] = [
+                available_dirs_in_history = {
+                    entry.get("directory")
+                    for entry in history_entries
+                    if entry.get("directory") in active_dirs
+                }
+                available_history_entries = [
                     entry
                     for entry in history_entries
-                    if entry.get("status") == "deleted"
-                    or entry.get("directory") in active_dirs
+                    if entry.get("directory") in available_dirs_in_history
                 ]
+                for active_dir in active_dirs:
+                    if active_dir not in available_dirs_in_history:
+                        identifier = active_dir.removeprefix(FIRMWARE_DIR_PREFIX)
+                        base_version = (
+                            ".".join(identifier.split(".")[:3]) if identifier else ""
+                        )
+                        available_history_entries.append(
+                            {
+                                "directory": active_dir,
+                                "identifier": identifier,
+                                "base_version": base_version,
+                                "status": "active",
+                                "active": True,
+                            }
+                        )
+                prerelease_summary["available_history_entries"] = (
+                    available_history_entries
+                )
             for missing_dir in missing_dirs:
                 if active_dirs:
                     logger.info(
@@ -1910,6 +1945,8 @@ class FirmwareReleaseDownloader(BaseDownloader):
         if not active_dirs:
             logger.info("No pre-release firmware available")
             return [], [], None, prerelease_summary
+
+        active_dirs = self._sort_prerelease_dirs(active_dirs)
 
         selected_patterns = self._get_prerelease_patterns()
         exclude_patterns = self._get_exclude_patterns()
@@ -1972,18 +2009,43 @@ class FirmwareReleaseDownloader(BaseDownloader):
 
         return successes, failures, active_dirs[-1], prerelease_summary
 
+    @staticmethod
+    def _sort_prerelease_dirs(dirs: List[str]) -> List[str]:
+        """Deduplicate and sort prerelease directory names by parsed version tuple, then directory string as tie breaker."""
+        version_manager = VersionManager()
+
+        def sort_key(directory: str) -> Tuple:
+            identifier = directory.removeprefix(FIRMWARE_DIR_PREFIX)
+            version_tuple = version_manager.get_release_tuple(identifier) or ()
+            return (version_tuple, directory)
+
+        seen: set[str] = set()
+        unique_dirs: list[str] = []
+        for d in dirs:
+            if d not in seen:
+                seen.add(d)
+                unique_dirs.append(d)
+        unique_dirs.sort(key=sort_key)
+        return unique_dirs
+
     def _get_active_prerelease_dirs_from_history(
         self, history_entries: List[Dict[str, Any]]
     ) -> list[str]:
-        """Return non-deleted prerelease directories from history in history order."""
+        """Return explicitly active prerelease directories from history in history order."""
         active_dirs: list[str] = []
         seen: set[str] = set()
         for entry in history_entries:
             directory = entry.get("directory")
+            is_active = entry.get("status") == "active" or entry.get("active") is True
             is_deleted = entry.get("status") == "deleted" or bool(
                 entry.get("removed_at")
             )
-            if not is_deleted and isinstance(directory, str) and directory not in seen:
+            if (
+                is_active
+                and not is_deleted
+                and isinstance(directory, str)
+                and directory not in seen
+            ):
                 active_dirs.append(directory)
                 seen.add(directory)
         return active_dirs

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1776,7 +1776,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 - successes: list of DownloadResult for assets that were successfully downloaded or skipped.
                 - failures: list of DownloadResult for assets that failed to download.
                 - active_dir: remote prerelease directory identifier used for the download, or `None` if no prerelease was found.
-                - prerelease_summary: a dict with prerelease history details (keys: `history_entries`, `clean_latest_release`, `expected_version`) for later reporting, or `None` when no history is available.
+                - prerelease_summary: a dict with prerelease history and/or repo-discovered details (keys: `history_entries`, `clean_latest_release`, `expected_version`, `available_history_entries`) for later reporting, or `None` when no prerelease processing was performed.
         """
         check_prereleases = self.config.get(
             "CHECK_FIRMWARE_PRERELEASES", self.config.get("CHECK_PRERELEASES", False)
@@ -1874,7 +1874,13 @@ class FirmwareReleaseDownloader(BaseDownloader):
                     )
                 else:
                     repo_dirs = [d for d in repo_dirs if isinstance(d, str)]
-                    repo_availability_verified = True
+                    if repo_dirs:
+                        repo_availability_verified = True
+                    else:
+                        logger.debug(
+                            "Repo availability scan returned no directories; "
+                            "cannot verify availability of history-derived prereleases"
+                        )
             except (requests.RequestException, OSError, ValueError, TypeError) as exc:
                 logger.debug(
                     "Repo availability scan failed; continuing with best history-derived active dirs: %s",

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1824,7 +1824,6 @@ class FirmwareReleaseDownloader(BaseDownloader):
         if active_dirs:
             logger.info("Using commit history for prerelease detection")
         else:
-            fallback_dir = None
             # Fallback: scan repo root for prerelease directories
             try:
                 dirs = self.cache_manager.get_repo_directories(
@@ -1849,17 +1848,15 @@ class FirmwareReleaseDownloader(BaseDownloader):
                             version_manager.get_release_tuple(ident) or (),
                             ident,
                         ),
-                        reverse=True,
                     )
-                    fallback_dir = f"{FIRMWARE_DIR_PREFIX}{matches[0]}"
+                    active_dirs = [
+                        f"{FIRMWARE_DIR_PREFIX}{identifier}" for identifier in matches
+                    ]
             except (requests.RequestException, OSError, ValueError, TypeError) as exc:
                 logger.debug(
                     "Fallback prerelease directory scan failed; skipping prerelease detection: %s",
                     exc,
                 )
-                fallback_dir = None
-            if fallback_dir:
-                active_dirs = [fallback_dir]
 
         if active_dirs:
             repo_dirs = self.cache_manager.get_repo_directories(
@@ -1868,12 +1865,28 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 github_token=self.config.get("GITHUB_TOKEN"),
                 allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
             )
+            repo_dirs = [d for d in repo_dirs if isinstance(d, str)]
             repo_dir_set = set(repo_dirs)
+            deleted_dirs = self._get_deleted_prerelease_dirs_from_history(
+                history_entries
+            )
+            matching_repo_dirs = [
+                f"{FIRMWARE_DIR_PREFIX}{identifier}"
+                for identifier in prerelease_manager.scan_prerelease_directories(
+                    repo_dirs, expected_version
+                )
+            ]
+            for repo_dir in matching_repo_dirs:
+                if repo_dir not in deleted_dirs and repo_dir not in active_dirs:
+                    active_dirs.append(repo_dir)
+
             missing_dirs = [
                 directory for directory in active_dirs if directory not in repo_dir_set
             ]
             active_dirs = [
-                directory for directory in active_dirs if directory in repo_dir_set
+                directory
+                for directory in active_dirs
+                if directory in repo_dir_set and directory not in deleted_dirs
             ]
             for missing_dir in missing_dirs:
                 if active_dirs:
@@ -1955,19 +1968,31 @@ class FirmwareReleaseDownloader(BaseDownloader):
     def _get_active_prerelease_dirs_from_history(
         self, history_entries: List[Dict[str, Any]]
     ) -> list[str]:
-        """Return active prerelease directories from history in history order."""
+        """Return non-deleted prerelease directories from history in history order."""
         active_dirs: list[str] = []
         seen: set[str] = set()
         for entry in history_entries:
             directory = entry.get("directory")
-            if (
-                entry.get("status") == "active"
-                and isinstance(directory, str)
-                and directory not in seen
-            ):
+            is_deleted = entry.get("status") == "deleted" or bool(
+                entry.get("removed_at")
+            )
+            if not is_deleted and isinstance(directory, str) and directory not in seen:
                 active_dirs.append(directory)
                 seen.add(directory)
         return active_dirs
+
+    def _get_deleted_prerelease_dirs_from_history(
+        self, history_entries: List[Dict[str, Any]]
+    ) -> set[str]:
+        """Return prerelease directories explicitly marked deleted in history."""
+        deleted_dirs: set[str] = set()
+        for entry in history_entries:
+            directory = entry.get("directory")
+            if not isinstance(directory, str):
+                continue
+            if entry.get("status") == "deleted" or bool(entry.get("removed_at")):
+                deleted_dirs.add(directory)
+        return deleted_dirs
 
     def log_prerelease_summary(
         self,

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1835,7 +1835,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 if not isinstance(dirs, list):
                     logger.debug(
                         "Expected list of repo directories from cache manager, got %s",
-                        type(dirs),
+                        type(dirs).__name__,
                     )
                     dirs = []
                 matches = prerelease_manager.scan_prerelease_directories(
@@ -1859,6 +1859,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 )
 
         if active_dirs:
+            repo_availability_verified = False
             try:
                 repo_dirs = self.cache_manager.get_repo_directories(
                     "",
@@ -1869,60 +1870,78 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 if not isinstance(repo_dirs, list):
                     logger.debug(
                         "Expected list of repo directories from cache manager, got %s",
-                        type(repo_dirs),
+                        type(repo_dirs).__name__,
                     )
-                    repo_dirs = []
-                repo_dirs = [d for d in repo_dirs if isinstance(d, str)]
+                else:
+                    repo_dirs = [d for d in repo_dirs if isinstance(d, str)]
+                    repo_availability_verified = True
             except (requests.RequestException, OSError, ValueError, TypeError) as exc:
                 logger.debug(
                     "Repo availability scan failed; continuing with best history-derived active dirs: %s",
                     exc,
                 )
                 repo_dirs = []
-            repo_dir_set = set(repo_dirs)
             deleted_dirs = self._get_deleted_prerelease_dirs_from_history(
                 history_entries
             )
-            matching_repo_dirs = [
-                f"{FIRMWARE_DIR_PREFIX}{identifier}"
-                for identifier in prerelease_manager.scan_prerelease_directories(
-                    repo_dirs, expected_version
-                )
-            ]
-            active_dirs_set = set(active_dirs)
-            for repo_dir in matching_repo_dirs:
-                if repo_dir not in deleted_dirs and repo_dir not in active_dirs_set:
-                    active_dirs.append(repo_dir)
-                    active_dirs_set.add(repo_dir)
+            if repo_availability_verified:
+                repo_dir_set = set(repo_dirs)
+                matching_repo_dirs = [
+                    f"{FIRMWARE_DIR_PREFIX}{identifier}"
+                    for identifier in prerelease_manager.scan_prerelease_directories(
+                        repo_dirs, expected_version
+                    )
+                ]
+                active_dirs_set = set(active_dirs)
+                for repo_dir in matching_repo_dirs:
+                    if repo_dir not in deleted_dirs and repo_dir not in active_dirs_set:
+                        active_dirs.append(repo_dir)
+                        active_dirs_set.add(repo_dir)
 
-            missing_dirs = [
-                directory for directory in active_dirs if directory not in repo_dir_set
-            ]
-            active_dirs = [
-                directory
-                for directory in active_dirs
-                if directory in repo_dir_set and directory not in deleted_dirs
-            ]
+                missing_dirs = [
+                    directory
+                    for directory in active_dirs
+                    if directory not in repo_dir_set
+                ]
+                active_dirs = [
+                    directory
+                    for directory in active_dirs
+                    if directory in repo_dir_set and directory not in deleted_dirs
+                ]
+                for missing_dir in missing_dirs:
+                    if active_dirs:
+                        logger.info(
+                            "Prerelease directory %s no longer exists; continuing with remaining active prereleases",
+                            missing_dir,
+                        )
+                    else:
+                        logger.info(
+                            "Prerelease directory %s no longer exists; skipping prerelease download",
+                            missing_dir,
+                        )
+            else:
+                active_dirs = [
+                    directory
+                    for directory in active_dirs
+                    if directory not in deleted_dirs
+                ]
+
             if prerelease_summary is not None:
+                available_history_entries = list(history_entries)
                 available_dirs_in_history = {
                     entry.get("directory")
                     for entry in history_entries
-                    if entry.get("directory") in active_dirs
+                    if entry.get("directory")
                 }
-                available_history_entries = [
-                    entry
-                    for entry in history_entries
-                    if entry.get("directory") in available_dirs_in_history
-                ]
-                for active_dir in active_dirs:
-                    if active_dir not in available_dirs_in_history:
-                        identifier = active_dir.removeprefix(FIRMWARE_DIR_PREFIX)
+                for active_dir_dir in active_dirs:
+                    if active_dir_dir not in available_dirs_in_history:
+                        identifier = active_dir_dir.removeprefix(FIRMWARE_DIR_PREFIX)
                         base_version = (
                             ".".join(identifier.split(".")[:3]) if identifier else ""
                         )
                         available_history_entries.append(
                             {
-                                "directory": active_dir,
+                                "directory": active_dir_dir,
                                 "identifier": identifier,
                                 "base_version": base_version,
                                 "status": "active",
@@ -1932,17 +1951,6 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 prerelease_summary["available_history_entries"] = (
                     available_history_entries
                 )
-            for missing_dir in missing_dirs:
-                if active_dirs:
-                    logger.info(
-                        "Prerelease directory %s no longer exists; continuing with remaining active prereleases",
-                        missing_dir,
-                    )
-                else:
-                    logger.info(
-                        "Prerelease directory %s no longer exists; skipping prerelease download",
-                        missing_dir,
-                    )
 
         if not active_dirs:
             logger.info("No pre-release firmware available")

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1926,6 +1926,13 @@ class FirmwareReleaseDownloader(BaseDownloader):
                     if directory not in deleted_dirs
                 ]
 
+            if prerelease_summary is None and active_dirs:
+                prerelease_summary = {
+                    "history_entries": history_entries or [],
+                    "clean_latest_release": clean_latest_release,
+                    "expected_version": expected_version,
+                }
+
             if prerelease_summary is not None:
                 available_dirs = set(active_dirs)
                 available_history_entries = [

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -207,6 +207,7 @@ class DownloadOrchestrator:
         """
         start_time = time.time()
         self.wifi_skipped = False
+        self.latest_available_firmware_prerelease_dir = None
         self.available_new_firmware_versions = []
         self.available_new_apk_versions = []
         self._client_app_downloads_processed = False

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -178,6 +178,7 @@ class DownloadOrchestrator:
         self.firmware_release_history: Optional[Dict[str, Any]] = None
         # Single-run only: cleared after _log_prerelease_summary()
         self.firmware_prerelease_summary: Optional[Dict[str, Any]] = None
+        self.latest_available_firmware_prerelease_dir: Optional[str] = None
         # Run-scoped selected set: reset at start of _process_firmware_downloads()
         self.firmware_releases_selected: Optional[List[Release]] = None
         self._client_app_downloads_processed = False
@@ -707,6 +708,7 @@ class DownloadOrchestrator:
         try:
             # Reset the selected releases at the start of each run
             self.firmware_releases_selected = None
+            self.latest_available_firmware_prerelease_dir = None
 
             if not self.config.get("SAVE_FIRMWARE", False):
                 logger.info("Firmware downloads are disabled in configuration")
@@ -785,11 +787,12 @@ class DownloadOrchestrator:
                 (
                     successes,
                     failures,
-                    _active_dir,
+                    active_dir,
                     prerelease_summary,
                 ) = self.firmware_downloader.download_repo_prerelease_firmware(
                     latest_release.tag_name, force_refresh=False
                 )
+                self.latest_available_firmware_prerelease_dir = active_dir
                 if prerelease_summary:
                     self.firmware_prerelease_summary = prerelease_summary
                 for result in successes:
@@ -1717,7 +1720,11 @@ class DownloadOrchestrator:
 
         self.firmware_prerelease_summary = None
 
-        history_entries = summary.get("history_entries") or []
+        history_entries = (
+            summary.get("available_history_entries")
+            or summary.get("history_entries")
+            or []
+        )
         clean_latest_release = summary.get("clean_latest_release")
         expected_version = summary.get("expected_version")
 
@@ -2097,7 +2104,13 @@ class DownloadOrchestrator:
         firmware_prerelease = None
         latest_firmware_release = self.firmware_downloader.get_latest_release_tag()
 
-        if latest_firmware_release:
+        active_dir = self.latest_available_firmware_prerelease_dir
+        if active_dir and active_dir.startswith(FIRMWARE_DIR_PREFIX):
+            firmware_prerelease = active_dir[len(FIRMWARE_DIR_PREFIX) :]
+        elif active_dir:
+            firmware_prerelease = active_dir
+
+        if latest_firmware_release and firmware_prerelease is None:
             clean_latest_release = (
                 self.version_manager.extract_clean_version(latest_firmware_release)
                 or latest_firmware_release

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -3517,7 +3517,7 @@ class TestFirmwarePrereleaseBaselineDerivation:
                 return_value=("firmware-2.7.23.2a858be", history_entries),
             ),
         ):
-            result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+            downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
 
         # Download order should be deterministic: sorted by version tuple then directory string
         call_args = [call.args[0] for call in download_assets.call_args_list]

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -3639,3 +3639,44 @@ class TestFirmwarePrereleaseBaselineDerivation:
         assert "firmware-2.7.23.cccccc" in available_dirs
         # Stale active dir missing from repo should be excluded
         assert "firmware-2.7.23.bbbbbb" not in available_dirs
+
+    def test_download_repo_prerelease_firmware_summary_fallback_no_history(
+        self, downloader, tmp_path
+    ):
+        """Repo-discovered prereleases with no history should still produce a summary."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[
+                    "firmware-2.7.23.aaaaaa",
+                    "firmware-2.7.23.bbbbbb",
+                ],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ),
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(None, []),
+            ),
+        ):
+            _results, _failed, latest, summary = (
+                downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+            )
+
+        assert summary is not None
+        assert summary["history_entries"] == []
+        assert summary["clean_latest_release"] == "v2.7.22"
+        assert summary["expected_version"] == "2.7.23"
+        available_entries = summary.get("available_history_entries")
+        assert available_entries is not None
+        available_dirs = {e["directory"] for e in available_entries}
+        assert "firmware-2.7.23.aaaaaa" in available_dirs
+        assert "firmware-2.7.23.bbbbbb" in available_dirs
+        assert latest == "firmware-2.7.23.bbbbbb"

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -2818,10 +2818,92 @@ class TestFirmwareUncoveredBranches:
             result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
 
         assert result[2] == "firmware-2.7.23.2a858be"
-        assert [call.args[0] for call in download_assets.call_args_list] == [
+        assert {call.args[0] for call in download_assets.call_args_list} == {
             "firmware-2.7.23.7be5426",
             "firmware-2.7.23.2a858be",
+        }
+
+    def test_download_repo_prerelease_firmware_syncs_existing_repo_dirs(
+        self, downloader, tmp_path
+    ):
+        """Backfill matching prerelease dirs that still exist even if history missed them."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+        history_entries = [
+            {
+                "identifier": "2.7.23.c0e52e6",
+                "directory": "firmware-2.7.23.c0e52e6",
+                "status": "deleted",
+            },
+            {
+                "identifier": "2.7.23.7be5426",
+                "directory": "firmware-2.7.23.7be5426",
+                "status": "active",
+            },
         ]
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[
+                    "firmware-2.7.23.c0e52e6",
+                    "firmware-2.7.23.7be5426",
+                    "firmware-2.7.23.2a858be",
+                ],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ) as download_assets,
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=("firmware-2.7.23.7be5426", history_entries),
+            ),
+        ):
+            result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+
+        assert result[2] == "firmware-2.7.23.2a858be"
+        assert {call.args[0] for call in download_assets.call_args_list} == {
+            "firmware-2.7.23.7be5426",
+            "firmware-2.7.23.2a858be",
+        }
+
+    def test_download_repo_prerelease_firmware_fallback_downloads_all_existing_dirs(
+        self, downloader, tmp_path
+    ):
+        """Fallback repo scanning should download every matching available prerelease dir."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[
+                    "firmware-2.7.23.7be5426",
+                    "firmware-2.7.23.2a858be",
+                    "firmware-2.7.24.bad9999",
+                ],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ) as download_assets,
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(None, []),
+            ),
+        ):
+            result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+
+        assert result[2] == "firmware-2.7.23.7be5426"
+        assert {call.args[0] for call in download_assets.call_args_list} == {
+            "firmware-2.7.23.7be5426",
+            "firmware-2.7.23.2a858be",
+        }
 
     # Lines 1797-1835: Release notes logging
     def test_log_prerelease_summary(self, downloader):

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -1448,7 +1448,9 @@ class TestFirmwareReleaseDownloader:
                 "get_repo_directories",
                 return_value=[],
             ),
-            patch.object(downloader, "_download_prerelease_assets") as mock_download,
+            patch.object(
+                downloader, "_download_prerelease_assets", return_value=([], [], False)
+            ),
         ):
             results, failed, latest, summary = (
                 downloader.download_repo_prerelease_firmware("v2.7.17.9058cce")
@@ -1456,10 +1458,9 @@ class TestFirmwareReleaseDownloader:
 
         assert results == []
         assert failed == []
-        assert latest is None
+        assert latest == active_dir
         assert summary is not None
         assert summary["history_entries"] == history_entries
-        mock_download.assert_not_called()
 
     @pytest.mark.unit
     @patch("os.path.exists")
@@ -3680,3 +3681,63 @@ class TestFirmwarePrereleaseBaselineDerivation:
         assert "firmware-2.7.23.aaaaaa" in available_dirs
         assert "firmware-2.7.23.bbbbbb" in available_dirs
         assert latest == "firmware-2.7.23.bbbbbb"
+
+    def test_download_repo_prerelease_firmware_empty_repo_scan_preserves_history(
+        self, downloader, tmp_path
+    ):
+        """Empty repo availability scan should preserve history-derived active dirs."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        active_dir = "firmware-2.7.23.aaaaaa"
+        deleted_dir = "firmware-2.7.23.cccccc"
+        history_entries = [
+            {
+                "identifier": "aaaaaa",
+                "directory": active_dir,
+                "status": "active",
+            },
+            {
+                "identifier": "bbbbbb",
+                "directory": "firmware-2.7.23.bbbbbb",
+                "status": "active",
+            },
+            {
+                "identifier": "cccccc",
+                "directory": deleted_dir,
+                "status": "deleted",
+            },
+        ]
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ),
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(active_dir, history_entries),
+            ),
+        ):
+            _results, _failed, latest, summary = (
+                downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+            )
+
+        # History-derived active dirs should be preserved even with empty repo scan
+        # Sorted order puts bbbbbb last (dir string tiebreaker)
+        assert latest == "firmware-2.7.23.bbbbbb"
+        assert summary is not None
+        available_entries = summary.get("available_history_entries")
+        assert available_entries is not None
+        available_dirs = {e["directory"] for e in available_entries}
+        # All history-derived active dirs preserved when repo scan is empty
+        assert active_dir in available_dirs
+        assert "firmware-2.7.23.bbbbbb" in available_dirs
+        # Deleted dir should still be included in summary
+        assert deleted_dir in available_dirs

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -2817,7 +2817,8 @@ class TestFirmwareUncoveredBranches:
         ):
             result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
 
-        assert result[2] == "firmware-2.7.23.2a858be"
+        # After deterministic sorting, newest by dir string tiebreaker
+        assert result[2] == "firmware-2.7.23.7be5426"
         assert {call.args[0] for call in download_assets.call_args_list} == {
             "firmware-2.7.23.7be5426",
             "firmware-2.7.23.2a858be",
@@ -2864,7 +2865,8 @@ class TestFirmwareUncoveredBranches:
         ):
             result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
 
-        assert result[2] == "firmware-2.7.23.2a858be"
+        # After deterministic sorting, newest by dir string tiebreaker
+        assert result[2] == "firmware-2.7.23.7be5426"
         assert {call.args[0] for call in download_assets.call_args_list} == {
             "firmware-2.7.23.7be5426",
             "firmware-2.7.23.2a858be",
@@ -2899,6 +2901,7 @@ class TestFirmwareUncoveredBranches:
         ):
             result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
 
+        # After deterministic sorting, the newest (by directory string tiebreaker) is returned
         assert result[2] == "firmware-2.7.23.7be5426"
         assert {call.args[0] for call in download_assets.call_args_list} == {
             "firmware-2.7.23.7be5426",
@@ -3269,3 +3272,318 @@ class TestFirmwarePrereleaseBaselineDerivation:
 
         assert result is True
         mock_rmtree.assert_called_once_with("/mock/prerelease/firmware-2.7.22.oldhash")
+
+    # =========================================================================
+    # Tests for deterministic prerelease directory sorting (review fix 1)
+    # =========================================================================
+
+    def test_sort_prerelease_dirs_orders_by_version_then_string(self, downloader):
+        """_sort_prerelease_dirs should sort by version tuple then directory string."""
+        unsorted = [
+            "firmware-2.7.25.999999",
+            "firmware-2.7.23.aaaaaa",
+            "firmware-2.7.24.cccccc",
+            "firmware-2.7.23.bbbbbb",
+        ]
+        sorted_dirs = downloader._sort_prerelease_dirs(unsorted)
+        assert sorted_dirs == [
+            "firmware-2.7.23.aaaaaa",
+            "firmware-2.7.23.bbbbbb",
+            "firmware-2.7.24.cccccc",
+            "firmware-2.7.25.999999",
+        ]
+
+    def test_sort_prerelease_dirs_dedupes(self, downloader):
+        """_sort_prerelease_dirs should remove duplicate entries."""
+        dirs = [
+            "firmware-2.7.24.cccccc",
+            "firmware-2.7.23.aaaaaa",
+            "firmware-2.7.24.cccccc",
+        ]
+        sorted_dirs = downloader._sort_prerelease_dirs(dirs)
+        assert sorted_dirs == [
+            "firmware-2.7.23.aaaaaa",
+            "firmware-2.7.24.cccccc",
+        ]
+
+    def test_sort_prerelease_dirs_newest_last(self, downloader):
+        """After sorting, the last element is the newest prerelease dir."""
+        dirs = [
+            "firmware-2.7.23.aaaaaa",
+            "firmware-2.7.25.999999",
+            "firmware-2.7.24.cccccc",
+        ]
+        sorted_dirs = downloader._sort_prerelease_dirs(dirs)
+        assert sorted_dirs[-1] == "firmware-2.7.25.999999"
+
+    # =========================================================================
+    # Tests for _get_active_prerelease_dirs_from_history tightening (review fix 4)
+    # =========================================================================
+
+    def test_get_active_prerelease_dirs_from_history_active_only(self, downloader):
+        """Only explicitly active entries should be returned."""
+        entries = [
+            {"directory": "firmware-2.7.23.aaaaaa", "status": "active"},
+            {"directory": "firmware-2.7.23.bbbbbb", "status": "deleted"},
+            {"directory": "firmware-2.7.23.cccccc", "status": "active"},
+            {
+                "directory": "firmware-2.7.23.dddddd"
+            },  # no status key, not explicitly active
+            {"directory": "firmware-2.7.23.eeeeee", "status": "unknown"},
+        ]
+        result = downloader._get_active_prerelease_dirs_from_history(entries)
+        assert result == ["firmware-2.7.23.aaaaaa", "firmware-2.7.23.cccccc"]
+
+    def test_get_active_prerelease_dirs_from_history_respects_removed_at(
+        self, downloader
+    ):
+        """Entries with removed_at should be excluded even if status is active."""
+        entries = [
+            {"directory": "firmware-2.7.23.aaaaaa", "status": "active"},
+            {
+                "directory": "firmware-2.7.23.bbbbbb",
+                "status": "active",
+                "removed_at": "2024-01-01",
+            },
+        ]
+        result = downloader._get_active_prerelease_dirs_from_history(entries)
+        assert result == ["firmware-2.7.23.aaaaaa"]
+
+    def test_get_active_prerelease_dirs_from_history_active_flag(self, downloader):
+        """Entries with active=True should be included."""
+        entries = [
+            {"directory": "firmware-2.7.23.aaaaaa", "active": True},
+            {"directory": "firmware-2.7.23.bbbbbb", "active": False},
+        ]
+        result = downloader._get_active_prerelease_dirs_from_history(entries)
+        assert result == ["firmware-2.7.23.aaaaaa"]
+
+    # =========================================================================
+    # Tests for error handling in second repo scan (review fixes 2/3)
+    # =========================================================================
+
+    def test_download_repo_prerelease_firmware_second_scan_error(
+        self, downloader, tmp_path
+    ):
+        """Exception in second repo availability scan should not crash prerelease processing."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        active_dir = "firmware-2.7.23.aaaaaa"
+        history_entries = [
+            {"identifier": "aaaaaa", "status": "active", "directory": active_dir}
+        ]
+
+        with (
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(active_dir, history_entries),
+            ),
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                side_effect=[
+                    [active_dir],  # first call (fallback scan) succeeds
+                    requests.RequestException(
+                        "Second scan failed"
+                    ),  # second call fails
+                ],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ),
+        ):
+            results, failed, latest, summary = (
+                downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+            )
+
+        # Should still complete without raising; active_dirs derived from history
+        assert isinstance(results, list)
+        assert isinstance(failed, list)
+
+    def test_download_repo_prerelease_firmware_second_scan_non_list(
+        self, downloader, tmp_path
+    ):
+        """Non-list response from second repo scan should be handled gracefully."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        active_dir = "firmware-2.7.23.aaaaaa"
+        history_entries = [
+            {"identifier": "aaaaaa", "status": "active", "directory": active_dir}
+        ]
+
+        with (
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(active_dir, history_entries),
+            ),
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                side_effect=[
+                    [active_dir],  # first call succeeds
+                    "not-a-list",  # second call returns non-list
+                ],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ),
+        ):
+            results, failed, latest, summary = (
+                downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+            )
+
+        assert isinstance(results, list)
+        assert isinstance(failed, list)
+
+    # =========================================================================
+    # Tests for unsorted repo directory listings (review fix 6)
+    # =========================================================================
+
+    def test_download_repo_prerelease_firmware_unsorted_fallback_dirs(
+        self, downloader, tmp_path
+    ):
+        """Fallback scan with unsorted repo dirs should download all matching and return the sorted newest."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        # All dirs must match expected_version "2.7.23"
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[
+                    "firmware-2.7.23.bbbbbb",
+                    "firmware-2.7.23.aaaaaa",
+                    "firmware-2.7.23.2a858be",
+                ],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ) as download_assets,
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(None, []),
+            ),
+        ):
+            result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+
+        # The returned active_dir should be the sorted newest (dir string tiebreaker)
+        # String comparison: '2' < 'a' < 'b', so newest = bbbbbb
+        assert result[2] == "firmware-2.7.23.bbbbbb"
+        # All matching dirs should be downloaded in deterministic sorted order (by dir string)
+        call_args = [call.args[0] for call in download_assets.call_args_list]
+        assert call_args == [
+            "firmware-2.7.23.2a858be",
+            "firmware-2.7.23.aaaaaa",
+            "firmware-2.7.23.bbbbbb",
+        ]
+
+    def test_download_repo_prerelease_firmware_unsorted_history_dirs(
+        self, downloader, tmp_path
+    ):
+        """History-derived dirs in arbitrary order should be sorted deterministically."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        history_entries = [
+            {
+                "identifier": "2a858be",
+                "directory": "firmware-2.7.23.2a858be",
+                "status": "active",
+            },
+            {
+                "identifier": "7be5426",
+                "directory": "firmware-2.7.23.7be5426",
+                "status": "active",
+            },
+        ]
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=["firmware-2.7.23.7be5426", "firmware-2.7.23.2a858be"],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ) as download_assets,
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=("firmware-2.7.23.2a858be", history_entries),
+            ),
+        ):
+            result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+
+        # Download order should be deterministic: sorted by version tuple then directory string
+        call_args = [call.args[0] for call in download_assets.call_args_list]
+        assert call_args == [
+            "firmware-2.7.23.2a858be",
+            "firmware-2.7.23.7be5426",
+        ]
+
+    # =========================================================================
+    # Tests for synthetic entries in prerelease summary (review fix 5)
+    # =========================================================================
+
+    def test_download_repo_prerelease_firmware_summary_includes_synthetic_entries(
+        self, downloader, tmp_path
+    ):
+        """Prerelease summary should include synthetic entries for repo-discovered dirs not in history."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        history_entries = [
+            {
+                "identifier": "7be5426",
+                "directory": "firmware-2.7.23.7be5426",
+                "status": "active",
+            },
+        ]
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[
+                    "firmware-2.7.23.7be5426",
+                    "firmware-2.7.23.2a858be",
+                ],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ),
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=("firmware-2.7.23.7be5426", history_entries),
+            ),
+        ):
+            _results, _failed, _latest, summary = (
+                downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+            )
+
+        assert summary is not None
+        available_entries = summary.get("available_history_entries")
+        assert available_entries is not None
+        available_dirs = {e["directory"] for e in available_entries}
+        assert "firmware-2.7.23.7be5426" in available_dirs
+        assert "firmware-2.7.23.2a858be" in available_dirs
+        # Find the synthetic entry
+        synthetic = [
+            e for e in available_entries if e["directory"] == "firmware-2.7.23.2a858be"
+        ]
+        assert len(synthetic) == 1
+        assert synthetic[0]["status"] == "active"
+        assert synthetic[0]["active"] is True
+        assert synthetic[0]["identifier"] == "2.7.23.2a858be"

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -3741,3 +3741,94 @@ class TestFirmwarePrereleaseBaselineDerivation:
         assert "firmware-2.7.23.bbbbbb" in available_dirs
         # Deleted dir should still be included in summary
         assert deleted_dir in available_dirs
+
+    def test_download_repo_prerelease_firmware_tracks_all_active_dirs_when_no_failures(
+        self, downloader, tmp_path
+    ):
+        """All deterministic active dirs should be tracked when there are no failures."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        older_dir = "firmware-2.7.23.aaaaaa"
+        newer_dir = "firmware-2.7.23.bbbbbb"
+        history_entries = [
+            {"identifier": "aaaaaa", "directory": older_dir, "status": "active"},
+            {"identifier": "bbbbbb", "directory": newer_dir, "status": "active"},
+        ]
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[older_dir, newer_dir],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                side_effect=[
+                    ([], [], True),  # older downloads new files
+                    ([], [], False),  # newer already exists (skipped)
+                ],
+            ),
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(newer_dir, history_entries),
+            ),
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.update_prerelease_tracking"
+            ) as mock_track,
+        ):
+            _results, _failed, latest, _summary = (
+                downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+            )
+
+        # Newer dir should be returned as latest (sorted order)
+        assert latest == newer_dir
+        # Both dirs should be tracked (no failures, so all active_dirs tracked)
+        assert mock_track.call_count == 2
+        track_dirs = [call.args[1] for call in mock_track.call_args_list]
+        assert track_dirs == [older_dir, newer_dir]
+
+    def test_download_repo_prerelease_firmware_tracks_only_downloaded_when_failures(
+        self, downloader, tmp_path
+    ):
+        """Only successfully downloaded dirs should be tracked when there are failures."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        success_dir = "firmware-2.7.23.aaaaaa"
+        fail_dir = "firmware-2.7.23.bbbbbb"
+        history_entries = [
+            {"identifier": "aaaaaa", "directory": success_dir, "status": "active"},
+            {"identifier": "bbbbbb", "directory": fail_dir, "status": "active"},
+        ]
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[success_dir, fail_dir],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                side_effect=[
+                    ([], [], True),  # success downloads
+                    ([], [Mock(success=False)], False),  # fail_dir has failures
+                ],
+            ),
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(fail_dir, history_entries),
+            ),
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.update_prerelease_tracking"
+            ) as mock_track,
+        ):
+            _results, _failed, latest, _summary = (
+                downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+            )
+
+        # Only the successfully downloaded dir should be tracked
+        assert mock_track.call_count == 1
+        assert mock_track.call_args.args[1] == success_dir

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -3581,3 +3581,61 @@ class TestFirmwarePrereleaseBaselineDerivation:
         assert synthetic[0]["status"] == "active"
         assert synthetic[0]["active"] is True
         assert synthetic[0]["identifier"] == "2.7.23.2a858be"
+
+    def test_download_repo_prerelease_firmware_summary_excludes_stale_active_entries(
+        self, downloader, tmp_path
+    ):
+        """Prerelease summary should exclude stale active history entries not present in the repo."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        history_entries = [
+            {
+                "identifier": "aaaaaa",
+                "directory": "firmware-2.7.23.aaaaaa",
+                "status": "active",
+            },
+            {
+                "identifier": "bbbbbb",
+                "directory": "firmware-2.7.23.bbbbbb",
+                "status": "active",
+            },
+            {
+                "identifier": "cccccc",
+                "directory": "firmware-2.7.23.cccccc",
+                "status": "deleted",
+            },
+        ]
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[
+                    "firmware-2.7.23.aaaaaa",
+                ],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ),
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=("firmware-2.7.23.aaaaaa", history_entries),
+            ),
+        ):
+            _results, _failed, _latest, summary = (
+                downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
+            )
+
+        assert summary is not None
+        available_entries = summary.get("available_history_entries")
+        assert available_entries is not None
+        available_dirs = {e["directory"] for e in available_entries}
+        # Available active dir should be included
+        assert "firmware-2.7.23.aaaaaa" in available_dirs
+        # Deleted dir should be included
+        assert "firmware-2.7.23.cccccc" in available_dirs
+        # Stale active dir missing from repo should be excluded
+        assert "firmware-2.7.23.bbbbbb" not in available_dirs

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -2819,10 +2819,10 @@ class TestFirmwareUncoveredBranches:
 
         # After deterministic sorting, newest by dir string tiebreaker
         assert result[2] == "firmware-2.7.23.7be5426"
-        assert {call.args[0] for call in download_assets.call_args_list} == {
-            "firmware-2.7.23.7be5426",
+        assert [call.args[0] for call in download_assets.call_args_list] == [
             "firmware-2.7.23.2a858be",
-        }
+            "firmware-2.7.23.7be5426",
+        ]
 
     def test_download_repo_prerelease_firmware_syncs_existing_repo_dirs(
         self, downloader, tmp_path
@@ -2867,10 +2867,10 @@ class TestFirmwareUncoveredBranches:
 
         # After deterministic sorting, newest by dir string tiebreaker
         assert result[2] == "firmware-2.7.23.7be5426"
-        assert {call.args[0] for call in download_assets.call_args_list} == {
-            "firmware-2.7.23.7be5426",
+        assert [call.args[0] for call in download_assets.call_args_list] == [
             "firmware-2.7.23.2a858be",
-        }
+            "firmware-2.7.23.7be5426",
+        ]
 
     def test_download_repo_prerelease_firmware_fallback_downloads_all_existing_dirs(
         self, downloader, tmp_path
@@ -2903,10 +2903,10 @@ class TestFirmwareUncoveredBranches:
 
         # After deterministic sorting, the newest (by directory string tiebreaker) is returned
         assert result[2] == "firmware-2.7.23.7be5426"
-        assert {call.args[0] for call in download_assets.call_args_list} == {
-            "firmware-2.7.23.7be5426",
+        assert [call.args[0] for call in download_assets.call_args_list] == [
             "firmware-2.7.23.2a858be",
-        }
+            "firmware-2.7.23.7be5426",
+        ]
 
     # Lines 1797-1835: Release notes logging
     def test_log_prerelease_summary(self, downloader):
@@ -3382,12 +3382,7 @@ class TestFirmwarePrereleaseBaselineDerivation:
             patch.object(
                 downloader.cache_manager,
                 "get_repo_directories",
-                side_effect=[
-                    [active_dir],  # first call (fallback scan) succeeds
-                    requests.RequestException(
-                        "Second scan failed"
-                    ),  # second call fails
-                ],
+                side_effect=requests.RequestException("Second scan failed"),
             ),
             patch.object(
                 downloader,
@@ -3399,9 +3394,10 @@ class TestFirmwarePrereleaseBaselineDerivation:
                 downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
             )
 
-        # Should still complete without raising; active_dirs derived from history
+        # Should still complete without raising; history-derived active dir preserved
         assert isinstance(results, list)
         assert isinstance(failed, list)
+        assert latest == active_dir
 
     def test_download_repo_prerelease_firmware_second_scan_non_list(
         self, downloader, tmp_path
@@ -3423,10 +3419,7 @@ class TestFirmwarePrereleaseBaselineDerivation:
             patch.object(
                 downloader.cache_manager,
                 "get_repo_directories",
-                side_effect=[
-                    [active_dir],  # first call succeeds
-                    "not-a-list",  # second call returns non-list
-                ],
+                return_value="not-a-list",
             ),
             patch.object(
                 downloader,
@@ -3440,6 +3433,7 @@ class TestFirmwarePrereleaseBaselineDerivation:
 
         assert isinstance(results, list)
         assert isinstance(failed, list)
+        assert latest == active_dir
 
     # =========================================================================
     # Tests for unsorted repo directory listings (review fix 6)

--- a/tests/test_download_orchestrator.py
+++ b/tests/test_download_orchestrator.py
@@ -1622,6 +1622,29 @@ class TestDownloadOrchestrator:
 
         orchestrator.firmware_downloader.log_prerelease_summary.assert_called_once()
 
+    def test_log_prerelease_summary_prefers_available_entries(self, orchestrator):
+        """_log_prerelease_summary should omit missing active dirs after availability filtering."""
+        available_entries = [{"directory": "firmware-2.7.23.7be5426"}]
+        full_entries = [
+            {"directory": "firmware-2.7.23.7be5426"},
+            {"directory": "firmware-2.7.23.2a858be"},
+        ]
+        orchestrator.firmware_prerelease_summary = {
+            "history_entries": full_entries,
+            "available_history_entries": available_entries,
+            "clean_latest_release": "v2.7.22.96dd647",
+            "expected_version": "2.7.23",
+        }
+        orchestrator.firmware_downloader.log_prerelease_summary = Mock()
+
+        orchestrator._log_prerelease_summary()
+
+        orchestrator.firmware_downloader.log_prerelease_summary.assert_called_once_with(
+            available_entries,
+            "v2.7.22.96dd647",
+            "2.7.23",
+        )
+
     def test_log_firmware_history_with_filter_revoked(self, orchestrator):
         """log_firmware_release_history_summary should filter revoked releases."""
         orchestrator.config["FILTER_REVOKED_RELEASES"] = True
@@ -1783,6 +1806,25 @@ class TestDownloadOrchestrator:
         versions = orchestrator.get_latest_versions()
 
         assert versions["firmware_prerelease"] == "1.0.1.abcdef"
+
+    def test_get_latest_versions_prefers_available_prerelease_dir(self, orchestrator):
+        """Verified available prerelease dir should win over stale commit-history latest."""
+        orchestrator.android_releases = []
+        orchestrator.desktop_releases = []
+        orchestrator.latest_available_firmware_prerelease_dir = (
+            "firmware-2.7.23.7be5426"
+        )
+        orchestrator.firmware_downloader.get_latest_release_tag = Mock(
+            return_value="v2.7.22.96dd647"
+        )
+        orchestrator.prerelease_manager.get_latest_active_prerelease_from_history = (
+            Mock(return_value=("firmware-2.7.23.2a858be", []))
+        )
+
+        versions = orchestrator.get_latest_versions()
+
+        assert versions["firmware_prerelease"] == "2.7.23.7be5426"
+        orchestrator.prerelease_manager.get_latest_active_prerelease_from_history.assert_not_called()
 
     def test_get_latest_versions_with_firmware_prerelease_no_prefix(self, orchestrator):
         """get_latest_versions should keep prerelease without firmware- prefix."""
@@ -2293,7 +2335,7 @@ class TestDownloadOrchestrator:
         orchestrator.firmware_downloader.download_repo_prerelease_firmware.return_value = (
             [mock_result],
             [],
-            None,
+            "firmware-2.0.1.available",
             prerelease_summary,
         )
         orchestrator._handle_download_result = Mock()
@@ -2301,6 +2343,10 @@ class TestDownloadOrchestrator:
         orchestrator._process_firmware_downloads()
 
         assert orchestrator.firmware_prerelease_summary == prerelease_summary
+        assert (
+            orchestrator.latest_available_firmware_prerelease_dir
+            == "firmware-2.0.1.available"
+        )
         orchestrator._handle_download_result.assert_any_call(
             mock_result, "firmware_prerelease_repo"
         )

--- a/tests/test_download_orchestrator.py
+++ b/tests/test_download_orchestrator.py
@@ -1885,9 +1885,10 @@ class TestDownloadOrchestrator:
 
         orchestrator._manage_prerelease_tracking()
 
-    def test_run_download_pipeline_resets_stale_wifi_skipped(self, orchestrator):
-        """Stale wifi_skipped=True must be cleared at the start of a subsequent run."""
+    def test_run_download_pipeline_resets_stale_pipeline_state(self, orchestrator):
+        """Stale pipeline state must be cleared at the start of a subsequent run."""
         orchestrator.wifi_skipped = True
+        orchestrator.latest_available_firmware_prerelease_dir = "firmware-2.0.0.stale"
         orchestrator._process_firmware_downloads = Mock()
         orchestrator._process_client_app_downloads = Mock()
         orchestrator._retry_failed_downloads = Mock()
@@ -1898,6 +1899,7 @@ class TestDownloadOrchestrator:
             orchestrator.run_download_pipeline()
 
         assert orchestrator.wifi_skipped is False
+        assert orchestrator.latest_available_firmware_prerelease_dir is None
 
     def test_run_download_pipeline_wifi_only_not_connected(self, orchestrator):
         """Pipeline should skip when WIFI_ONLY and not connected."""
@@ -1918,6 +1920,7 @@ class TestDownloadOrchestrator:
             result = orchestrator.run_download_pipeline()
 
         assert result == ([], [])
+        assert orchestrator.latest_available_firmware_prerelease_dir is None
         orchestrator._process_client_app_downloads.assert_not_called()
 
     def test_get_firmware_keep_limit_invalid(self, orchestrator):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR refines prerelease firmware directory discovery and tracking so repository directory listings are treated as the final source of truth while still respecting deletion metadata recorded in prerelease history. Instead of picking a single "latest" prerelease directory, the downloader now discovers, filters, sorts and (when present upstream) downloads all matching prerelease firmware directories. Orchestrator state and prerelease summaries are updated so downstream code can rely on availability-aware information.

## Key changes

Features
- Downloads all matching prerelease firmware-<expected_version>.<hash> directories that still exist upstream instead of only the newest match.
- Orchestrator records the discovered prerelease directory per run in latest_available_firmware_prerelease_dir and uses it as the authoritative source for firmware_prerelease.
- prerelease summaries gain available_history_entries which include deleted history entries and synthesized entries for repo-discovered active directories.
- New helper: _sort_prerelease_dirs(dirs: List[str]) -> List[str] for deduplication and deterministic ordering (version-then-string, newest-last).

Fixes
- Strictly exclude prerelease directories flagged as deleted in history (status == "deleted" or removed_at) from active lists and downloads, including when falling back to history-derived directories.
- Fallback repo scanning now processes all matching directories and reconciles them with history-derived active directories, preventing re-adding deleted entries and avoiding duplicates when repo verification succeeds.

Refactors / behavior changes
- download_repo_prerelease_firmware() now treats the repository directory listing as the final source of truth and reconciles history-derived data against it.
- Prerelease tracking updates run when there are active directories and no failures, not only after downloads or force_refresh.
- Orchestrator.get_latest_versions() prioritizes latest_available_firmware_prerelease_dir over commit-history lookup.
- _log_prerelease_summary() prefers available_history_entries and falls back to history_entries.

Tests
- Added and adjusted tests to ensure deterministic ordering and deduplication of prerelease dirs, syncing/backfilling of repo-existing directories even if history marks them deleted, and robust behavior when secondary repo scans fail or return non-list responses.
- Unit tests added for _sort_prerelease_dirs and tightened expectations for _get_active_prerelease_dirs_from_history.

Breaking changes / migration notes

- No public API signature changes were introduced. Behavior changes are internal and affect how prerelease directories are discovered and how orchestrator prefers availability-derived prerelease information; callers that relied on the previous single-"latest" selection may observe multiple downloads or different selected dirs now. No explicit migration steps are required beyond adapting to the availability-aware prerelease value (latest_available_firmware_prerelease_dir) if downstream code inspects orchestrator internals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->