### PR TITLE
fix: skip extraction for archives with no matching members

### DIFF
--- a/src/fetchtastic/download/files.py
+++ b/src/fetchtastic/download/files.py
@@ -738,7 +738,13 @@ class FileOperations:
         """
         Determine whether the ZIP archive requires extraction by comparing candidate members against existing files in extract_dir.
 
-        This checks archive members that match the given filename patterns (applied to the base filename) and are not excluded, verifies each candidate would be safely extracted, and compares existing extracted file sizes to the archive entry sizes. If all matching candidates already exist with matching sizes, extraction is not needed.
+        Selection rules:
+        - Missing ZIP path -> extraction not needed.
+        - No extraction patterns -> extraction not needed.
+        - No safe, non-excluded archive members match the patterns -> extraction not needed (this is the normal no-op case, not a warning).
+        - One or more matching members, all already extracted with matching sizes -> extraction not needed.
+        - One or more matching members, at least one missing or size-stale -> extraction needed.
+        - Bad or unreadable ZIP -> returns True to preserve defensive behavior (assume extraction is needed, surface the error).
 
         Parameters:
             zip_path (str): Path to the ZIP archive.
@@ -747,7 +753,7 @@ class FileOperations:
             exclude_patterns (list[str]): Filename patterns to exclude (matched against the base filename).
 
         Returns:
-            bool: `True` if extraction should be performed, `False` if extraction can be skipped. If the ZIP file is missing, returns `False`. On any error while checking, returns `True` (assumes extraction is needed).
+            bool: `True` if extraction should be performed, `False` if extraction can be skipped.
         """
         try:
             # If the ZIP file doesn't exist, extraction is not needed
@@ -789,9 +795,19 @@ class FileOperations:
                             if os.path.getsize(extract_path) == file_info.file_size:
                                 files_existing += 1
 
+                # No archive members matched the extraction patterns: this is
+                # an expected no-op (e.g. an rp2040/stm32 zip when the user's
+                # patterns only target other boards). Skip extraction quietly.
+                if files_to_extract == 0:
+                    logger.debug(
+                        "No archive members matched extraction patterns in"
+                        f" {os.path.basename(zip_path)} - skipping extraction"
+                    )
+                    return False
+
                 # If all files that would be extracted already exist with correct sizes,
                 # extraction is not needed
-                if files_to_extract > 0 and files_existing == files_to_extract:
+                if files_existing == files_to_extract:
                     logger.debug(
                         f"All {files_to_extract} files already extracted - skipping extraction"
                     )

--- a/src/fetchtastic/download/files.py
+++ b/src/fetchtastic/download/files.py
@@ -796,11 +796,12 @@ class FileOperations:
                                 files_existing += 1
 
                 # No archive members matched the extraction patterns: this is
-                # an expected no-op (e.g. an rp2040/stm32 zip when the user's
-                # patterns only target other boards). Skip extraction quietly.
+                # an expected no-op (e.g. an rp2040/rp2350/stm32 zip when the
+                # user's patterns only target other boards). Skip extraction
+                # quietly.
                 if files_to_extract == 0:
                     logger.debug(
-                        "No archive members matched extraction patterns in"
+                        f"No archive members matched extraction patterns in"
                         f" {os.path.basename(zip_path)} - skipping extraction"
                     )
                     return False

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1183,7 +1183,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
             exclude_patterns (List[str]): Glob patterns of files to exclude.
 
         Returns:
-            bool: `True` if extraction is needed (files are missing, outdated, or do not match the patterns), `False` otherwise.
+            bool: `True` if extraction is needed (matching members are missing or size-stale, or the archive could not be inspected). `False` if extraction can be skipped, including when the archive has no members matching the patterns (the normal no-op case).
         """
         return self.file_operations.check_extraction_needed(
             file_path, extract_dir, patterns, exclude_patterns

--- a/src/fetchtastic/download/latest_pointer.py
+++ b/src/fetchtastic/download/latest_pointer.py
@@ -71,6 +71,25 @@ def update_latest_pointer(
                 "Skipping latest pointer because path is not a symlink: %s", link_path
             )
             return False
+        # Idempotent fast-path: if the existing symlink already points at
+        # the desired target, do nothing. Avoids replace + "Updated" log
+        # noise on every run when the pointer is already current.
+        if link_path.is_symlink():
+            try:
+                if os.readlink(link_path) == target_name:
+                    logger.debug(
+                        "Latest pointer already current: %s -> %s",
+                        link_path,
+                        target_name,
+                    )
+                    return True
+            except OSError as exc:
+                # Could not read the existing link; fall through to replacement.
+                logger.debug(
+                    "Could not read existing latest pointer %s: %s; recreating",
+                    link_path,
+                    exc,
+                )
         os.symlink(
             target_name,
             tmp_path,

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -521,7 +521,7 @@ class DownloadOrchestrator:
                 and app_releases
                 and not prereleases
             ):
-                logger.info("No client app prereleases available")
+                logger.info("No new client app prereleases to download")
 
             if not any_app_downloaded and not releases_to_download:
                 logger.info("All client app assets are up to date.")
@@ -1756,10 +1756,10 @@ class DownloadOrchestrator:
         ]
         total_failures = len(self.failed_downloads)
 
-        logger.info("Download pipeline completed")
-        logger.info(f"Time taken: {elapsed_time:.2f} seconds")
+        logger.debug("Download pipeline completed")
+        logger.debug(f"Time taken: {elapsed_time:.2f} seconds")
         if not downloaded and total_failures == 0:
-            logger.info("All assets are up to date.")
+            logger.debug("All assets are up to date.")
         else:
             # Group results by product category
             client_app_downloads = [

--- a/tests/test_download_orchestrator.py
+++ b/tests/test_download_orchestrator.py
@@ -754,23 +754,29 @@ class TestDownloadOrchestrator:
 
     @patch("fetchtastic.download.orchestrator.logger")
     def test_log_download_summary(self, mock_logger, orchestrator):
-        """Test download summary logging."""
-        start_time = 1000.0
+        """Test download summary logging.
 
-        # Mock statistics
-        orchestrator.get_download_statistics = Mock(
-            return_value={
-                "total_downloads": 5,
-                "successful_downloads": 4,
-                "failed_downloads": 1,
-                "success_rate": 80.0,
-            }
-        )
+        With empty results the pipeline-completion lines ("Download pipeline
+        completed", "Time taken", "All assets are up to date.") are emitted
+        at DEBUG, not INFO, because the human-facing final summary is owned
+        by DownloadCLIIntegration. The DEBUG lines must still be emitted so
+        library users of the orchestrator can see them at DEBUG level.
+        """
+        start_time = 1000.0
 
         orchestrator._log_download_summary(start_time)
 
-        # Should log summary information
-        mock_logger.info.assert_called()
+        # The completion lines are emitted at DEBUG (dedup with CLI summary).
+        mock_logger.debug.assert_called()
+        # No INFO duplicate of the up-to-date line should fire from the
+        # orchestrator now that the CLI integration owns that message.
+        info_messages = [
+            call.args[0] if call.args else ""
+            for call in mock_logger.info.call_args_list
+        ]
+        assert not any(
+            "All assets are up to date" in msg for msg in info_messages
+        ), info_messages
 
     def test_enhance_download_results_with_metadata(self, orchestrator):
         """Test enhancing results with metadata."""
@@ -3323,8 +3329,17 @@ class TestDownloadOrchestrator:
             "v1.0.1-beta"
         )
 
-    def test_process_client_app_downloads_no_prereleases_log(self, orchestrator):
-        """Test client app processing logs 'No client app prereleases available'."""
+    def test_process_client_app_downloads_no_prereleases_log(
+        self, orchestrator, caplog
+    ):
+        """Test client app processing logs the no-new-prereleases wording.
+
+        The pipeline message must reflect that no *new* prerelease downloads
+        are needed (not that no prereleases exist at all), since the final
+        summary may still report the latest known prerelease tag.
+        """
+        import logging
+
         orchestrator.config["CHECK_APP_PRERELEASES"] = True
         mock_asset = Mock()
         mock_asset.name = "app.apk"
@@ -3339,9 +3354,16 @@ class TestDownloadOrchestrator:
         orchestrator.client_app_downloader.should_download_asset.return_value = True
         orchestrator.client_app_downloader.get_assets.return_value = [mock_asset]
 
-        orchestrator._process_client_app_downloads()
+        with caplog.at_level(logging.INFO, logger="fetchtastic"):
+            orchestrator._process_client_app_downloads()
 
         orchestrator.client_app_downloader.handle_prereleases.assert_called_once()
+        # Lock the new wording. The old "No client app prereleases available"
+        # phrasing contradicted the final summary's "Latest ... prerelease" line.
+        assert any(
+            "No new client app prereleases to download" in r.getMessage()
+            for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
 
     @patch.object(
         DownloadOrchestrator, "_download_client_app_release", return_value=False

--- a/tests/test_download_orchestrator.py
+++ b/tests/test_download_orchestrator.py
@@ -783,12 +783,19 @@ class TestDownloadOrchestrator:
             "All assets are up to date" in msg for msg in debug_messages
         ), debug_messages
 
-        # No INFO duplicate of the up-to-date line should fire from the
-        # orchestrator now that the CLI integration owns that message.
+        # No INFO duplicate of the demoted completion lines should fire
+        # from the orchestrator now that the CLI integration owns the
+        # human-facing summary. All three lines were demoted together;
+        # a regression that re-introduces any one of them at INFO must
+        # fail this test.
         info_messages = [
             call.args[0] if call.args else ""
             for call in mock_logger.info.call_args_list
         ]
+        assert not any(
+            "Download pipeline completed" in msg for msg in info_messages
+        ), info_messages
+        assert not any("Time taken" in msg for msg in info_messages), info_messages
         assert not any(
             "All assets are up to date" in msg for msg in info_messages
         ), info_messages

--- a/tests/test_download_orchestrator.py
+++ b/tests/test_download_orchestrator.py
@@ -753,7 +753,9 @@ class TestDownloadOrchestrator:
         )
 
     @patch("fetchtastic.download.orchestrator.logger")
-    def test_log_download_summary(self, mock_logger, orchestrator):
+    def test_log_download_summary_demotes_completion_lines_to_debug(
+        self, mock_logger, orchestrator
+    ):
         """Test download summary logging.
 
         With empty results the pipeline-completion lines ("Download pipeline
@@ -766,8 +768,21 @@ class TestDownloadOrchestrator:
 
         orchestrator._log_download_summary(start_time)
 
-        # The completion lines are emitted at DEBUG (dedup with CLI summary).
-        mock_logger.debug.assert_called()
+        # Lock the three specific demoted messages, not just "some DEBUG fired".
+        # logger.debug is called with pre-formatted f-strings, so args[0] holds
+        # the final message text.
+        debug_messages = [
+            call.args[0] if call.args else ""
+            for call in mock_logger.debug.call_args_list
+        ]
+        assert any(
+            "Download pipeline completed" in msg for msg in debug_messages
+        ), debug_messages
+        assert any("Time taken" in msg for msg in debug_messages), debug_messages
+        assert any(
+            "All assets are up to date" in msg for msg in debug_messages
+        ), debug_messages
+
         # No INFO duplicate of the up-to-date line should fire from the
         # orchestrator now that the CLI integration owns that message.
         info_messages = [
@@ -3329,17 +3344,13 @@ class TestDownloadOrchestrator:
             "v1.0.1-beta"
         )
 
-    def test_process_client_app_downloads_no_prereleases_log(
-        self, orchestrator, caplog
-    ):
+    def test_process_client_app_downloads_no_new_prereleases_log(self, orchestrator):
         """Test client app processing logs the no-new-prereleases wording.
 
         The pipeline message must reflect that no *new* prerelease downloads
         are needed (not that no prereleases exist at all), since the final
         summary may still report the latest known prerelease tag.
         """
-        import logging
-
         orchestrator.config["CHECK_APP_PRERELEASES"] = True
         mock_asset = Mock()
         mock_asset.name = "app.apk"
@@ -3354,16 +3365,24 @@ class TestDownloadOrchestrator:
         orchestrator.client_app_downloader.should_download_asset.return_value = True
         orchestrator.client_app_downloader.get_assets.return_value = [mock_asset]
 
-        with caplog.at_level(logging.INFO, logger="fetchtastic"):
+        with patch("fetchtastic.download.orchestrator.logger") as mock_logger:
             orchestrator._process_client_app_downloads()
 
         orchestrator.client_app_downloader.handle_prereleases.assert_called_once()
-        # Lock the new wording. The old "No client app prereleases available"
-        # phrasing contradicted the final summary's "Latest ... prerelease" line.
+
+        info_messages = [
+            call.args[0] if call.args else ""
+            for call in mock_logger.info.call_args_list
+        ]
+        # Lock the new wording.
         assert any(
-            "No new client app prereleases to download" in r.getMessage()
-            for r in caplog.records
-        ), [r.getMessage() for r in caplog.records]
+            "No new client app prereleases to download" in msg for msg in info_messages
+        ), info_messages
+        # And confirm the old contradictory wording is gone — a regression
+        # that reintroduces it alongside the new line would otherwise pass.
+        assert not any(
+            "No client app prereleases available" in msg for msg in info_messages
+        ), info_messages
 
     @patch.object(
         DownloadOrchestrator, "_download_client_app_release", return_value=False

--- a/tests/test_files_operations.py
+++ b/tests/test_files_operations.py
@@ -11,6 +11,7 @@ Comprehensive tests for the files.py module covering:
 """
 
 import hashlib
+import logging
 import os
 import zipfile
 from pathlib import Path
@@ -499,6 +500,126 @@ class TestFileOperations:
             str(zip_path), str(tmp_path / "extract"), [], []
         )
         assert result is False
+
+    def test_check_extraction_needed_zero_matching_members(self, tmp_path):
+        """Archive whose members do not match extraction patterns is a no-op.
+
+        This is the regression test for the bug that caused rp2040/rp2350/stm32
+        zips to be queued for extraction and then warn "no files extracted".
+        Zero matching members must mean extraction is not needed.
+        """
+        file_ops = FileOperations()
+        zip_path = tmp_path / "firmware.zip"
+        extract_dir = tmp_path / "extract"
+
+        # Archive members that no realistic default pattern matches.
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("firmware-heltec-v3-2.7.6.uf2", b"heltec")
+            zf.writestr(
+                "Meshtastic_nRF52_tft_feather_sense_update_v3_S140_6.1.0.uf2",
+                b"update",
+            )
+            zf.writestr("readme.txt", b"docs")
+
+        result = file_ops.check_extraction_needed(
+            str(zip_path), str(extract_dir), ["rak4631-"], []
+        )
+
+        assert result is False
+
+    def test_check_extraction_needed_zero_match_emits_debug_not_warning(
+        self, tmp_path, caplog
+    ):
+        """Zero-match skip must be a DEBUG message, never a WARNING.
+
+        Warnings are reserved for actionable anomalies; "this archive has no
+        selected members" is an expected no-op.
+        """
+        file_ops = FileOperations()
+        zip_path = tmp_path / "firmware.zip"
+        extract_dir = tmp_path / "extract"
+
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("firmware-heltec-v3-2.7.6.uf2", b"heltec")
+
+        with caplog.at_level(logging.DEBUG, logger="fetchtastic"):
+            result = file_ops.check_extraction_needed(
+                str(zip_path), str(extract_dir), ["rak4631-"], []
+            )
+
+        assert result is False
+        messages = [(r.levelname, r.getMessage()) for r in caplog.records]
+        assert "WARNING" not in [
+            level for level, _ in messages
+        ], f"unexpected WARNING records: {messages}"
+        # Sanity: the DEBUG skip line is present.
+        assert any(
+            level == "DEBUG" and "matched extraction patterns" in msg
+            for level, msg in messages
+        ), f"expected DEBUG skip message, got: {messages}"
+
+    def test_check_extraction_needed_matching_member_missing(self, tmp_path):
+        """Matching member that has not been extracted yet -> extraction needed."""
+        file_ops = FileOperations()
+        zip_path = tmp_path / "firmware.zip"
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("firmware-rak4631-2.7.6.uf2", b"rak")
+
+        result = file_ops.check_extraction_needed(
+            str(zip_path), str(extract_dir), ["rak4631-"], []
+        )
+        assert result is True
+
+    def test_check_extraction_needed_matching_member_already_extracted(self, tmp_path):
+        """All matching members present with matching sizes -> not needed."""
+        file_ops = FileOperations()
+        zip_path = tmp_path / "firmware.zip"
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        payload = b"rak payload bytes"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("firmware-rak4631-2.7.6.uf2", payload)
+
+        # Pre-place the extracted file at the exact size.
+        (extract_dir / "firmware-rak4631-2.7.6.uf2").write_bytes(payload)
+
+        result = file_ops.check_extraction_needed(
+            str(zip_path), str(extract_dir), ["rak4631-"], []
+        )
+        assert result is False
+
+    def test_check_extraction_needed_matching_member_excluded(self, tmp_path):
+        """Matching member that an exclude pattern removes -> zero candidates -> not needed."""
+        file_ops = FileOperations()
+        zip_path = tmp_path / "firmware.zip"
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("firmware-rak4631-2.7.6.uf2", b"rak")
+
+        # Pattern matches, but exclude pattern removes the only candidate.
+        # (_matches_exclude is glob-based, so a wildcard is required.)
+        result = file_ops.check_extraction_needed(
+            str(zip_path), str(extract_dir), ["rak4631-"], ["*rak4631*"]
+        )
+        assert result is False
+
+    def test_check_extraction_needed_bad_zip_preserves_defensive_true(self, tmp_path):
+        """Unreadable ZIP must keep returning True so extraction is attempted/error-visible."""
+        file_ops = FileOperations()
+        zip_path = tmp_path / "broken.zip"
+        # Not a real zip: ZipFile will raise BadZipFile on open.
+        zip_path.write_bytes(b"definitely not a zip")
+
+        result = file_ops.check_extraction_needed(
+            str(zip_path), str(tmp_path / "extract"), ["rak4631-"], []
+        )
+        assert result is True
 
     def test_extract_with_validation_success(self, tmp_path):
         """Test successful extraction with validation."""

--- a/tests/test_files_operations.py
+++ b/tests/test_files_operations.py
@@ -11,10 +11,10 @@ Comprehensive tests for the files.py module covering:
 """
 
 import hashlib
-import logging
 import os
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 import platformdirs
 import pytest
@@ -527,9 +527,7 @@ class TestFileOperations:
 
         assert result is False
 
-    def test_check_extraction_needed_zero_match_emits_debug_not_warning(
-        self, tmp_path, caplog
-    ):
+    def test_check_extraction_needed_zero_match_emits_debug_not_warning(self, tmp_path):
         """Zero-match skip must be a DEBUG message, never a WARNING.
 
         Warnings are reserved for actionable anomalies; "this archive has no
@@ -542,21 +540,22 @@ class TestFileOperations:
         with zipfile.ZipFile(zip_path, "w") as zf:
             zf.writestr("firmware-heltec-v3-2.7.6.uf2", b"heltec")
 
-        with caplog.at_level(logging.DEBUG, logger="fetchtastic"):
+        with patch("fetchtastic.download.files.logger") as mock_logger:
             result = file_ops.check_extraction_needed(
                 str(zip_path), str(extract_dir), ["rak4631-"], []
             )
 
         assert result is False
-        messages = [(r.levelname, r.getMessage()) for r in caplog.records]
-        assert "WARNING" not in [
-            level for level, _ in messages
-        ], f"unexpected WARNING records: {messages}"
-        # Sanity: the DEBUG skip line is present.
+        # The DEBUG skip line is present.
+        debug_messages = [
+            call.args[0] if call.args else ""
+            for call in mock_logger.debug.call_args_list
+        ]
         assert any(
-            level == "DEBUG" and "matched extraction patterns" in msg
-            for level, msg in messages
-        ), f"expected DEBUG skip message, got: {messages}"
+            "matched extraction patterns" in msg for msg in debug_messages
+        ), debug_messages
+        # No warning was emitted.
+        mock_logger.warning.assert_not_called()
 
     def test_check_extraction_needed_matching_member_missing(self, tmp_path):
         """Matching member that has not been extracted yet -> extraction needed."""

--- a/tests/test_firmware_get_zips_extraction.py
+++ b/tests/test_firmware_get_zips_extraction.py
@@ -352,3 +352,50 @@ class TestGetZipsNeedingExtraction:
         assert result[1] is asset2
         # matches_selected_patterns must never be called (short-circuited)
         mock_matches.assert_not_called()
+
+    # --- Regression: zero-match zips must NOT be queued for extraction ---
+    #
+    # Reproduces the user-visible noise from a real download run where
+    # rp2040/rp2350/stm32 archives were repeatedly queued, re-extracted,
+    # and then warned "no files extracted ... no matches for patterns".
+    # The fix lives in FileOperations.check_extraction_needed(); this test
+    # drives it through the public FirmwareReleaseDownloader queue builder
+    # so the whole "decide what to extract" path is covered.
+
+    def test_zero_match_zip_not_queued_for_extraction(self, downloader):
+        """A firmware zip whose contents do not match EXTRACT_PATTERNS
+        must not appear in the extraction queue."""
+        import zipfile
+
+        from fetchtastic.download.files import FileOperations
+
+        # Use the REAL FileOperations so the zero-match fix is exercised.
+        downloader.file_operations = FileOperations()
+        downloader._get_exclude_patterns = Mock(return_value=[])
+
+        # EXTRACT_PATTERNS targets a family the archive does not contain.
+        downloader.config["EXTRACT_PATTERNS"] = ["rak4631-"]
+
+        # Build a real zip on disk in the version dir, containing members
+        # that no realistic pattern in EXTRACT_PATTERNS will match.
+        version_dir = _setup_version_dir(downloader, "v2.3.2")
+        zip_path = os.path.join(version_dir, "firmware-rp2040-2.3.2.zip")
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("firmware-heltec-v3-2.3.2.uf2", b"heltec")
+            zf.writestr(
+                "Meshtastic_nRF52_tft_feather_sense_update_v3_S140_6.1.0.uf2",
+                b"update",
+            )
+            zf.writestr("readme.txt", b"docs")
+
+        asset = Asset(
+            name="firmware-rp2040-2.3.2.zip",
+            download_url="https://example.com/rp2040.zip",
+            size=100,
+        )
+        release = _make_release(assets=[asset])
+
+        result = downloader.get_zips_needing_extraction(release)
+
+        # The zero-match zip must NOT be queued.
+        assert result == [], "zero-match zip should not be queued for extraction"

--- a/tests/test_latest_pointer.py
+++ b/tests/test_latest_pointer.py
@@ -155,6 +155,67 @@ def test_update_latest_pointer_does_not_replace_regular_file(tmp_path):
     assert latest.read_text(encoding="utf-8") == "user content"
 
 
+def test_update_latest_pointer_already_current_is_noop(tmp_path, symlinks_supported):
+    """When `latest` already points at the desired target, the call must not
+    replace the symlink and must not log "Updated latest pointer".
+
+    This is the same class of no-op cleanup as zero-match extraction: the
+    operation is currently idempotent in result but noisy in operation,
+    logging "Updated" on every run.
+    """
+    if not symlinks_supported:
+        pytest.skip("os.symlink not supported on this platform")
+    target = tmp_path / "v2.7.0"
+    target.mkdir()
+    latest = tmp_path / LATEST_POINTER_NAME
+    latest.symlink_to("v2.7.0")
+
+    with (
+        patch("fetchtastic.download.latest_pointer.logger") as mock_logger,
+        patch("fetchtastic.download.latest_pointer.os.replace") as mock_replace,
+        patch("fetchtastic.download.latest_pointer.os.symlink") as mock_symlink,
+    ):
+        result = update_latest_pointer(tmp_path, target.name)
+
+    assert result is True
+    # Symlink is unchanged.
+    assert os.readlink(latest) == "v2.7.0"
+    # No filesystem mutation happened.
+    mock_replace.assert_not_called()
+    mock_symlink.assert_not_called()
+    # The "already current" debug line fired.
+    debug_messages = [
+        call.args[0] if call.args else "" for call in mock_logger.debug.call_args_list
+    ]
+    assert any(
+        "Latest pointer already current" in msg for msg in debug_messages
+    ), debug_messages
+    # And the misleading "Updated latest pointer" line did NOT.
+    assert not any(
+        "Updated latest pointer" in msg for msg in debug_messages
+    ), debug_messages
+
+
+def test_update_latest_pointer_replaces_when_target_differs(
+    tmp_path, symlinks_supported
+):
+    """If the existing symlink points at a different target, the call must
+    still replace it (the no-op fast-path only matches identical targets)."""
+    if not symlinks_supported:
+        pytest.skip("os.symlink not supported on this platform")
+    new_target = tmp_path / "v2.7.0"
+    old_target = tmp_path / "v2.6.0"
+    new_target.mkdir()
+    old_target.mkdir()
+    latest = tmp_path / LATEST_POINTER_NAME
+    latest.symlink_to("v2.6.0")
+
+    result = update_latest_pointer(tmp_path, new_target.name)
+
+    assert result is True
+    assert os.readlink(latest) == "v2.7.0"
+
+
 def test_remove_latest_pointer_removes_managed_symlink_and_leaves_target(
     tmp_path, symlinks_supported
 ):


### PR DESCRIPTION
## Overview

This pull request cleans up noisy no-op download logging without changing Fetchtastic’s download behavior.

A recent successful `fetchtastic download` run showed repeated firmware extraction noise for archives that did not contain any files matching the configured extraction patterns. Those archives were reported as needing extraction, then re-extracted, then logged warnings because no files matched. The assets were already handled correctly, but the pipeline was doing avoidable work and producing warning-level output for an expected no-op case.

Before this change, `FileOperations.check_extraction_needed()` treated an archive with zero matching members as needing extraction. That allowed nonmatching firmware ZIPs to enter the extraction queue, which produced repeated “re-extracting” messages and “no files extracted” warnings.

The same run also showed `latest` pointers being logged as updated even when they already pointed at the latest firmware or app release. Those symlink updates were idempotent in result, but noisy in operation.

This change makes those no-op cases explicit. Archives with no selected members are skipped at DEBUG level and are not queued for extraction. Already-current `latest` symlinks are left untouched and logged as already current. The branch also cleans up a confusing client app prerelease no-op message and demotes duplicate orchestrator completion summary lines so the final CLI summary remains the human-facing INFO output.

## Key Changes

* Treated ZIP archives with zero matching extraction members as extraction-not-needed.
* Added DEBUG logging for zero-match extraction skips.
* Prevented zero-match firmware ZIPs from entering the extraction queue.
* Preserved defensive behavior for bad or unreadable ZIP files.
* Preserved extraction behavior for missing or stale matching files.
* Updated extraction-needed docstrings to describe zero-match behavior.
* Reworded the client app prerelease no-op message to avoid contradicting the final summary.
* Demoted duplicate orchestrator completion summary lines from INFO to DEBUG.
* Kept the CLI integration summary as the user-facing final summary.
* Avoided replacing `latest` symlinks when they already point at the requested target.
* Logged already-current latest pointers as DEBUG no-ops.
* Kept structured counters and a redesigned INFO summary out of scope for a future branch.

## Testing

* Added coverage proving zero-match ZIP archives return extraction-not-needed.
* Added coverage proving zero-match ZIP archives emit DEBUG logging without WARNING-level noise.
* Added coverage proving missing matching files still require extraction.
* Added coverage proving already-extracted matching files do not require extraction.
* Added coverage proving excluded matching files do not require extraction.
* Added coverage preserving missing-ZIP behavior.
* Added coverage preserving bad-ZIP defensive behavior.
* Added coverage proving zero-match firmware ZIPs do not enter the extraction queue.
* Added coverage for the updated client app prerelease no-op wording.
* Added coverage proving the old contradictory client app prerelease wording is not emitted.
* Added coverage proving duplicate orchestrator completion summary lines are DEBUG-only.
* Added coverage proving already-current `latest` symlinks are not replaced.
* Added coverage proving stale `latest` symlinks are still replaced.
* Verified the targeted latest pointer, file operation, orchestrator, firmware extraction, default extraction pattern, logging, and notification test subset passes.

## Migration Notes

* No user data migration is required.
* Existing download directories, release history, prerelease history, hashes, and caches are unchanged.
* Existing extraction patterns are unchanged.
* Existing download, cache, retention, notification, and pattern semantics are unchanged.
* Existing `latest` symlinks remain valid.
* This only avoids unnecessary extraction attempts, warning-level log noise, duplicate INFO summary lines, and redundant latest-pointer rewrites for already-current symlinks.
