### PR TITLE
fix: Expand default firmware extraction patterns

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -282,6 +282,8 @@ A few real-world tokens you might use:
 - `tlora-v2-1-1_6-` for the TLORA V2.1.1_6 line
 - `t-deck-` for the T-Deck line
 - `meshtasticd_` for desktop packages like `meshtasticd_...deb`
+- `mt-` for ESP32 OTA helper binaries (`mt-esp32-ota.bin`, `mt-esp32s3-ota.bin`, `mt-esp32c3-ota.bin`, `mt-esp32c6-ota.bin`)
+- `factory_erase` for nRF52 factory erase / recovery UF2 files (`Meshtastic_nRF52_factory_erase_*.uf2`); these are recovery artifacts, not normal firmware update files
 
 Tips:
 

--- a/src/fetchtastic/constants.py
+++ b/src/fetchtastic/constants.py
@@ -163,13 +163,19 @@ VERSION_REGEX_PATTERN = (
 
 # Default extraction patterns (examples for documentation)
 DEFAULT_EXTRACTION_PATTERNS = [
-    "rak4631-",
-    "tbeam",
-    "t1000-e-",
-    "tlora-v2-1-1_6-",
-    "device-",
-    "littlefs-",
-    "bleota",
+    # Device families: each token matches firmware images for that board.
+    "rak4631-",  # RAK4631 base family (hyphen form)
+    "tbeam",  # T-Beam family
+    "t1000-e-",  # T1000-E family
+    "tlora-v2-1-1_6-",  # TLORA V2.1.1_6 variant line
+    # Non-device artifacts bundled with firmware releases.
+    "device-",  # device-install.sh / device-update.sh setup scripts
+    "littlefs-",  # LittleFS filesystem images
+    "bleota",  # BLE OTA blobs (bleota.bin, bleota-c3.bin, bleota-s3.bin)
+    # ESP32 OTA helper binaries (covers esp32, esp32s3, esp32c3, esp32c6).
+    "mt-",
+    # nRF52 factory erase / recovery UF2 files (not normal update images).
+    "factory_erase",
 ]
 
 # Configuration file names

--- a/tests/test_default_extraction_patterns.py
+++ b/tests/test_default_extraction_patterns.py
@@ -2,14 +2,24 @@
 #
 # Locks in that the default pattern list shipped to users covers the
 # ESP32 OTA helper binaries (`mt-*-ota.bin`) and the nRF52 factory
-# erase / recovery UF2 files (`Meshtastic_nRF52_factory_erase_*.uf2`),
-# and that those files are actually selected by matches_extract_patterns
-# when the defaults are in use.
+# erase / recovery UF2 files (`Meshtastic_nRF52_factory_erase_*.uf2`).
+#
+# The tests exercise the PRODUCTION extraction path:
+#   - matches_selected_patterns() is what FileOperations.extract_archive()
+#     and FileOperations.check_extraction_needed() call on each archive
+#     member (see src/fetchtastic/download/files.py).
+#   - The ZIP-level tests drive those FileOperations methods directly with
+#     DEFAULT_EXTRACTION_PATTERNS so the full include-filter + extract
+#     pipeline is covered end-to-end.
+
+import zipfile
+from pathlib import Path
 
 import pytest
 
 from fetchtastic import constants
-from fetchtastic.utils import matches_extract_patterns
+from fetchtastic.download.files import FileOperations
+from fetchtastic.utils import matches_selected_patterns
 
 # Files that upstream firmware releases publish and that users expect
 # the default pattern list to catch.
@@ -23,9 +33,8 @@ DEFAULT_SHOULD_MATCH = [
 ]
 
 # Negative controls: common release artifacts the defaults should NOT
-# silently pull in just because of the new patterns. These are chosen so
-# that no existing default pattern (rak4631-, tbeam, t1000-e-, ...) hits
-# them either.
+# silently pull in. Chosen so that no existing default pattern
+# (rak4631-, tbeam, t1000-e-, ...) hits them either.
 DEFAULT_SHOULD_NOT_MATCH = [
     "readme.txt",
     # A device family not present in the default list.
@@ -67,13 +76,15 @@ class TestDefaultExtractionPatterns:
 
     @pytest.mark.parametrize("filename", DEFAULT_SHOULD_MATCH)
     def test_default_patterns_match_expected_files(self, filename):
-        assert matches_extract_patterns(
+        # Production extraction filter: matches_selected_patterns is what
+        # FileOperations.extract_archive() applies to each archive member.
+        assert matches_selected_patterns(
             filename, constants.DEFAULT_EXTRACTION_PATTERNS
         ), f"default patterns did not match {filename!r}"
 
     @pytest.mark.parametrize("filename", DEFAULT_SHOULD_NOT_MATCH)
     def test_default_patterns_do_not_match_controls(self, filename):
-        assert not matches_extract_patterns(
+        assert not matches_selected_patterns(
             filename, constants.DEFAULT_EXTRACTION_PATTERNS
         ), f"default patterns should not match {filename!r}"
 
@@ -88,7 +99,7 @@ class TestDefaultExtractionPatterns:
     )
     def test_mt_prefix_alone_matches_all_esp32_ota_variants(self, filename):
         # Single `mt-` pattern is sufficient for every ESP32 variant.
-        assert matches_extract_patterns(filename, ["mt-"])
+        assert matches_selected_patterns(filename, ["mt-"])
 
     @pytest.mark.parametrize(
         ("filename", "should_match"),
@@ -101,5 +112,112 @@ class TestDefaultExtractionPatterns:
         ],
     )
     def test_factory_erase_targets_recovery_files_only(self, filename, should_match):
-        result = matches_extract_patterns(filename, ["factory_erase"])
+        result = matches_selected_patterns(filename, ["factory_erase"])
         assert result is should_match
+
+
+# ---------------------------------------------------------------------------
+# ZIP-level integration tests: drive FileOperations.extract_archive() and
+# check_extraction_needed() with DEFAULT_EXTRACTION_PATTERNS so the full
+# production extraction pipeline is covered, not just the helper function.
+# ---------------------------------------------------------------------------
+
+
+def _build_firmware_zip(zip_path: Path, members: dict[str, bytes]) -> None:
+    """Write a zip archive whose member names map to the given contents."""
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in members.items():
+            zf.writestr(name, content)
+
+
+@pytest.mark.integration
+@pytest.mark.core_downloads
+class TestFileOperationsExtractionWithDefaults:
+    """Drive the real extraction pipeline with DEFAULT_EXTRACTION_PATTERNS."""
+
+    # Archive contents: two files the defaults must extract, plus three
+    # negative controls the defaults must leave behind.
+    ARCHIVE_MEMBERS: dict[str, bytes] = {
+        "mt-esp32s3-ota.bin": b"esp32s3 ota payload",
+        "Meshtastic_nRF52_factory_erase_v3_S140_6.1.0.uf2": b"nrf52 factory erase",
+        "readme.txt": b"should not be extracted",
+        "firmware-heltec-v3-2.7.6.uf2": b"heltec image, not in defaults",
+        "Meshtastic_nRF52_tft_feather_sense_update_v3_S140_6.1.0.uf2": b"update image",
+    }
+
+    EXPECTED_EXTRACTED = {
+        "mt-esp32s3-ota.bin",
+        "Meshtastic_nRF52_factory_erase_v3_S140_6.1.0.uf2",
+    }
+
+    def test_extract_archive_pulls_only_default_matched_files(self, tmp_path):
+        zip_path = tmp_path / "firmware.zip"
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        _build_firmware_zip(zip_path, self.ARCHIVE_MEMBERS)
+
+        ops = FileOperations()
+        extracted = ops.extract_archive(
+            str(zip_path),
+            str(extract_dir),
+            list(constants.DEFAULT_EXTRACTION_PATTERNS),
+            [],
+        )
+
+        extracted_names = {p.name for p in extracted}
+        assert extracted_names == self.EXPECTED_EXTRACTED
+        # Files actually exist on disk.
+        for name in self.EXPECTED_EXTRACTED:
+            assert (extract_dir / name).is_file()
+        # Negative controls were not extracted.
+        for name in self.ARCHIVE_MEMBERS:
+            if name not in self.EXPECTED_EXTRACTED:
+                assert not (
+                    extract_dir / name
+                ).exists(), f"{name!r} should not have been extracted"
+
+    def test_check_extraction_needed_true_when_matches_not_yet_extracted(
+        self, tmp_path
+    ):
+        zip_path = tmp_path / "firmware.zip"
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        _build_firmware_zip(zip_path, self.ARCHIVE_MEMBERS)
+
+        ops = FileOperations()
+        # Nothing extracted yet → extraction is required.
+        assert (
+            ops.check_extraction_needed(
+                str(zip_path),
+                str(extract_dir),
+                list(constants.DEFAULT_EXTRACTION_PATTERNS),
+                [],
+            )
+            is True
+        )
+
+    def test_check_extraction_needed_false_after_extraction(self, tmp_path):
+        zip_path = tmp_path / "firmware.zip"
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        _build_firmware_zip(zip_path, self.ARCHIVE_MEMBERS)
+
+        ops = FileOperations()
+        ops.extract_archive(
+            str(zip_path),
+            str(extract_dir),
+            list(constants.DEFAULT_EXTRACTION_PATTERNS),
+            [],
+        )
+
+        # All default-matched files now exist with matching sizes → no
+        # further extraction needed.
+        assert (
+            ops.check_extraction_needed(
+                str(zip_path),
+                str(extract_dir),
+                list(constants.DEFAULT_EXTRACTION_PATTERNS),
+                [],
+            )
+            is False
+        )

--- a/tests/test_default_extraction_patterns.py
+++ b/tests/test_default_extraction_patterns.py
@@ -91,16 +91,13 @@ class TestDefaultExtractionPatterns:
         assert matches_extract_patterns(filename, ["mt-"])
 
     @pytest.mark.parametrize(
-        [
-            "filename",
-            "should_match",
-        ],
+        ("filename", "should_match"),
         [
             ("Meshtastic_nRF52_factory_erase_v3_S140_6.1.0.uf2", True),
             ("Meshtastic_nRF52_factory_erase_v3_S140_7.3.0.uf2", True),
-            # Substring match must not over-match: an update image whose
-            # name merely contains "erase" should not be picked up.
-            ("Meshtastic_nRF52_tft_feather_sense_update_v3.uf2", False),
+            # Substring match must not over-match: a file whose name merely
+            # contains "erase" (but not "factory_erase") is not picked up.
+            ("Meshtastic_nRF52_tft_feather_sense_erase_v3.uf2", False),
         ],
     )
     def test_factory_erase_targets_recovery_files_only(self, filename, should_match):

--- a/tests/test_default_extraction_patterns.py
+++ b/tests/test_default_extraction_patterns.py
@@ -1,0 +1,108 @@
+# Tests for the default/suggested firmware extraction patterns.
+#
+# Locks in that the default pattern list shipped to users covers the
+# ESP32 OTA helper binaries (`mt-*-ota.bin`) and the nRF52 factory
+# erase / recovery UF2 files (`Meshtastic_nRF52_factory_erase_*.uf2`),
+# and that those files are actually selected by matches_extract_patterns
+# when the defaults are in use.
+
+import pytest
+
+from fetchtastic import constants
+from fetchtastic.utils import matches_extract_patterns
+
+# Files that upstream firmware releases publish and that users expect
+# the default pattern list to catch.
+DEFAULT_SHOULD_MATCH = [
+    "mt-esp32-ota.bin",
+    "mt-esp32s3-ota.bin",
+    "mt-esp32c3-ota.bin",
+    "mt-esp32c6-ota.bin",
+    "Meshtastic_nRF52_factory_erase_v3_S140_6.1.0.uf2",
+    "Meshtastic_nRF52_factory_erase_v3_S140_7.3.0.uf2",
+]
+
+# Negative controls: common release artifacts the defaults should NOT
+# silently pull in just because of the new patterns. These are chosen so
+# that no existing default pattern (rak4631-, tbeam, t1000-e-, ...) hits
+# them either.
+DEFAULT_SHOULD_NOT_MATCH = [
+    "readme.txt",
+    # A device family not present in the default list.
+    "firmware-heltec-v3-2.7.6.uf2",
+    # An nRF52 *update* image (not a factory-erase recovery file).
+    "Meshtastic_nRF52_tft_feather_sense_update_v3_S140_6.1.0.uf2",
+]
+
+
+@pytest.mark.unit
+@pytest.mark.configuration
+class TestDefaultExtractionPatterns:
+    """The default/suggested extraction pattern list."""
+
+    def test_includes_mt_prefix(self):
+        # `mt-` covers ESP32, ESP32-S3, ESP32-C3, and ESP32-C6 OTA helpers
+        # (`mt-esp32-ota.bin`, `mt-esp32s3-ota.bin`, ...). The narrower
+        # `mt-esp32-ota` would miss S3/C3/C6.
+        assert "mt-" in constants.DEFAULT_EXTRACTION_PATTERNS
+
+    def test_includes_factory_erase(self):
+        # nRF52 recovery / factory erase UF2 files.
+        assert "factory_erase" in constants.DEFAULT_EXTRACTION_PATTERNS
+
+    def test_existing_patterns_preserved(self):
+        # Adding new patterns must not drop the existing suggestions.
+        for expected in (
+            "rak4631-",
+            "tbeam",
+            "t1000-e-",
+            "tlora-v2-1-1_6-",
+            "device-",
+            "littlefs-",
+            "bleota",
+        ):
+            assert (
+                expected in constants.DEFAULT_EXTRACTION_PATTERNS
+            ), f"existing pattern {expected!r} was removed"
+
+    @pytest.mark.parametrize("filename", DEFAULT_SHOULD_MATCH)
+    def test_default_patterns_match_expected_files(self, filename):
+        assert matches_extract_patterns(
+            filename, constants.DEFAULT_EXTRACTION_PATTERNS
+        ), f"default patterns did not match {filename!r}"
+
+    @pytest.mark.parametrize("filename", DEFAULT_SHOULD_NOT_MATCH)
+    def test_default_patterns_do_not_match_controls(self, filename):
+        assert not matches_extract_patterns(
+            filename, constants.DEFAULT_EXTRACTION_PATTERNS
+        ), f"default patterns should not match {filename!r}"
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "mt-esp32-ota.bin",
+            "mt-esp32s3-ota.bin",
+            "mt-esp32c3-ota.bin",
+            "mt-esp32c6-ota.bin",
+        ],
+    )
+    def test_mt_prefix_alone_matches_all_esp32_ota_variants(self, filename):
+        # Single `mt-` pattern is sufficient for every ESP32 variant.
+        assert matches_extract_patterns(filename, ["mt-"])
+
+    @pytest.mark.parametrize(
+        [
+            "filename",
+            "should_match",
+        ],
+        [
+            ("Meshtastic_nRF52_factory_erase_v3_S140_6.1.0.uf2", True),
+            ("Meshtastic_nRF52_factory_erase_v3_S140_7.3.0.uf2", True),
+            # Substring match must not over-match: an update image whose
+            # name merely contains "erase" should not be picked up.
+            ("Meshtastic_nRF52_tft_feather_sense_update_v3.uf2", False),
+        ],
+    )
+    def test_factory_erase_targets_recovery_files_only(self, filename, should_match):
+        result = matches_extract_patterns(filename, ["factory_erase"])
+        assert result is should_match


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This pull request expands Fetchtastic’s suggested firmware extraction patterns to cover newer Meshtastic firmware artifacts.

Recent firmware builds require ESP32-family OTA helper binaries during flashing. These files are named by MCU family, such as `mt-esp32-ota.bin`, `mt-esp32s3-ota.bin`, `mt-esp32c3-ota.bin`, and `mt-esp32c6-ota.bin`. Before this change, Fetchtastic’s suggested extraction patterns did not include a broad pattern for those helper files, so users could download firmware archives without automatically extracting files now needed by the upstream flashing scripts.

This change adds the broader `mt-` pattern rather than a single `mt-esp32-ota` pattern, so the suggested pattern list covers the ESP32, ESP32-S3, ESP32-C3, and ESP32-C6 OTA helper binaries.

This also adds a suggested `factory_erase` pattern for nRF52 factory erase / recovery UF2 files. These are not normal firmware update images, but they are useful recovery artifacts and are common enough to document as an optional extraction target.

## Key Changes

* Added `mt-` to the default/suggested firmware extraction patterns.
* Added `factory_erase` to the default/suggested firmware extraction patterns.
* Preserved all existing suggested extraction patterns.
* Documented `mt-` as the broad ESP32-family OTA helper binary pattern.
* Documented `factory_erase` as an nRF52 factory erase / recovery UF2 pattern.
* Avoided adding board-specific OTA helper patterns that would miss ESP32 variants.
* Avoided adding broad erase/update patterns that could over-select unrelated firmware files.

## Testing

* Added coverage proving `mt-` is included in the suggested extraction pattern list.
* Added coverage proving `factory_erase` is included in the suggested extraction pattern list.
* Added coverage proving existing suggested patterns are preserved.
* Added coverage for ESP32 OTA helper files:

  * `mt-esp32-ota.bin`
  * `mt-esp32s3-ota.bin`
  * `mt-esp32c3-ota.bin`
  * `mt-esp32c6-ota.bin`
* Added coverage for nRF52 factory erase / recovery UF2 files:

  * `Meshtastic_nRF52_factory_erase_v3_S140_6.1.0.uf2`
  * `Meshtastic_nRF52_factory_erase_v3_S140_7.3.0.uf2`
* Added negative coverage proving unrelated files and normal nRF52 update UF2 files are not selected by the new patterns.
* Verified the targeted pattern, firmware extraction, repository downloader, and constants test subset passes in review.

## Migration Notes

* No user data migration is required.
* Existing configurations are unchanged.
* Existing user-defined extraction patterns are preserved.
* Users who want the newer ESP32-family OTA helper binaries should add `mt-` to their extraction patterns.
* Users who want nRF52 factory erase / recovery UF2 files should add `factory_erase` to their extraction patterns.
* The new patterns only affect suggested/default pattern guidance and do not force existing installations to extract additional files automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->