### PR TITLE
Add Python 3.13/3.14 to CI matrix and upgrade pytest to 9.1.0

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: Android",
   "Operating System :: POSIX :: Linux",
   "Operating System :: MacOS",
@@ -38,7 +39,7 @@ dependencies = [
 [project.optional-dependencies]
 win = ["pywin32", "winshell"]
 test = [
-  "pytest==9.0.3",
+  "pytest==9.1.0",
   "pytest-mock==3.15.1",
   "pytest-cov==7.1.0",
   "pytest-asyncio==1.4.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Development and testing dependencies
-pytest==9.0.3
+pytest==9.1.0
 pytest-cov==7.1.0
 pytest-mock==3.15.1
 pytest-asyncio==1.3.0

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -12,7 +12,7 @@ from fetchtastic import log_utils
 pytestmark = [pytest.mark.unit, pytest.mark.infrastructure]
 
 
-def _app_handlers():
+def _app_handlers() -> list[logging.Handler]:
     """Return the logger's own handlers, excluding pytest's caplog capture handlers.
 
     pytest 9+ attaches ``LogCaptureHandler`` instances directly to the logger under
@@ -31,9 +31,16 @@ class TestLogUtils:
     """Test suite for log_utils module."""
 
     def setup_method(self):
-        """Reset logger state before each test."""
-        # Clear all handlers
-        for handler in log_utils.logger.handlers[:]:
+        """Reset logger state before each test.
+
+        Only application handlers are removed and closed; pytest's
+        ``LogCaptureHandler`` (caplog) is preserved so log capture stays intact
+        across the test session.
+        """
+        # Clear only application handlers, preserving pytest's LogCaptureHandler
+        for handler in list(log_utils.logger.handlers):
+            if handler.__class__.__name__ == "LogCaptureHandler":
+                continue
             log_utils.logger.removeHandler(handler)
             handler.close()
 
@@ -47,15 +54,18 @@ class TestLogUtils:
         """Test that logger is properly initialized."""
         assert log_utils.logger.name == "fetchtastic"
         assert not log_utils.logger.propagate
-        assert len(_app_handlers()) == 1
-        assert isinstance(_app_handlers()[0], RichHandler)
+        handlers = _app_handlers()
+        assert len(handlers) == 1
+        assert isinstance(handlers[0], RichHandler)
 
     def test_logger_initialization_with_env_var(self):
         """Test logger initialization with environment variable."""
         with patch.dict(os.environ, {"FETCHTASTIC_LOG_LEVEL": "DEBUG"}):
             log_utils._initialize_logger()
             assert log_utils.logger.level == logging.DEBUG
-            assert _app_handlers()[0].level == logging.DEBUG
+            handlers = _app_handlers()
+            assert len(handlers) == 1
+            assert handlers[0].level == logging.DEBUG
 
     def test_logger_initialization_with_invalid_env_var(self):
         """Test logger initialization with invalid environment variable."""

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -12,6 +12,21 @@ from fetchtastic import log_utils
 pytestmark = [pytest.mark.unit, pytest.mark.infrastructure]
 
 
+def _app_handlers():
+    """Return the logger's own handlers, excluding pytest's caplog capture handlers.
+
+    pytest 9+ attaches ``LogCaptureHandler`` instances directly to the logger under
+    test (8.x only attached them to root). Filter by class name so assertions
+    describe the module's configuration, not the test harness. Duck-typed to avoid
+    importing the private ``_pytest.logging`` module.
+    """
+    return [
+        h
+        for h in log_utils.logger.handlers
+        if h.__class__.__name__ != "LogCaptureHandler"
+    ]
+
+
 class TestLogUtils:
     """Test suite for log_utils module."""
 
@@ -32,15 +47,15 @@ class TestLogUtils:
         """Test that logger is properly initialized."""
         assert log_utils.logger.name == "fetchtastic"
         assert not log_utils.logger.propagate
-        assert len(log_utils.logger.handlers) == 1
-        assert isinstance(log_utils.logger.handlers[0], RichHandler)
+        assert len(_app_handlers()) == 1
+        assert isinstance(_app_handlers()[0], RichHandler)
 
     def test_logger_initialization_with_env_var(self):
         """Test logger initialization with environment variable."""
         with patch.dict(os.environ, {"FETCHTASTIC_LOG_LEVEL": "DEBUG"}):
             log_utils._initialize_logger()
             assert log_utils.logger.level == logging.DEBUG
-            assert log_utils.logger.handlers[0].level == logging.DEBUG
+            assert _app_handlers()[0].level == logging.DEBUG
 
     def test_logger_initialization_with_invalid_env_var(self):
         """Test logger initialization with invalid environment variable."""
@@ -68,7 +83,7 @@ class TestLogUtils:
         """Test that setting log level updates formatters appropriately."""
         # Set to DEBUG level
         log_utils.set_log_level("DEBUG")
-        handler = log_utils.logger.handlers[0]
+        handler = _app_handlers()[0]
         formatter = handler.formatter
 
         # DEBUG formatter should be clean and simple
@@ -77,7 +92,7 @@ class TestLogUtils:
 
         # Set to INFO level
         log_utils.set_log_level("INFO")
-        handler = log_utils.logger.handlers[0]
+        handler = _app_handlers()[0]
         formatter = handler.formatter
 
         # INFO formatter should be simpler
@@ -91,7 +106,7 @@ class TestLogUtils:
             log_utils.add_file_logging(log_dir, "INFO")
 
             # Check that file handler was added
-            assert len(log_utils.logger.handlers) == 2  # Console + File
+            assert len(_app_handlers()) == 2  # Console + File
             assert log_utils._file_handler is not None
             assert log_utils._file_handler in log_utils.logger.handlers
 
@@ -114,7 +129,7 @@ class TestLogUtils:
 
             # Should have replaced the first handler
             assert first_handler != second_handler
-            assert len(log_utils.logger.handlers) == 2  # Still just console + file
+            assert len(_app_handlers()) == 2  # Still just console + file
 
     def test_add_file_logging_different_levels(self):
         """Test file logging with different log levels."""
@@ -281,8 +296,8 @@ class TestLogUtils:
         """Test that _initialize_logger can be called multiple times safely."""
         # Should not raise any errors
         log_utils._initialize_logger()
-        initial_handlers = len(log_utils.logger.handlers)
+        initial_handlers = len(_app_handlers())
 
         log_utils._initialize_logger()
         # Should still have same number of handlers (replaces them)
-        assert len(log_utils.logger.handlers) == initial_handlers
+        assert len(_app_handlers()) == initial_handlers


### PR DESCRIPTION


## Summary by Sourcery

Adjust logging tests for pytest 9 handler behavior and expand supported Python versions.

Enhancements:
- Update log_utils tests to ignore pytest's LogCaptureHandler so assertions target application handlers.

Build:
- Bump pytest dependency to 9.1.0 in test extras.
- Advertise Python 3.14 support in project metadata.

CI:
- Extend GitHub Actions test matrix to run against Python 3.13 and 3.14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR updates the project to be compatible with pytest 9.1.0 and extends continuous integration testing to include Python 3.13 and 3.14. The main work involves adapting log utility tests to handle pytest 9's new behavior of attaching capture handlers directly to tested loggers, and updating project metadata and CI configuration accordingly.

## Key changes

**Fixes**
- Modified `tests/test_log_utils.py` to filter out pytest's `LogCaptureHandler` instances when asserting on logger handlers, preventing test failures due to pytest 9.x's new handler attachment behavior. Introduced a `_app_handlers()` helper function that returns the application's handlers while excluding pytest's capture handlers.

**Dependencies**
- Bumped pytest from 9.0.3 to 9.1.0 in both `pyproject.toml` and `requirements-dev.txt`

**Testing & CI**
- Expanded the test matrix in `.github/workflows/test-and-coverage.yml` to include Python 3.13 and 3.14
- Added Python 3.14 classifier to project metadata in `pyproject.toml`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->