### PR TITLE
Add firmware ZIP extraction re-checking for completed releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ junit.xml
 build/
 .opencode/
 .codex
+.omo/
 
 #Ignore vscode AI rules
 .github/instructions/codacy.instructions.md

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,32 +7,32 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.6
+      ref: v1.10.0
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
     - go@1.21.0
     - node@22.16.0
-    - python@3.10.8
+    - python@3.14.4
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - renovate@43.142.1
+    - renovate@43.150.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - gitleaks@8.30.1
     - codespell@2.4.2
     - actionlint@1.7.12
     - bandit@1.9.4
-    - black@26.3.1
-    - checkov@3.2.525
+    - black@26.5.1
+    - checkov@3.2.529
     - git-diff-check
     - isort@8.0.1
     - markdownlint@0.48.0
     - osv-scanner@2.3.5
     - prettier@3.8.3
-    - ruff@0.15.12
+    - ruff@0.15.14
     - taplo@0.10.0
     - trufflehog@3.95.2
     - yamllint@1.38.0

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,6 +18,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
+    - grype@0.110.0
     - renovate@43.150.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
@@ -30,11 +31,11 @@ lint:
     - git-diff-check
     - isort@8.0.1
     - markdownlint@0.48.0
-    - osv-scanner@2.3.5
+    - osv-scanner@2.3.8
     - prettier@3.8.3
     - ruff@0.15.14
     - taplo@0.10.0
-    - trufflehog@3.95.2
+    - trufflehog@3.95.3
     - yamllint@1.38.0
 actions:
   disabled:

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1114,6 +1114,8 @@ class FirmwareReleaseDownloader(BaseDownloader):
 
         exclude_patterns = self._get_exclude_patterns()
         selected_patterns = self.config.get("SELECTED_FIRMWARE_ASSETS", [])
+        if isinstance(selected_patterns, str):
+            selected_patterns = [selected_patterns]
 
         result: List[Asset] = []
         for asset in release.assets:

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1074,6 +1074,79 @@ class FirmwareReleaseDownloader(BaseDownloader):
 
         return True
 
+    def get_zips_needing_extraction(self, release: Release) -> List[Asset]:
+        """
+        Return the list of .zip assets from a release whose extracted contents
+        do not match the current EXTRACT_PATTERNS / EXCLUDE_PATTERNS configuration.
+
+        This enables re-extraction when the user changes extraction patterns or
+        when previously extracted files are missing or have incorrect sizes.
+
+        Parameters:
+            release (Release): Release whose .zip assets to inspect.
+
+        Returns:
+            List[Asset]: .zip assets that need extraction. Empty list if
+                AUTO_EXTRACT is disabled, no extract patterns are configured,
+                the version directory does not exist, or all files are already
+                extracted correctly.
+        """
+        if not self.config.get("AUTO_EXTRACT", False):
+            return []
+
+        extract_patterns = self.config.get("EXTRACT_PATTERNS", [])
+        if isinstance(extract_patterns, str):
+            extract_patterns = [extract_patterns]
+        if not extract_patterns:
+            return []
+
+        try:
+            storage_tag = self._get_release_storage_tag(release)
+        except ValueError:
+            logger.warning(
+                "Skipping extraction check for unsafe firmware tag: %s",
+                release.tag_name,
+            )
+            return []
+        version_dir = os.path.join(self.download_dir, FIRMWARE_DIR_NAME, storage_tag)
+        if not os.path.isdir(version_dir):
+            return []
+
+        exclude_patterns = self._get_exclude_patterns()
+        selected_patterns = self.config.get("SELECTED_FIRMWARE_ASSETS", [])
+
+        result: List[Asset] = []
+        for asset in release.assets:
+            if not asset.name:
+                continue
+
+            if not asset.name.lower().endswith(".zip"):
+                continue
+
+            if selected_patterns and not matches_selected_patterns(
+                asset.name, selected_patterns
+            ):
+                continue
+
+            if self._matches_exclude_patterns(asset.name, exclude_patterns):
+                continue
+
+            zip_path = os.path.join(version_dir, asset.name)
+            if not os.path.exists(zip_path):
+                continue
+
+            if self.file_operations.check_extraction_needed(
+                zip_path, version_dir, extract_patterns, exclude_patterns
+            ):
+                result.append(asset)
+
+        logger.debug(
+            "Found %d zip(s) needing extraction for release %s",
+            len(result),
+            release.tag_name,
+        )
+        return result
+
     def validate_extraction_patterns(
         self, patterns: List[str], exclude_patterns: List[str]
     ) -> bool:

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -794,11 +794,38 @@ class DownloadOrchestrator:
             )
             releases_to_download = []
             successful_firmware_releases: list[Release] = []
+            any_firmware_downloaded = False
             for release, is_complete in zip(
                 releases_to_process, completion_states, strict=True
             ):
                 if is_complete:
                     self.firmware_downloader.ensure_release_notes(release)
+
+                    # Re-check extraction for complete releases: the user may have changed
+                    # EXTRACT_PATTERNS, or previously extracted files may be missing.
+                    zips_needing_extraction = (
+                        self.firmware_downloader.get_zips_needing_extraction(release)
+                    )
+                    if zips_needing_extraction:
+                        extract_patterns = self._get_extraction_patterns()
+                        exclude_patterns = self._get_exclude_patterns()
+                        for asset in zips_needing_extraction:
+                            logger.info(
+                                "Re-extracting %s from %s (patterns changed or files missing)",
+                                asset.name,
+                                release.tag_name,
+                            )
+                            extract_result = self.firmware_downloader.extract_firmware(
+                                release, asset, extract_patterns, exclude_patterns
+                            )
+                            self._handle_download_result(
+                                extract_result, "firmware_extraction"
+                            )
+                            if extract_result.success and not getattr(
+                                extract_result, "was_skipped", False
+                            ):
+                                any_firmware_downloaded = True
+
                     if self._has_selected_non_manifest_firmware_asset(release):
                         successful_firmware_releases.append(release)
                     else:
@@ -812,7 +839,6 @@ class DownloadOrchestrator:
                 else:
                     releases_to_download.append(release)
 
-            any_firmware_downloaded = False
             if releases_to_download:
                 for release in releases_to_download:
                     logger.info(f"Downloading firmware release {release.tag_name}")

--- a/tests/test_download_orchestrator.py
+++ b/tests/test_download_orchestrator.py
@@ -77,6 +77,7 @@ class TestDownloadOrchestrator:
         orch.firmware_downloader = Mock()
         orch.firmware_downloader.download_dir = "/tmp/test"
         orch.firmware_downloader.is_release_revoked = Mock(return_value=False)
+        orch.firmware_downloader.get_zips_needing_extraction = Mock(return_value=[])
 
         def _collect_non_revoked(*, initial_releases, current_fetch_limit, **_unused):
             return initial_releases, initial_releases, current_fetch_limit
@@ -4620,6 +4621,7 @@ class TestFirmwareSummaryUsesSelectedReleases:
         orch.firmware_downloader = Mock()
         orch.firmware_downloader.download_dir = "/tmp/test"
         orch.firmware_downloader.is_release_revoked = Mock(return_value=False)
+        orch.firmware_downloader.get_zips_needing_extraction = Mock(return_value=[])
         orch.desktop_downloader = Mock()
         orch.desktop_downloader.download_dir = "/tmp/test"
 

--- a/tests/test_firmware_get_zips_extraction.py
+++ b/tests/test_firmware_get_zips_extraction.py
@@ -1,0 +1,354 @@
+# Tests for get_zips_needing_extraction method
+#
+# Comprehensive unit tests for every branch of
+# FirmwareReleaseDownloader.get_zips_needing_extraction.
+
+import os
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import Mock, patch
+
+import pytest
+
+from fetchtastic.constants import FIRMWARE_DIR_NAME
+from fetchtastic.download.cache import CacheManager
+from fetchtastic.download.firmware import FirmwareReleaseDownloader
+from fetchtastic.download.interfaces import Asset, Release
+from fetchtastic.download.version import VersionManager
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_config(tmp_path):
+    """Provide a mock configuration dictionary using tmp_path."""
+    return {
+        "DOWNLOAD_DIR": str(tmp_path / "downloads"),
+        "AUTO_EXTRACT": True,
+        "EXTRACT_PATTERNS": ["*.bin"],
+        "EXCLUDE_PATTERNS": [],
+        "SELECTED_FIRMWARE_ASSETS": [],
+        "GITHUB_TOKEN": "test_token",
+        "CHECK_FIRMWARE_PRERELEASES": True,
+    }
+
+
+@pytest.fixture
+def mock_cache_manager(tmp_path):
+    """Mock CacheManager instance using tmp_path."""
+    mock = Mock(spec=CacheManager)
+    mock.cache_dir = str(tmp_path / "cache")
+    mock.get_cache_file_path.side_effect = lambda file_name: os.path.join(
+        mock.cache_dir, file_name
+    )
+    return mock
+
+
+@pytest.fixture
+def downloader(mock_config, mock_cache_manager):
+    """Create a FirmwareReleaseDownloader with mocked dependencies."""
+    dl = FirmwareReleaseDownloader(mock_config, mock_cache_manager)
+    dl.cache_manager = mock_cache_manager
+    dl.file_operations = Mock()
+    dl.version_manager = Mock()
+    real_version_manager = VersionManager()
+    dl.version_manager.get_release_tuple.side_effect = (
+        real_version_manager.get_release_tuple
+    )
+    dl.version_manager.extract_clean_version.side_effect = (
+        real_version_manager.extract_clean_version
+    )
+    # Stub internal methods that are tested elsewhere
+    dl._get_release_storage_tag = Mock(return_value="v2.3.2")
+    dl._get_exclude_patterns = Mock(return_value=[])
+    dl._matches_exclude_patterns = Mock(return_value=False)
+    return dl
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_release(tag: str = "v2.3.2", assets=None) -> Release:
+    """Create a Release with optional assets."""
+    release = Release(
+        tag_name=tag,
+        prerelease=False,
+        published_at="2025-01-01T00:00:00Z",
+    )
+    if assets is not None:
+        release.assets = list(assets)
+    return release
+
+
+def _setup_version_dir(
+    downloader: FirmwareReleaseDownloader,
+    storage_tag: str = "v2.3.2",
+    zip_names: list | None = None,
+) -> str:
+    """Create the version directory and optional zip files on disk.
+
+    Returns the version_dir path.
+    """
+    version_dir = os.path.join(downloader.download_dir, FIRMWARE_DIR_NAME, storage_tag)
+    os.makedirs(version_dir, exist_ok=True)
+    if zip_names:
+        for name in zip_names:
+            Path(os.path.join(version_dir, name)).touch()
+    return version_dir
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.core_downloads
+class TestGetZipsNeedingExtraction:
+    """Test suite for the get_zips_needing_extraction method.
+
+    Covers every branch of the method as implemented in
+    src/fetchtastic/download/firmware.py lines 1094-1148.
+    """
+
+    pytestmark: ClassVar[list] = [pytest.mark.unit, pytest.mark.core_downloads]
+
+    # --- Branch 1: AUTO_EXTRACT is False → returns [] ---
+
+    def test_returns_empty_when_auto_extract_disabled(self, downloader):
+        downloader.config["AUTO_EXTRACT"] = False
+        release = _make_release()
+        assert downloader.get_zips_needing_extraction(release) == []
+
+    # --- Branch 2: EXTRACT_PATTERNS is empty list → returns [] ---
+
+    def test_returns_empty_when_extract_patterns_empty_list(self, downloader):
+        downloader.config["EXTRACT_PATTERNS"] = []
+        release = _make_release()
+        assert downloader.get_zips_needing_extraction(release) == []
+
+    # --- Branch 3: EXTRACT_PATTERNS is a string → wrapped into list ---
+
+    def test_string_extract_patterns_wrapped_in_list(self, downloader):
+        """When EXTRACT_PATTERNS is a string it must be wrapped into a single-element list before being passed downstream."""
+        downloader.config["EXTRACT_PATTERNS"] = "*.bin"
+        version_dir = _setup_version_dir(downloader, "v2.3.2", ["device.zip"])
+        asset = Asset(
+            name="device.zip",
+            download_url="https://example.com/d.zip",
+            size=100,
+        )
+        release = _make_release(assets=[asset])
+        downloader.file_operations.check_extraction_needed.return_value = True
+
+        result = downloader.get_zips_needing_extraction(release)
+        assert len(result) == 1
+        # The wrapped list — not the raw string — must reach check_extraction_needed.
+        downloader.file_operations.check_extraction_needed.assert_called_once_with(
+            os.path.join(version_dir, "device.zip"),
+            version_dir,
+            ["*.bin"],
+            [],
+        )
+
+    # --- Branch 4: _get_release_storage_tag raises ValueError → returns [] ---
+
+    def test_returns_empty_on_value_error_from_storage_tag(self, downloader):
+        downloader._get_release_storage_tag.side_effect = ValueError("unsafe tag")
+        release = _make_release(tag="../../etc")
+        result = downloader.get_zips_needing_extraction(release)
+        assert result == []
+
+    # --- Branch 5: version_dir doesn't exist → returns [] ---
+
+    def test_returns_empty_when_version_dir_not_exists(self, downloader):
+        # _get_release_storage_tag returns "v2.3.2" but we never create the dir
+        release = _make_release()
+        result = downloader.get_zips_needing_extraction(release)
+        assert result == []
+
+    # --- Branch 6: Asset with empty name → skipped ---
+
+    def test_skips_asset_with_empty_name(self, downloader):
+        _setup_version_dir(downloader, "v2.3.2")
+        asset = Asset(name="", download_url="https://example.com/empty.zip", size=100)
+        release = _make_release(assets=[asset])
+        result = downloader.get_zips_needing_extraction(release)
+        assert result == []
+        downloader.file_operations.check_extraction_needed.assert_not_called()
+
+    # --- Branch 7: Asset name doesn't end with .zip (case-insensitive) ---
+
+    def test_skips_non_zip_asset(self, downloader):
+        _setup_version_dir(downloader, "v2.3.2")
+        asset = Asset(
+            name="firmware.bin",
+            download_url="https://example.com/f.bin",
+            size=100,
+        )
+        release = _make_release(assets=[asset])
+        result = downloader.get_zips_needing_extraction(release)
+        assert result == []
+        downloader.file_operations.check_extraction_needed.assert_not_called()
+
+    def test_accepts_uppercase_zip_extension(self, downloader):
+        """The .zip check is case-insensitive (.ZIP should pass)."""
+        _setup_version_dir(downloader, "v2.3.2", ["device.ZIP"])
+        asset = Asset(
+            name="device.ZIP",
+            download_url="https://example.com/d.zip",
+            size=100,
+        )
+        release = _make_release(assets=[asset])
+        downloader.file_operations.check_extraction_needed.return_value = True
+
+        result = downloader.get_zips_needing_extraction(release)
+        assert len(result) == 1
+        assert result[0].name == "device.ZIP"
+
+    # --- Branch 8: Asset doesn't match SELECTED_FIRMWARE_ASSETS → skipped ---
+
+    @patch("fetchtastic.download.firmware.matches_selected_patterns")
+    def test_skips_asset_not_matching_selected_patterns(self, mock_matches, downloader):
+        mock_matches.return_value = False
+        downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
+        _setup_version_dir(downloader, "v2.3.2")
+        asset = Asset(
+            name="heltec.zip",
+            download_url="https://example.com/h.zip",
+            size=100,
+        )
+        release = _make_release(assets=[asset])
+        result = downloader.get_zips_needing_extraction(release)
+        assert result == []
+        mock_matches.assert_called_once_with("heltec.zip", ["rak4631"])
+
+    # --- Branch 9: Asset matches exclude patterns → skipped ---
+
+    def test_skips_asset_matching_exclude_patterns(self, downloader):
+        downloader._matches_exclude_patterns.return_value = True
+        _setup_version_dir(downloader, "v2.3.2")
+        asset = Asset(
+            name="device-debug.zip",
+            download_url="https://example.com/d.zip",
+            size=100,
+        )
+        release = _make_release(assets=[asset])
+        result = downloader.get_zips_needing_extraction(release)
+        assert result == []
+        downloader.file_operations.check_extraction_needed.assert_not_called()
+
+    # --- Branch 10: Zip file doesn't exist on disk → skipped ---
+
+    def test_skips_asset_when_zip_not_on_disk(self, downloader):
+        _setup_version_dir(downloader, "v2.3.2")  # dir exists, no zip files
+        asset = Asset(
+            name="device.zip",
+            download_url="https://example.com/d.zip",
+            size=100,
+        )
+        release = _make_release(assets=[asset])
+        result = downloader.get_zips_needing_extraction(release)
+        assert result == []
+
+    # --- Branch 11: check_extraction_needed returns True → asset added ---
+
+    def test_adds_asset_when_extraction_needed(self, downloader):
+        version_dir = _setup_version_dir(downloader, "v2.3.2", ["device.zip"])
+        asset = Asset(
+            name="device.zip",
+            download_url="https://example.com/d.zip",
+            size=100,
+        )
+        release = _make_release(assets=[asset])
+        downloader.file_operations.check_extraction_needed.return_value = True
+
+        result = downloader.get_zips_needing_extraction(release)
+        assert len(result) == 1
+        assert result[0] is asset
+        downloader.file_operations.check_extraction_needed.assert_called_once_with(
+            os.path.join(version_dir, "device.zip"),
+            version_dir,
+            ["*.bin"],
+            [],
+        )
+
+    # --- Branch 12: check_extraction_needed returns False → NOT added ---
+
+    def test_skips_asset_when_extraction_not_needed(self, downloader):
+        _setup_version_dir(downloader, "v2.3.2", ["device.zip"])
+        asset = Asset(
+            name="device.zip",
+            download_url="https://example.com/d.zip",
+            size=100,
+        )
+        release = _make_release(assets=[asset])
+        downloader.file_operations.check_extraction_needed.return_value = False
+
+        result = downloader.get_zips_needing_extraction(release)
+        assert result == []
+
+    # --- Branch 13: Mixed assets → correct subset returned ---
+
+    def test_mixed_assets_returns_correct_subset(self, downloader):
+        _setup_version_dir(downloader, "v2.3.2", ["device-a.zip", "device-b.zip"])
+        asset_a = Asset(
+            name="device-a.zip",
+            download_url="https://example.com/a.zip",
+            size=100,
+        )
+        asset_b = Asset(
+            name="device-b.zip",
+            download_url="https://example.com/b.zip",
+            size=200,
+        )
+        asset_nonzip = Asset(
+            name="readme.txt",
+            download_url="https://example.com/r.txt",
+            size=50,
+        )
+        release = _make_release(assets=[asset_a, asset_b, asset_nonzip])
+
+        # Only device-a needs extraction
+        def check_side_effect(zip_path, vdir, patterns, excludes):
+            return "device-a" in zip_path
+
+        downloader.file_operations.check_extraction_needed.side_effect = (
+            check_side_effect
+        )
+
+        result = downloader.get_zips_needing_extraction(release)
+        assert len(result) == 1
+        assert result[0] is asset_a
+
+    # --- Branch 14: SELECTED_FIRMWARE_ASSETS is empty → all pass that filter ---
+
+    @patch("fetchtastic.download.firmware.matches_selected_patterns")
+    def test_empty_selected_firmware_assets_passes_all(self, mock_matches, downloader):
+        """When SELECTED_FIRMWARE_ASSETS is empty the selected-pattern check
+        is short-circuited and every asset passes that filter."""
+        downloader.config["SELECTED_FIRMWARE_ASSETS"] = []
+        _setup_version_dir(downloader, "v2.3.2", ["dev1.zip", "dev2.zip"])
+        asset1 = Asset(
+            name="dev1.zip",
+            download_url="https://example.com/1.zip",
+            size=100,
+        )
+        asset2 = Asset(
+            name="dev2.zip",
+            download_url="https://example.com/2.zip",
+            size=200,
+        )
+        release = _make_release(assets=[asset1, asset2])
+        downloader.file_operations.check_extraction_needed.return_value = True
+
+        result = downloader.get_zips_needing_extraction(release)
+        assert len(result) == 2
+        assert result[0] is asset1
+        assert result[1] is asset2
+        # matches_selected_patterns must never be called (short-circuited)
+        mock_matches.assert_not_called()

--- a/tests/test_orchestrator_reextraction.py
+++ b/tests/test_orchestrator_reextraction.py
@@ -1,0 +1,294 @@
+# Tests for re-extraction block in _process_firmware_downloads
+#
+# Covers orchestrator.py lines 809-827: the for-loop that re-extracts
+# firmware zips when zips_needing_extraction is non-empty during
+# processing of already-complete releases.
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from fetchtastic.download.interfaces import Asset, DownloadResult, Release
+from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+pytestmark = [pytest.mark.unit, pytest.mark.core_downloads]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def orch(tmp_path):
+    """Create a DownloadOrchestrator with firmware-related mocks pre-wired.
+
+    The fixture creates the orchestrator with SAVE_FIRMWARE=True and
+    wires up the minimum set of mocks required for _process_firmware_downloads
+    to reach the re-extraction block.  All state-affecting methods are
+    mocked so that the test can focus solely on lines 809-827.
+    """
+    config = {
+        "DOWNLOAD_DIR": str(tmp_path),
+        "SAVE_APKS": False,
+        "SAVE_FIRMWARE": True,
+        "SELECTED_FIRMWARE_ASSETS": ["rak4631"],
+        "EXCLUDE_PATTERNS": ["*debug*"],
+        "EXTRACT_PATTERNS": ["*.bin"],
+        "GITHUB_TOKEN": "test_token",
+        "FIRMWARE_VERSIONS_TO_KEEP": 2,
+        "KEEP_LAST_BETA": False,
+        "FILTER_REVOKED_RELEASES": False,
+        "AUTO_EXTRACT": True,
+        "CREATE_LATEST_SYMLINKS": True,
+    }
+    orch = DownloadOrchestrator(config)
+
+    # --- firmware downloader mocks ---
+    orch.firmware_downloader.download_dir = str(tmp_path / "firmware")
+    orch.firmware_downloader.is_release_revoked = Mock(return_value=False)
+    orch.firmware_downloader.format_release_log_suffix = Mock(return_value="")
+    orch.firmware_downloader.ensure_release_notes = Mock()
+    orch.firmware_downloader.download_repo_prerelease_firmware = Mock(
+        return_value=([], [], None, None)
+    )
+    orch.firmware_downloader.cleanup_superseded_prereleases = Mock()
+    orch.firmware_downloader.update_manifest_baseline_if_needed = Mock()
+    orch.firmware_downloader.should_download_release = Mock(return_value=True)
+    orch.firmware_downloader.is_release_complete = Mock(return_value=True)
+    orch.firmware_downloader.download_manifests = Mock(return_value=[])
+    orch.firmware_downloader.download_firmware = Mock()
+
+    # --- orchestrator-level mocks ---
+    orch._has_selected_non_manifest_firmware_asset = Mock(return_value=True)
+    orch._select_latest_release_by_version = Mock(return_value=None)
+
+    return orch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_asset(name="firmware-rak4631.zip") -> Asset:
+    """Create a minimal Asset for use in extraction tests."""
+    return Asset(
+        name=name,
+        download_url="https://example.com/" + name,
+        size=100,
+    )
+
+
+def _wire_release(orch, tag="v2.0.0", assets=None):
+    """Wire a release into the orchestrator's firmware processing pipeline.
+
+    Returns the Release object so tests can make assertions against it.
+    """
+    if assets is None:
+        assets = [_make_asset()]
+    release = Release(tag_name=tag, prerelease=False, assets=list(assets))
+    orch.firmware_downloader.get_releases = Mock(return_value=[release])
+    orch.firmware_downloader.collect_non_revoked_releases = Mock(
+        return_value=([release], [release], 8)
+    )
+    return release
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestReExtractionBlock:
+    """Tests for orchestrator._process_firmware_downloads lines 809-827.
+
+    The block is entered when a release is already complete but
+    get_zips_needing_extraction returns one or more assets — indicating
+    that extraction patterns changed or previously extracted files are
+    missing.
+    """
+
+    # ------------------------------------------------------------------
+    # Extraction succeeds, not skipped
+    # ------------------------------------------------------------------
+
+    def test_re_extract_success_sets_firmware_downloaded(self, orch):
+        """Re-extraction that succeeds (was_skipped=False) calls all
+        expected collaborators."""
+        asset = _make_asset("firmware-rak4631.zip")
+        release = _wire_release(orch, "v2.0.0", [asset])
+
+        orch.firmware_downloader.get_zips_needing_extraction = Mock(
+            return_value=[asset]
+        )
+
+        extract_result = Mock(spec=DownloadResult)
+        extract_result.success = True
+        extract_result.was_skipped = False
+        orch.firmware_downloader.extract_firmware = Mock(return_value=extract_result)
+
+        with patch.object(orch, "_handle_download_result") as mock_handle, patch.object(
+            orch.firmware_downloader, "update_latest_pointer_for_release"
+        ) as mock_pointer:
+            orch._process_firmware_downloads()
+
+        # extract_firmware called with correct arguments
+        orch.firmware_downloader.extract_firmware.assert_called_once_with(
+            release,
+            asset,
+            ["*.bin"],
+            ["*debug*"],
+        )
+
+        # _handle_download_result called with "firmware_extraction"
+        mock_handle.assert_called_once_with(extract_result, "firmware_extraction")
+
+        # Latest pointer should be updated after successful re-extraction
+        mock_pointer.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # Extraction succeeds but was_skipped=True
+    # ------------------------------------------------------------------
+
+    def test_re_extract_skipped_still_handles_result(self, orch):
+        """When extract_firmware returns was_skipped=True the result is
+        still passed to _handle_download_result with the correct op type."""
+        asset = _make_asset()
+        _wire_release(orch, "v2.0.0", [asset])
+
+        orch.firmware_downloader.get_zips_needing_extraction = Mock(
+            return_value=[asset]
+        )
+
+        extract_result = Mock(spec=DownloadResult)
+        extract_result.success = True
+        extract_result.was_skipped = True
+        orch.firmware_downloader.extract_firmware = Mock(return_value=extract_result)
+
+        with patch.object(orch, "_handle_download_result") as mock_handle, patch.object(
+            orch.firmware_downloader, "update_latest_pointer_for_release"
+        ):
+            orch._process_firmware_downloads()
+
+        # Still passed through to result handler
+        mock_handle.assert_called_once_with(extract_result, "firmware_extraction")
+
+    # ------------------------------------------------------------------
+    # Extraction failure
+    # ------------------------------------------------------------------
+
+    def test_re_extract_failure_handles_result(self, orch):
+        """A failed extraction result is still routed to
+        _handle_download_result."""
+        asset = _make_asset()
+        _wire_release(orch, "v2.0.0", [asset])
+
+        orch.firmware_downloader.get_zips_needing_extraction = Mock(
+            return_value=[asset]
+        )
+
+        extract_result = Mock(spec=DownloadResult)
+        extract_result.success = False
+        orch.firmware_downloader.extract_firmware = Mock(return_value=extract_result)
+
+        with patch.object(orch, "_handle_download_result") as mock_handle, patch.object(
+            orch.firmware_downloader, "update_latest_pointer_for_release"
+        ):
+            orch._process_firmware_downloads()
+
+        mock_handle.assert_called_once_with(extract_result, "firmware_extraction")
+
+    # ------------------------------------------------------------------
+    # Multiple assets in zips_needing_extraction
+    # ------------------------------------------------------------------
+
+    def test_re_extract_multiple_assets(self, orch):
+        """Each asset in zips_needing_extraction triggers its own
+        extract_firmware and _handle_download_result call."""
+        asset_a = _make_asset("firmware-rak4631.zip")
+        asset_b = _make_asset("firmware-tbeam.zip")
+        _wire_release(orch, "v2.0.0", [asset_a, asset_b])
+
+        orch.firmware_downloader.get_zips_needing_extraction = Mock(
+            return_value=[asset_a, asset_b]
+        )
+
+        result_a = Mock(spec=DownloadResult)
+        result_a.success = True
+        result_a.was_skipped = False
+        result_b = Mock(spec=DownloadResult)
+        result_b.success = True
+        result_b.was_skipped = False
+        orch.firmware_downloader.extract_firmware = Mock(
+            side_effect=[result_a, result_b]
+        )
+
+        with patch.object(orch, "_handle_download_result") as mock_handle, patch.object(
+            orch.firmware_downloader, "update_latest_pointer_for_release"
+        ):
+            orch._process_firmware_downloads()
+
+        assert orch.firmware_downloader.extract_firmware.call_count == 2
+        assert mock_handle.call_count == 2
+        mock_handle.assert_any_call(result_a, "firmware_extraction")
+        mock_handle.assert_any_call(result_b, "firmware_extraction")
+
+    # ------------------------------------------------------------------
+    # No zips needing extraction → block skipped
+    # ------------------------------------------------------------------
+
+    def test_no_zips_needing_extraction_skips_block(self, orch):
+        """When get_zips_needing_extraction returns [], the re-extraction
+        block is never entered and extract_firmware is not called."""
+        asset = _make_asset()
+        _wire_release(orch, "v2.0.0", [asset])
+
+        orch.firmware_downloader.get_zips_needing_extraction = Mock(return_value=[])
+        orch.firmware_downloader.extract_firmware = Mock()
+
+        with patch.object(orch, "_handle_download_result") as mock_handle, patch.object(
+            orch.firmware_downloader, "update_latest_pointer_for_release"
+        ):
+            orch._process_firmware_downloads()
+
+        orch.firmware_downloader.extract_firmware.assert_not_called()
+        # No extraction result → no firmware_extraction handle call
+        extraction_calls = [
+            c for c in mock_handle.call_args_list if c[0][1] == "firmware_extraction"
+        ]
+        assert len(extraction_calls) == 0
+
+    # ------------------------------------------------------------------
+    # Extraction patterns are pulled from config
+    # ------------------------------------------------------------------
+
+    def test_re_extract_uses_configured_patterns(self, orch):
+        """Verify that _get_extraction_patterns / _get_exclude_patterns
+        are called and their return values reach extract_firmware."""
+        orch.config["EXTRACT_PATTERNS"] = ["*.uf2", "*.bin"]
+        orch.config["EXCLUDE_PATTERNS"] = ["*debug*", "*test*"]
+
+        asset = _make_asset()
+        release = _wire_release(orch, "v2.0.0", [asset])
+
+        orch.firmware_downloader.get_zips_needing_extraction = Mock(
+            return_value=[asset]
+        )
+
+        extract_result = Mock(spec=DownloadResult)
+        extract_result.success = True
+        extract_result.was_skipped = False
+        orch.firmware_downloader.extract_firmware = Mock(return_value=extract_result)
+
+        with patch.object(orch, "_handle_download_result"), patch.object(
+            orch.firmware_downloader, "update_latest_pointer_for_release"
+        ):
+            orch._process_firmware_downloads()
+
+        orch.firmware_downloader.extract_firmware.assert_called_once_with(
+            release,
+            asset,
+            ["*.uf2", "*.bin"],
+            ["*debug*", "*test*"],
+        )

--- a/tests/test_orchestrator_reextraction.py
+++ b/tests/test_orchestrator_reextraction.py
@@ -44,7 +44,9 @@ def orch(tmp_path):
     }
     orch = DownloadOrchestrator(config)
 
-    # --- firmware downloader mocks ---
+    # Replace firmware_downloader entirely with a Mock so no real methods
+    # leak through.  This matches the pattern in test_download_orchestrator.py.
+    orch.firmware_downloader = Mock()
     orch.firmware_downloader.download_dir = str(tmp_path / "firmware")
     orch.firmware_downloader.is_release_revoked = Mock(return_value=False)
     orch.firmware_downloader.format_release_log_suffix = Mock(return_value="")
@@ -53,11 +55,15 @@ def orch(tmp_path):
         return_value=([], [], None, None)
     )
     orch.firmware_downloader.cleanup_superseded_prereleases = Mock()
-    orch.firmware_downloader.update_manifest_baseline_if_needed = Mock()
-    orch.firmware_downloader.should_download_release = Mock(return_value=True)
     orch.firmware_downloader.is_release_complete = Mock(return_value=True)
     orch.firmware_downloader.download_manifests = Mock(return_value=[])
-    orch.firmware_downloader.download_firmware = Mock()
+
+    def _collect_non_revoked(*, initial_releases, current_fetch_limit, **_unused):
+        return initial_releases, initial_releases, current_fetch_limit
+
+    orch.firmware_downloader.collect_non_revoked_releases = Mock(
+        side_effect=_collect_non_revoked
+    )
 
     # --- orchestrator-level mocks ---
     orch._has_selected_non_manifest_firmware_asset = Mock(return_value=True)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request introduces automatic re-extraction of firmware ZIP assets when extraction/exclusion patterns change or extracted files go missing, even for previously completed releases. It also updates build tooling and test infrastructure to support this new capability.

## Changes

**Features**
- Added `get_zips_needing_extraction()` method to `FirmwareReleaseDownloader` that identifies firmware ZIP assets requiring extraction based on configured patterns, existing extracted files, and the `AUTO_EXTRACT` setting
- Modified `DownloadOrchestrator._process_firmware_downloads()` to detect and re-extract firmware ZIPs for completed releases when needed, recomputing extraction/exclusion patterns from current configuration and recording extractions via the existing result handler

**Build & Configuration**
- Updated Trunk plugin source from v1.7.6 to v1.10.0
- Upgraded Python runtime from 3.10.8 to 3.14.4
- Updated linter/tool versions including grype, renovate, black, checkov, osv-scanner, ruff, and trufflehog
- Added `.omo/` directory to `.gitignore`

**Tests**
- Updated `DownloadOrchestrator` test fixtures to mock `firmware_downloader.get_zips_needing_extraction()` to return an empty list, ensuring deterministic test behavior and preserving existing test expectations

## Breaking Changes

None identified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jeremiah-k/fetchtastic/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->