### PR TITLE
Restore client-app prerelease selection and latest pointer safety

### DIFF
--- a/src/fetchtastic/download/client_app.py
+++ b/src/fetchtastic/download/client_app.py
@@ -74,7 +74,7 @@ from .github_source import (
     create_release_from_github_data,
 )
 from .interfaces import Asset, DownloadResult, Release
-from .latest_pointer import update_latest_pointer
+from .latest_pointer import remove_latest_pointer, update_latest_pointer
 from .prerelease_history import PrereleaseHistoryManager
 from .release_history import ReleaseHistoryManager
 from .version import VersionManager
@@ -1156,6 +1156,9 @@ class MeshtasticClientAppDownloader(BaseDownloader):
         prerelease_dir = os.path.join(app_dir, APK_PRERELEASES_DIR_NAME)
         if self._is_safe_managed_dir(prerelease_dir):
             self._remove_unexpected_entries(prerelease_dir, expected_prerelease)
+        self._validate_latest_pointer(app_dir, expected_stable)
+        if self._is_safe_managed_dir(prerelease_dir):
+            self._validate_latest_pointer(prerelease_dir, expected_prerelease)
 
     def _remove_unexpected_entries(self, base_dir: str, allowed: set[str]) -> None:
         try:
@@ -1190,6 +1193,38 @@ class MeshtasticClientAppDownloader(BaseDownloader):
             logger.info("Removing stale client app version dir: %s", entry.name)
             _safe_rmtree(entry.path, base_dir, entry.name)
 
+    def _validate_latest_pointer(
+        self, parent_dir: str, retained_names: set[str]
+    ) -> None:
+        """Validate a managed latest symlink after cleanup removals.
+
+        Removes the latest pointer via ``remove_latest_pointer`` when its target
+        is missing, unsafe (absolute/traversal/nested), itself a symlink, or not
+        in the retained set. Never removes a non-symlink latest entry. Does not
+        follow symlinks. Parent/ancestor symlink protections are delegated to
+        ``remove_latest_pointer``.
+        """
+        link_path = os.path.join(parent_dir, LATEST_POINTER_NAME)
+        if not os.path.islink(link_path):
+            return
+        try:
+            target = os.readlink(link_path)
+        except OSError:
+            return
+        safe_target = _sanitize_path_component(target)
+        if safe_target is None or safe_target != target:
+            remove_latest_pointer(parent_dir)
+            return
+        if safe_target not in retained_names:
+            remove_latest_pointer(parent_dir)
+            return
+        target_path = os.path.join(parent_dir, safe_target)
+        try:
+            if os.path.islink(target_path) or not os.path.exists(target_path):
+                remove_latest_pointer(parent_dir)
+        except OSError:
+            remove_latest_pointer(parent_dir)
+
     def get_latest_release_tag(self) -> str | None:
         if os.path.exists(self.latest_release_path):
             try:
@@ -1215,6 +1250,81 @@ class MeshtasticClientAppDownloader(BaseDownloader):
             },
         )
 
+    def _latest_stable_release_tuple(
+        self, releases: list[Release]
+    ) -> tuple[int, ...] | None:
+        """Return the release tuple of the latest genuine stable release.
+
+        Selection is deterministic and independent of input order: the stable
+        release with the highest version tuple wins, with published_at and tag
+        name as tie breakers. Returns None when no stable release is present.
+        """
+        stable_releases = [r for r in releases if self._is_client_app_stable(r)]
+        if not stable_releases:
+            return None
+
+        def _key(release: Release) -> tuple[Any, ...]:
+            release_tuple = self.version_manager.get_release_tuple(release.tag_name)
+            published_dt = parse_iso_datetime_utc(release.published_at)
+            published_ts = published_dt.timestamp() if published_dt else 0
+            return (release_tuple or (0,), published_ts, release.tag_name or "")
+
+        latest = max(stable_releases, key=_key)
+        return self.version_manager.get_release_tuple(latest.tag_name)
+
+    def _select_active_prereleases(self, releases: list[Release]) -> list[Release]:
+        """Select active client-app prereleases on the single highest eligible base.
+
+        Policy:
+        - Only classified non-snapshot prereleases are considered (snapshots excluded).
+        - When a parseable stable release exists, prerelease bases whose parsed
+          base is <= the stable base are discarded.
+        - Every tag (open/closed/internal) on the single highest eligible
+          prerelease base is retained; superseded bases are dropped entirely.
+        - When no stable release has a parseable tuple, the highest parseable
+          prerelease base wins.
+        - When no candidate has a parseable base, all classified candidates are
+          preserved so unparseable prereleases are never silently dropped.
+          Unparseable candidates are never retained alongside a parseable winner
+          because they cannot be assigned to that stream.
+        - Output is deterministic: published_at descending with a tag-name
+          tiebreak, independent of input order.
+        """
+        candidates = [r for r in releases if self._is_client_app_prerelease(r)]
+
+        def _selection_sort_key(release: Release) -> tuple[Any, ...]:
+            return (release.published_at or "", release.tag_name or "")
+
+        candidates.sort(key=_selection_sort_key, reverse=True)
+        if not candidates:
+            return []
+
+        latest_stable_tuple = self._latest_stable_release_tuple(releases)
+
+        has_parseable = False
+        eligible_by_base: dict[tuple[int, ...], list[Release]] = {}
+        for candidate in candidates:
+            clean = self.version_manager.extract_clean_version(candidate.tag_name)
+            candidate_base = (
+                self.version_manager.get_release_tuple(clean) if clean else None
+            )
+            if candidate_base is None:
+                continue
+            has_parseable = True
+            if (
+                latest_stable_tuple is not None
+                and candidate_base <= latest_stable_tuple
+            ):
+                continue
+            eligible_by_base.setdefault(candidate_base, []).append(candidate)
+
+        if eligible_by_base:
+            winning_base = max(eligible_by_base)
+            return eligible_by_base[winning_base]
+        if has_parseable:
+            return []
+        return candidates
+
     def handle_prereleases(
         self,
         releases: list[Release],
@@ -1225,41 +1335,22 @@ class MeshtasticClientAppDownloader(BaseDownloader):
         )
         if not check_prereleases:
             return []
-        prereleases = [r for r in releases if self._is_client_app_prerelease(r)]
-        prereleases.sort(key=lambda r: r.published_at or "", reverse=True)
-        latest_release = next(
-            (r for r in releases if self._is_client_app_stable(r)), None
-        )
-        expected_base = (
-            self.version_manager.calculate_expected_prerelease_version(
-                latest_release.tag_name
-            )
-            if latest_release
-            else None
-        )
-        if expected_base:
-            expected_tuple = self.version_manager.get_release_tuple(expected_base)
-            filtered = []
-            for prerelease in prereleases:
-                clean = self.version_manager.extract_clean_version(prerelease.tag_name)
-                clean_tuple = self.version_manager.get_release_tuple(clean)
-                if not clean or clean_tuple is None or clean_tuple == expected_tuple:
-                    filtered.append(prerelease)
-            prereleases = filtered
-        if recent_commits and expected_base:
+        selected = self._select_active_prereleases(releases)
+        if recent_commits and selected:
             hashes = [
                 commit.get("sha", "")[:7]
                 for commit in recent_commits
                 if commit.get("sha")
             ]
-            by_commit = [
-                prerelease
-                for prerelease in prereleases
-                if any(hash_part in prerelease.tag_name for hash_part in hashes)
-            ]
-            if by_commit:
-                prereleases = by_commit
-        return prereleases
+            if hashes:
+                narrowed = [
+                    release
+                    for release in selected
+                    if any(short in release.tag_name for short in hashes)
+                ]
+                if narrowed:
+                    selected = narrowed
+        return selected
 
     def get_latest_prerelease_tag(
         self, releases: list[Release] | None = None
@@ -1267,37 +1358,8 @@ class MeshtasticClientAppDownloader(BaseDownloader):
         available = releases or self.get_releases()
         if not available:
             return None
-        sorted_releases = sorted(
-            available,
-            key=lambda release: release.published_at or "",
-            reverse=True,
-        )
-        latest_stable = next(
-            (
-                release
-                for release in sorted_releases
-                if self._is_client_app_stable(release)
-            ),
-            None,
-        )
-        latest_stable_tuple = (
-            self.version_manager.get_release_tuple(latest_stable.tag_name)
-            if latest_stable
-            else None
-        )
-        for release in sorted_releases:
-            if self._is_client_app_stable(release):
-                continue
-            if is_snapshot_tag(release.tag_name):
-                continue
-            prerelease_tuple = self.version_manager.get_release_tuple(release.tag_name)
-            if (
-                latest_stable_tuple is None
-                or prerelease_tuple is None
-                or prerelease_tuple > latest_stable_tuple
-            ):
-                return release.tag_name
-        return None
+        selected = self._select_active_prereleases(available)
+        return selected[0].tag_name if selected else None
 
     def get_prerelease_tracking_file(self) -> str:
         return self.cache_manager.get_cache_file_path(self.latest_prerelease_file)

--- a/src/fetchtastic/download/client_app.py
+++ b/src/fetchtastic/download/client_app.py
@@ -1250,39 +1250,75 @@ class MeshtasticClientAppDownloader(BaseDownloader):
             },
         )
 
+    @staticmethod
+    def _normalize_release_tuple(
+        release_tuple: tuple[int, ...] | None, width: int = 6
+    ) -> tuple[int, ...] | None:
+        """Normalize a release tuple to a fixed-width semantic base.
+
+        Returns ``None`` for ``None`` or empty input. Longer tuples are
+        truncated to ``width`` and shorter tuples are zero-padded so that
+        semantically equivalent bases (e.g. ``(2, 7)``, ``(2, 7, 0)``,
+        ``(2, 7, 0, 0)``) collapse to a single comparable key. The default
+        ``width`` of 6 matches the existing cleanup retention policy.
+        """
+        if not release_tuple:
+            return None
+        truncated = tuple(release_tuple[:width])
+        return truncated + (0,) * (width - len(truncated))
+
     def _latest_stable_release_tuple(
         self, releases: list[Release]
     ) -> tuple[int, ...] | None:
-        """Return the release tuple of the latest genuine stable release.
+        """Return the latest genuine stable release's normalized semantic base.
 
-        Selection is deterministic and independent of input order: the stable
-        release with the highest version tuple wins, with published_at and tag
-        name as tie breakers. Returns None when no stable release is present.
+        Selection is deterministic and independent of input order: each
+        stable release tuple is normalized to a width-6 semantic base so
+        that tags like ``v2.7`` and ``v2.7.0`` compare equal. The stable
+        release with the highest normalized base wins, with published_at
+        and tag name as tie breakers. Returns the normalized width-6 tuple
+        for the selected release, or ``None`` when no stable release is
+        present.
         """
         stable_releases = [r for r in releases if self._is_client_app_stable(r)]
         if not stable_releases:
             return None
 
         def _key(release: Release) -> tuple[Any, ...]:
-            release_tuple = self.version_manager.get_release_tuple(release.tag_name)
+            normalized = self._normalize_release_tuple(
+                self.version_manager.get_release_tuple(release.tag_name)
+            )
             published_dt = parse_iso_datetime_utc(release.published_at)
             published_ts = published_dt.timestamp() if published_dt else 0
-            return (release_tuple or (0,), published_ts, release.tag_name or "")
+            # An unparseable stable normalizes to None; rank it below any
+            # parseable base via a zero width-6 tuple so it only wins when
+            # no parseable stable is present.
+            return (
+                normalized or (0, 0, 0, 0, 0, 0),
+                published_ts,
+                release.tag_name or "",
+            )
 
         latest = max(stable_releases, key=_key)
-        return self.version_manager.get_release_tuple(latest.tag_name)
+        return self._normalize_release_tuple(
+            self.version_manager.get_release_tuple(latest.tag_name)
+        )
 
     def _select_active_prereleases(self, releases: list[Release]) -> list[Release]:
         """Select active client-app prereleases on the single highest eligible base.
 
         Policy:
         - Only classified non-snapshot prereleases are considered (snapshots excluded).
-        - When a parseable stable release exists, prerelease bases whose parsed
-          base is <= the stable base are discarded.
+        - Release tuples are compared by a shared width-6 normalized form so
+          that semantically equal bases (``v2.7`` == ``v2.7.0`` ==
+          ``v2.7.0.0``) collapse and compare equal.
+        - When a parseable stable release exists, prerelease bases whose
+          normalized base is <= the normalized stable base are discarded.
         - Every tag (open/closed/internal) on the single highest eligible
-          prerelease base is retained; superseded bases are dropped entirely.
+          normalized prerelease base is retained; superseded bases are
+          dropped entirely.
         - When no stable release has a parseable tuple, the highest parseable
-          prerelease base wins.
+          normalized prerelease base wins.
         - When no candidate has a parseable base, all classified candidates are
           preserved so unparseable prereleases are never silently dropped.
           Unparseable candidates are never retained alongside a parseable winner
@@ -1311,12 +1347,15 @@ class MeshtasticClientAppDownloader(BaseDownloader):
             if candidate_base is None:
                 continue
             has_parseable = True
+            normalized_base = self._normalize_release_tuple(candidate_base)
+            if normalized_base is None:
+                continue
             if (
                 latest_stable_tuple is not None
-                and candidate_base <= latest_stable_tuple
+                and normalized_base <= latest_stable_tuple
             ):
                 continue
-            eligible_by_base.setdefault(candidate_base, []).append(candidate)
+            eligible_by_base.setdefault(normalized_base, []).append(candidate)
 
         if eligible_by_base:
             winning_base = max(eligible_by_base)

--- a/src/fetchtastic/download/client_app.py
+++ b/src/fetchtastic/download/client_app.py
@@ -1199,9 +1199,10 @@ class MeshtasticClientAppDownloader(BaseDownloader):
         """Validate a managed latest symlink after cleanup removals.
 
         Removes the latest pointer via ``remove_latest_pointer`` when its target
-        is missing, unsafe (absolute/traversal/nested), itself a symlink, or not
-        in the retained set. Never removes a non-symlink latest entry. Does not
-        follow symlinks. Parent/ancestor symlink protections are delegated to
+        is missing, unsafe (absolute/traversal/nested), itself a symlink, not a
+        directory (e.g. a regular file named like a retained tag), or not in the
+        retained set. Never removes a non-symlink latest entry. Does not follow
+        symlinks. Parent/ancestor symlink protections are delegated to
         ``remove_latest_pointer``.
         """
         link_path = os.path.join(parent_dir, LATEST_POINTER_NAME)
@@ -1220,7 +1221,10 @@ class MeshtasticClientAppDownloader(BaseDownloader):
             return
         target_path = os.path.join(parent_dir, safe_target)
         try:
-            if os.path.islink(target_path) or not os.path.exists(target_path):
+            # ``exists`` would accept a regular file named like a retained tag,
+            # leaving ``latest`` pointing somewhere that cannot serve as a
+            # release directory. Require a directory instead.
+            if os.path.islink(target_path) or not os.path.isdir(target_path):
                 remove_latest_pointer(parent_dir)
         except OSError:
             remove_latest_pointer(parent_dir)
@@ -1290,10 +1294,14 @@ class MeshtasticClientAppDownloader(BaseDownloader):
             )
             published_dt = parse_iso_datetime_utc(release.published_at)
             published_ts = published_dt.timestamp() if published_dt else 0
-            # An unparseable stable normalizes to None; rank it below any
-            # parseable base via a zero width-6 tuple so it only wins when
-            # no parseable stable is present.
+            # ``normalized or (0,...)`` collapses an unparsable stable (None)
+            # and a parseable ``v0.0.0`` to the same zero tuple, so a newer
+            # unparsable tag could win on the published_at tiebreak and make
+            # this helper return None. Lead with ``normalized is not None`` so
+            # any parseable base outranks an unparsable one before the
+            # published_at tiebreak is consulted.
             return (
+                normalized is not None,
                 normalized or (0, 0, 0, 0, 0, 0),
                 published_ts,
                 release.tag_name or "",
@@ -1320,8 +1328,8 @@ class MeshtasticClientAppDownloader(BaseDownloader):
         - When no stable release has a parseable tuple, the highest parseable
           normalized prerelease base wins.
         - When no candidate has a parseable base, all classified candidates are
-          preserved so unparseable prereleases are never silently dropped.
-          Unparseable candidates are never retained alongside a parseable winner
+          preserved so unparsable prereleases are never silently dropped.
+          Unparsable candidates are never retained alongside a parseable winner
           because they cannot be assigned to that stream.
         - Output is deterministic: published_at descending with a tag-name
           tiebreak, independent of input order.

--- a/tests/test_client_app_coverage.py
+++ b/tests/test_client_app_coverage.py
@@ -1315,7 +1315,10 @@ def test_handle_prereleases_disabled(downloader):
     assert downloader.handle_prereleases(releases) == []
 
 
-def test_handle_prereleases_basic(downloader, mocker):
+def test_handle_prereleases_basic(downloader):
+    # A prerelease sharing the stable base (2.7.14-closed.1 over v2.7.14) is
+    # excluded: the stable release supersedes same-base prereleases, so the
+    # highest-active-base selector returns no eligible candidates.
     releases = [
         Release(
             tag_name="v2.7.14", prerelease=False, published_at="2026-01-01T00:00:00Z"
@@ -1326,14 +1329,8 @@ def test_handle_prereleases_basic(downloader, mocker):
             published_at="2026-01-02T00:00:00Z",
         ),
     ]
-    mocker.patch.object(
-        downloader.version_manager,
-        "calculate_expected_prerelease_version",
-        return_value=None,
-    )
     result = downloader.handle_prereleases(releases)
-    assert len(result) == 1
-    assert result[0].tag_name == "v2.7.14-closed.1"
+    assert result == []
 
 
 def test_handle_prereleases_filters_by_expected_base(downloader, mocker):
@@ -1388,7 +1385,11 @@ def test_handle_prereleases_filters_by_expected_base_exclude(downloader, mocker)
     assert result == []
 
 
-def test_handle_prereleases_expected_base_does_not_prefix_match(downloader, mocker):
+def test_handle_prereleases_higher_patch_tuple_eligible_over_stable(downloader):
+    # Guards against string-prefix comparison: a prerelease on base 2.7.10 is
+    # eligible over a stable on 2.7.0 because tuple comparison
+    # (2, 7, 10) > (2, 7, 0). A naive string-prefix check would mis-rank these
+    # (e.g. treat "2.7.10" as sharing a "2.7.1" prefix or ranking below "2.7.0").
     downloader.config["CHECK_APP_PRERELEASES"] = True
     releases = [
         Release(
@@ -1400,15 +1401,10 @@ def test_handle_prereleases_expected_base_does_not_prefix_match(downloader, mock
             published_at="2026-01-02T00:00:00Z",
         ),
     ]
-    mocker.patch.object(
-        downloader.version_manager,
-        "calculate_expected_prerelease_version",
-        return_value="2.7.1",
-    )
 
     result = downloader.handle_prereleases(releases)
 
-    assert result == []
+    assert [r.tag_name for r in result] == ["v2.7.10-open.1"]
 
 
 def test_handle_prereleases_filters_by_expected_base_no_clean(downloader, mocker):

--- a/tests/test_client_app_prerelease_selection.py
+++ b/tests/test_client_app_prerelease_selection.py
@@ -266,15 +266,15 @@ def test_case7_no_stable_selects_highest_parseable_base(downloader):
 
 
 # ---------------------------------------------------------------------------
-# Case 8: all candidate bases unparseable -> preserve classified candidates
+# Case 8: all candidate bases unparsable -> preserve classified candidates
 # ---------------------------------------------------------------------------
 
 
-def test_case8_all_unparseable_bases_preserves_classified_candidates(downloader):
+def test_case8_all_unparsable_bases_preserves_classified_candidates(downloader):
     """
     Given a stable v2.7.14 and classified prereleases whose base versions
     cannot be parsed, When handle_prereleases selects the active set,
-    Then every classified candidate is preserved (fallback so unparseable
+    Then every classified candidate is preserved (fallback so unparsable
     prereleases are never silently dropped).
     """
     releases = [
@@ -485,3 +485,22 @@ def test_norm_production_v2_7_14_and_v2_8_0_closed_8_remains_selected(downloader
     selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
 
     assert selected == ["v2.8.0-closed.8"]
+
+
+def test_norm_parseable_zero_tuple_outranks_newer_unparsable_stable(downloader):
+    """
+    Regression: ``normalized or (0,...)`` collapsed a parseable ``v0.0.0``
+    and an unparsable stable (e.g. ``edge``) to the same zero tuple, so a
+    newer unparsable tag could win the published_at tiebreak and make
+    ``_latest_stable_release_tuple`` return None, disabling the stable
+    cutoff. The leading ``normalized is not None`` key now ensures any
+    parseable base outranks an unparsable one.
+    """
+    parseable_zero = _stable("v0.0.0", "2024-01-01T00:00:00Z")
+    newer_unparsable = _stable("edge", "2024-02-01T00:00:00Z")
+
+    resolved = downloader._latest_stable_release_tuple(
+        [parseable_zero, newer_unparsable]
+    )
+
+    assert resolved == (0, 0, 0, 0, 0, 0)

--- a/tests/test_client_app_prerelease_selection.py
+++ b/tests/test_client_app_prerelease_selection.py
@@ -1,16 +1,18 @@
 """
-RED regression suite for the highest-active client-app prerelease policy.
+Regression suite for the highest-active client-app prerelease policy.
 
 These tests pin the intended selection behaviour for Android client-app
 prereleases (the legacy ``-open.N`` / ``-closed.N`` tag tracks) and the
 consistency invariant between ``MeshtasticClientAppDownloader.handle_prereleases``
 and ``MeshtasticClientAppDownloader.get_latest_prerelease_tag``.
 
-Intended policy (see task context):
+Intended policy:
 - Consider classified non-snapshot prereleases only.
+- Release tuples are compared by a shared width-6 normalized form so that
+  semantically equal bases (v2.7 == v2.7.0 == v2.7.0.0) compare equal.
 - When a parseable stable release exists, discard prerelease bases whose
-  parsed base is <= the stable base, then retain every tag on the single
-  highest newer parseable base.
+  normalized base is <= the normalized stable base, then retain every tag
+  on the single highest newer parseable base.
 - When no parseable stable exists, retain every tag on the highest
   parseable prerelease base.
 - When no candidate base parses, preserve every classified candidate.
@@ -19,9 +21,9 @@ Intended policy (see task context):
 - Recent SHA filtering is a later step inside handle_prereleases and does
   not affect the base-selection invariants pinned here.
 
-Each test names one of the eleven required cases and is written to fail
-against the current (pre-fix) implementation for a behaviour reason, not
-for a syntax, import, or fixture reason.
+The semantic normalization cases below pin width-6 base comparison via the
+shared helper in client_app.py; the production-shaped cases (Case 1, Case
+11) guard the ordinary higher-base selection path.
 """
 
 import pytest
@@ -361,3 +363,125 @@ def test_case11_production_scenario_no_empty_selection_with_reported_tag(downloa
 
     assert selected, "selection must not be empty when a prerelease is available"
     assert reported in selected
+
+
+# ---------------------------------------------------------------------------
+# Semantic release-tuple normalization (width-6 base comparison)
+#
+# These cases pin width-6 normalization of release tuples so that
+# semantically equal bases (v2.7 == v2.7.0 == v2.7.0.0) compare equal.
+# They exercise the shared width-6 normalization helper in client_app.py;
+# the production-shaped cases above guard the ordinary higher-base path.
+# ---------------------------------------------------------------------------
+
+
+def test_norm_stable_v2_7_excludes_prerelease_v2_7_0_open_1(downloader):
+    """
+    Given a parseable stable v2.7 and a classified prerelease v2.7.0-open.1
+    whose base 2.7.0 is semantically equal to the stable base 2.7,
+    When handle_prereleases selects the active set and
+    get_latest_prerelease_tag reports the leading tag,
+    Then the selection is empty and the reported tag is None (the
+    prerelease base is <= the stable base once widths are normalized).
+    """
+    releases = [
+        _stable("v2.7", "2024-01-15T00:00:00Z"),
+        _pre("v2.7.0-open.1", "2024-02-20T00:00:00Z"),
+    ]
+
+    selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
+    reported = downloader.get_latest_prerelease_tag(releases)
+
+    assert selected == []
+    assert reported is None
+
+
+def test_norm_stable_v2_7_0_excludes_prerelease_v2_7_open_1(downloader):
+    """
+    Given a parseable stable v2.7.0 and a classified prerelease v2.7-open.1
+    whose base 2.7 is semantically equal to the stable base 2.7.0,
+    When handle_prereleases selects the active set,
+    Then the selection is empty (the prerelease base is <= the stable base
+    once widths are normalized).
+    """
+    releases = [
+        _stable("v2.7.0", "2024-01-15T00:00:00Z"),
+        _pre("v2.7-open.1", "2024-02-20T00:00:00Z"),
+    ]
+
+    selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
+
+    assert selected == []
+
+
+def test_norm_open_and_closed_on_equal_semantic_base_retained(downloader):
+    """
+    Given an older stable v2.7.14 and two prereleases whose bases 2.8 and
+    2.8.0 are semantically equal, When handle_prereleases selects the active
+    set, Then both tags are retained on the single winning semantic base in
+    deterministic published_at-descending order (tag-name tiebreak).
+    """
+    releases = [
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+        _pre("v2.8-open.1", "2024-02-15T00:00:00Z"),
+        _pre("v2.8.0-closed.1", "2024-02-20T00:00:00Z"),
+    ]
+
+    selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
+
+    assert selected == ["v2.8.0-closed.1", "v2.8-open.1"]
+
+
+def test_norm_bases_v2_8_v2_8_0_v2_8_0_0_grouped_as_one(downloader):
+    """
+    Given classified prereleases spelling the same semantic base as v2.8,
+    v2.8.0, and v2.8.0.0, When handle_prereleases selects the active set,
+    Then all three tags are retained on one semantic base (none is dropped
+    to a narrower-width sibling group).
+    """
+    releases = [
+        _pre("v2.8-open.1", "2024-02-01T00:00:00Z"),
+        _pre("v2.8.0-closed.2", "2024-02-10T00:00:00Z"),
+        _pre("v2.8.0.0-open.3", "2024-02-20T00:00:00Z"),
+    ]
+
+    selected = sorted(r.tag_name for r in downloader.handle_prereleases(releases))
+
+    assert selected == ["v2.8-open.1", "v2.8.0-closed.2", "v2.8.0.0-open.3"]
+
+
+def test_norm_private_stable_helper_returns_width_six_tuple(downloader):
+    """
+    Given stable candidates v2.7 and v2.7.0, When _latest_stable_release_tuple
+    resolves the latest stable, Then the returned tuple is the width-6
+    normalized form (2, 7, 0, 0, 0, 0) and the resolution is deterministic
+    across input permutations (publication and tag-name tiebreaks).
+    """
+    later_v2_7 = _stable("v2.7", "2024-02-20T00:00:00Z")
+    earlier_v2_7_0 = _stable("v2.7.0", "2024-01-15T00:00:00Z")
+    first_input = [later_v2_7, earlier_v2_7_0]
+    permuted_input = [earlier_v2_7_0, later_v2_7]
+
+    resolved_first = downloader._latest_stable_release_tuple(first_input)
+    resolved_permuted = downloader._latest_stable_release_tuple(permuted_input)
+
+    assert resolved_first == (2, 7, 0, 0, 0, 0)
+    assert resolved_permuted == (2, 7, 0, 0, 0, 0)
+
+
+def test_norm_production_v2_7_14_and_v2_8_0_closed_8_remains_selected(downloader):
+    """
+    Given the production-shaped stable v2.7.14 and a v2.8.0-closed.8
+    prerelease, When handle_prereleases selects the active set,
+    Then the v2.8.0-closed.8 prerelease remains selected (the newer
+    semantic base survives normalization). This is the green production
+    regression guard for the normalization change.
+    """
+    releases = [
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+        _pre("v2.8.0-closed.8", "2024-02-20T00:00:00Z"),
+    ]
+
+    selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
+
+    assert selected == ["v2.8.0-closed.8"]

--- a/tests/test_client_app_prerelease_selection.py
+++ b/tests/test_client_app_prerelease_selection.py
@@ -1,0 +1,363 @@
+"""
+RED regression suite for the highest-active client-app prerelease policy.
+
+These tests pin the intended selection behaviour for Android client-app
+prereleases (the legacy ``-open.N`` / ``-closed.N`` tag tracks) and the
+consistency invariant between ``MeshtasticClientAppDownloader.handle_prereleases``
+and ``MeshtasticClientAppDownloader.get_latest_prerelease_tag``.
+
+Intended policy (see task context):
+- Consider classified non-snapshot prereleases only.
+- When a parseable stable release exists, discard prerelease bases whose
+  parsed base is <= the stable base, then retain every tag on the single
+  highest newer parseable base.
+- When no parseable stable exists, retain every tag on the highest
+  parseable prerelease base.
+- When no candidate base parses, preserve every classified candidate.
+- Output order is deterministic: published_at descending with a tag-name
+  fallback so equal timestamps never depend on input order.
+- Recent SHA filtering is a later step inside handle_prereleases and does
+  not affect the base-selection invariants pinned here.
+
+Each test names one of the eleven required cases and is written to fail
+against the current (pre-fix) implementation for a behaviour reason, not
+for a syntax, import, or fixture reason.
+"""
+
+import pytest
+
+from fetchtastic.download.cache import CacheManager
+from fetchtastic.download.client_app import MeshtasticClientAppDownloader
+from fetchtastic.download.interfaces import Asset, Release
+
+pytestmark = [pytest.mark.unit, pytest.mark.core_downloads]
+
+# Realistic Android release asset name used across the client-app suite.
+_APK_NAME = "app-fdroid-universal-release.apk"
+
+
+def _apk_release(tag_name: str, *, prerelease: bool, published_at: str) -> Release:
+    """Build a minimal Release carrying one Android APK asset."""
+    return Release(
+        tag_name=tag_name,
+        prerelease=prerelease,
+        published_at=published_at,
+        assets=[
+            Asset(
+                name=_APK_NAME, download_url="https://example.invalid/app.apk", size=1
+            )
+        ],
+    )
+
+
+def _stable(tag_name: str, published_at: str) -> Release:
+    """Build a genuine stable client-app release (prerelease flag False)."""
+    return _apk_release(tag_name, prerelease=False, published_at=published_at)
+
+
+def _pre(tag_name: str, published_at: str) -> Release:
+    """Build a classified client-app prerelease (prerelease flag True)."""
+    return _apk_release(tag_name, prerelease=True, published_at=published_at)
+
+
+def _snapshot(published_at: str) -> Release:
+    """Build the rolling snapshot debug-build release."""
+    return Release(
+        tag_name="snapshot",
+        prerelease=True,
+        published_at=published_at,
+        assets=[
+            Asset(
+                name="androidApp-fdroid-universal-debug-29321447.apk",
+                download_url="https://example.invalid/snapshot.apk",
+                size=1,
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def cache_manager(tmp_path):
+    """Real CacheManager rooted at tmp_path (no network, file-safe)."""
+    return CacheManager(cache_dir=str(tmp_path))
+
+
+@pytest.fixture
+def downloader(tmp_path, cache_manager):
+    """Client-app downloader with prerelease checking enabled."""
+    config = {
+        "DOWNLOAD_DIR": str(tmp_path / "downloads"),
+        "SAVE_CLIENT_APPS": True,
+        "SELECTED_APP_ASSETS": [_APK_NAME],
+        "APP_VERSIONS_TO_KEEP": 1,
+        "CHECK_APP_PRERELEASES": True,
+        "EXCLUDE_PATTERNS": [],
+    }
+    return MeshtasticClientAppDownloader(config, cache_manager)
+
+
+# ---------------------------------------------------------------------------
+# Case 1: stable v2.7.14 present, closed prerelease on newer base v2.8.0
+# ---------------------------------------------------------------------------
+
+
+def test_case1_newer_base_closed_prerelease_selected(downloader):
+    """
+    Given a parseable stable v2.7.14 and a v2.8.0-closed.8 prerelease,
+    When handle_prereleases selects the active set,
+    Then the v2.8.0-closed.8 prerelease is retained (its base 2.8.0 > 2.7.14).
+    """
+    releases = [
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+        _pre("v2.8.0-closed.8", "2024-02-20T00:00:00Z"),
+    ]
+
+    selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
+
+    assert "v2.8.0-closed.8" in selected
+
+
+# ---------------------------------------------------------------------------
+# Case 2: same-base superseded prereleases excluded when a newer base exists
+# ---------------------------------------------------------------------------
+
+
+def test_case2_superseded_base_prereleases_excluded(downloader):
+    """
+    Given stable v2.7.14 and prereleases on bases 2.7.15 and 2.8.0,
+    When handle_prereleases selects the active set,
+    Then only prereleases on the highest newer base (2.8.0) are retained and
+    every tag on the superseded 2.7.15 base is excluded.
+    """
+    releases = [
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+        _pre("v2.7.15-closed.3", "2024-02-01T00:00:00Z"),
+        _pre("v2.7.15-open.5", "2024-02-10T00:00:00Z"),
+        _pre("v2.8.0-closed.8", "2024-02-20T00:00:00Z"),
+    ]
+
+    selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
+
+    assert "v2.8.0-closed.8" in selected
+    assert "v2.7.15-closed.3" not in selected
+    assert "v2.7.15-open.5" not in selected
+
+
+# ---------------------------------------------------------------------------
+# Case 3: next-patch prerelease selected over current stable
+# ---------------------------------------------------------------------------
+
+
+def test_case3_next_patch_prerelease_selected(downloader):
+    """
+    Given stable v2.7.14 and a v2.7.15-closed.5 prerelease (the immediate
+    next patch base), When handle_prereleases selects the active set,
+    Then v2.7.15-closed.5 is retained (base 2.7.15 > stable 2.7.14).
+    """
+    releases = [
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+        _pre("v2.7.15-closed.5", "2024-02-01T00:00:00Z"),
+    ]
+
+    selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
+
+    assert selected == ["v2.7.15-closed.5"]
+
+
+# ---------------------------------------------------------------------------
+# Case 4: only the highest of bases 2.7.15 / 2.8.0 is retained
+# ---------------------------------------------------------------------------
+
+
+def test_case4_only_highest_base_retained(downloader):
+    """
+    Given stable v2.7.14 and one prerelease on each of bases 2.7.15 and
+    2.8.0, When handle_prereleases selects the active set,
+    Then only the 2.8.0-base prerelease is retained.
+    """
+    releases = [
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+        _pre("v2.7.15-open.3", "2024-02-01T00:00:00Z"),
+        _pre("v2.8.0-closed.8", "2024-02-20T00:00:00Z"),
+    ]
+
+    selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
+
+    assert selected == ["v2.8.0-closed.8"]
+
+
+# ---------------------------------------------------------------------------
+# Case 5: both -open and -closed tags on the winning base are retained
+# ---------------------------------------------------------------------------
+
+
+def test_case5_open_and_closed_tags_on_winning_base_retained(downloader):
+    """
+    Given stable v2.7.14 and two v2.8.0 prereleases (one -open, one
+    -closed), When handle_prereleases selects the active set,
+    Then both tags on the winning v2.8.0 base are retained.
+    """
+    releases = [
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+        _pre("v2.8.0-open.5", "2024-02-15T00:00:00Z"),
+        _pre("v2.8.0-closed.8", "2024-02-20T00:00:00Z"),
+    ]
+
+    selected = sorted(r.tag_name for r in downloader.handle_prereleases(releases))
+
+    assert selected == ["v2.8.0-closed.8", "v2.8.0-open.5"]
+
+
+# ---------------------------------------------------------------------------
+# Case 6: deterministic published_at desc ordering with tag fallback
+# ---------------------------------------------------------------------------
+
+
+def test_case6_ordering_is_deterministic_across_input_permutations(downloader):
+    """
+    Given two prereleases sharing the same published_at timestamp, When
+    handle_prereleases selects the active set from two different input
+    orderings, Then the output tag sequence is identical for both inputs
+    (ordering must not depend on input order).
+    """
+    # Use the next-patch base (2.7.15) so both prereleases survive selection
+    # and their relative order is what the tiebreak must make deterministic.
+    shared_published_at = "2024-02-20T00:00:00Z"
+    first_input = [
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+        _pre("v2.7.15-closed.7", shared_published_at),
+        _pre("v2.7.15-closed.8", shared_published_at),
+    ]
+    permuted_input = [
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+        _pre("v2.7.15-closed.8", shared_published_at),
+        _pre("v2.7.15-closed.7", shared_published_at),
+    ]
+
+    selected_first = [r.tag_name for r in downloader.handle_prereleases(first_input)]
+    selected_permuted = [
+        r.tag_name for r in downloader.handle_prereleases(permuted_input)
+    ]
+
+    assert selected_first == selected_permuted
+
+
+# ---------------------------------------------------------------------------
+# Case 7: no stable release -> select the highest parseable prerelease base
+# ---------------------------------------------------------------------------
+
+
+def test_case7_no_stable_selects_highest_parseable_base(downloader):
+    """
+    Given no stable release and prereleases on parseable bases 2.7.15 and
+    2.8.0, When handle_prereleases selects the active set,
+    Then only the highest parseable base (2.8.0) prerelease is retained.
+    """
+    releases = [
+        _pre("v2.7.15-closed.5", "2024-02-01T00:00:00Z"),
+        _pre("v2.8.0-closed.8", "2024-02-20T00:00:00Z"),
+    ]
+
+    selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
+
+    assert selected == ["v2.8.0-closed.8"]
+
+
+# ---------------------------------------------------------------------------
+# Case 8: all candidate bases unparseable -> preserve classified candidates
+# ---------------------------------------------------------------------------
+
+
+def test_case8_all_unparseable_bases_preserves_classified_candidates(downloader):
+    """
+    Given a stable v2.7.14 and classified prereleases whose base versions
+    cannot be parsed, When handle_prereleases selects the active set,
+    Then every classified candidate is preserved (fallback so unparseable
+    prereleases are never silently dropped).
+    """
+    releases = [
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+        _pre("vfoo-closed.1", "2024-02-01T00:00:00Z"),
+        _pre("vbar-open.2", "2024-02-10T00:00:00Z"),
+    ]
+
+    selected = sorted(r.tag_name for r in downloader.handle_prereleases(releases))
+
+    assert selected == ["vbar-open.2", "vfoo-closed.1"]
+
+
+# ---------------------------------------------------------------------------
+# Case 9: snapshot debug-build tag is never classified as an active prerelease
+# ---------------------------------------------------------------------------
+
+
+def test_case9_snapshot_excluded_from_selection(downloader):
+    """
+    Given the rolling snapshot release alongside a real prerelease and a
+    stable, When handle_prereleases selects the active set,
+    Then the snapshot tag is absent and the real prerelease is retained.
+    """
+    # The real prerelease uses the next-patch base so it survives selection
+    # and the only behavior under test here is snapshot exclusion.
+    releases = [
+        _snapshot("2024-02-25T00:00:00Z"),
+        _pre("v2.7.15-closed.5", "2024-02-20T00:00:00Z"),
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+    ]
+
+    selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
+
+    assert "snapshot" not in selected
+    assert "v2.7.15-closed.5" in selected
+
+
+# ---------------------------------------------------------------------------
+# Case 10: get_latest_prerelease_tag matches the first shared candidate
+# ---------------------------------------------------------------------------
+
+
+def test_case10_latest_prerelease_tag_matches_first_selected_candidate(downloader):
+    """
+    Given a release set, When handle_prereleases selects the active set and
+    get_latest_prerelease_tag reports a single tag,
+    Then the reported tag is either None or exactly the first tag of the
+    selected set (the two methods must agree on the leading candidate).
+    """
+    releases = [
+        _stable("v2.7.14", "2024-01-15T00:00:00Z"),
+        _pre("v2.8.0-closed.8", "2024-02-20T00:00:00Z"),
+    ]
+
+    selected = downloader.handle_prereleases(releases)
+    reported = downloader.get_latest_prerelease_tag(releases)
+
+    if reported is not None:
+        assert selected, "reported tag must not exist when selection is empty"
+        assert reported == selected[0].tag_name
+
+
+# ---------------------------------------------------------------------------
+# Case 11: production scenario must never report a tag with an empty selection
+# ---------------------------------------------------------------------------
+
+
+def test_case11_production_scenario_no_empty_selection_with_reported_tag(downloader):
+    """
+    Given a production-shaped release set (realistic timestamps and asset
+    layout for the v2.7.14 -> v2.8.0 transition), When handle_prereleases
+    selects the active set and get_latest_prerelease_tag reports a tag,
+    Then the selection is non-empty and contains the reported tag. The
+    production system must never present an empty selection alongside a
+    reported prerelease tag.
+    """
+    releases = [
+        _stable("v2.7.14", "2024-12-10T18:32:11Z"),
+        _pre("v2.8.0-open.4", "2025-01-08T09:14:00Z"),
+        _pre("v2.8.0-closed.8", "2025-01-22T20:47:33Z"),
+    ]
+
+    selected = [r.tag_name for r in downloader.handle_prereleases(releases)]
+    reported = downloader.get_latest_prerelease_tag(releases)
+
+    assert selected, "selection must not be empty when a prerelease is available"
+    assert reported in selected

--- a/tests/test_download_orchestrator.py
+++ b/tests/test_download_orchestrator.py
@@ -4523,6 +4523,190 @@ class TestDownloadOrchestrator:
         assert mock_pointer.call_count == 1
         mock_pointer.assert_called_once_with(older)
 
+    # ------------------------------------------------------------------
+    # Client-app higher-minor prerelease contracts (cases 20-24).
+    #
+    # Production reproduction fixture: stable v2.7.14 + prerelease
+    # v2.8.0-closed.8.  The orchestrator's transactional tracking/latest
+    # updates and completeness-triggered backfill already work, but the
+    # selector (handle_prereleases) currently rejects higher-minor
+    # prereleases because clean_tuple (2,8,0) != expected_tuple (2,7,15).
+    # T1 locks the selector contract (RED until the selector fix lands);
+    # T2/T3/T4 lock the orchestration contracts that the fix must not
+    # break.  Cases 22/23/24 are covered by existing tests (named below)
+    # and depend on the same selector fix represented by T1.
+    # ------------------------------------------------------------------
+
+    def test_higher_minor_prerelease_selector_must_surface_v2_8_0_closed(
+        self, tmp_path
+    ):
+        """Case 20 (selector): handle_prereleases must not reject a higher-minor prerelease.
+
+        RED until the selector accepts v2.8.0-closed.8 alongside stable v2.7.14.
+        Currently the expected-base filter (clean_tuple (2,8,0) != expected (2,7,15))
+        drops the prerelease, which also blocks backfill (case 22) and retain/repair
+        (case 23) for the reproduction fixture.
+        """
+        config = {
+            "DOWNLOAD_DIR": str(tmp_path),
+            "SAVE_CLIENT_APPS": True,
+            "CHECK_APP_PRERELEASES": True,
+        }
+        orch = DownloadOrchestrator(config)
+        prerelease = Release(tag_name="v2.8.0-closed.8", prerelease=True, assets=[])
+        stable = Release(tag_name="v2.7.14", prerelease=False, assets=[])
+
+        surfaced = orch.client_app_downloader.handle_prereleases([prerelease, stable])
+
+        assert any(r.tag_name == "v2.8.0-closed.8" for r in surfaced), surfaced
+
+    def test_higher_minor_prerelease_storage_under_prerelease_dir(self, tmp_path):
+        """Case 20 (storage): prerelease assets resolve under app/prerelease/<tag>/.
+
+        GREEN: the storage-path logic already handles higher-minor tags; this locks
+        the path so a regression in _resolve_release_dir is caught.
+        """
+        config = {
+            "DOWNLOAD_DIR": str(tmp_path),
+            "SAVE_CLIENT_APPS": True,
+            "CHECK_APP_PRERELEASES": True,
+        }
+        orch = DownloadOrchestrator(config)
+        prerelease = Release(tag_name="v2.8.0-closed.8", prerelease=True, assets=[])
+
+        target = orch.client_app_downloader.get_target_path_for_release(
+            "v2.8.0-closed.8", "app.apk", release=prerelease
+        )
+
+        expected = str(tmp_path / "app" / "prerelease" / "v2.8.0-closed.8" / "app.apk")
+        assert target == expected
+
+    def test_higher_minor_prerelease_download_passes_assets_then_tracking_then_latest(
+        self, orchestrator
+    ):
+        """Case 20 (orchestration + transaction ordering): all selected assets are
+        passed to download_app, tracking updates only after every asset succeeds,
+        and the latest pointer updates after completion.
+
+        GREEN: the orchestrator already enforces the transaction; this locks the
+        ordering (download_app* < update_prerelease_tracking < latest pointer) on the
+        reproduction fixture so the selector fix cannot regress it.
+        """
+        asset_apk = Mock()
+        asset_apk.name = "app.apk"
+        asset_dmg = Mock()
+        asset_dmg.name = "app.dmg"
+        prerelease = Release(
+            tag_name="v2.8.0-closed.8",
+            prerelease=True,
+            assets=[asset_apk, asset_dmg],
+        )
+        # Stable release with no assets is filtered out of releases_to_process, so
+        # it does not update the stable latest pointer and isolates the prerelease path.
+        stable = Release(tag_name="v2.7.14", prerelease=False, assets=[])
+
+        orchestrator.client_app_downloader.get_releases.return_value = [stable]
+        orchestrator.client_app_downloader.update_release_history.return_value = {}
+        orchestrator.client_app_downloader.ensure_release_notes.return_value = None
+        orchestrator.client_app_downloader.format_release_log_suffix.return_value = ""
+        orchestrator.client_app_downloader.is_release_complete.return_value = True
+        orchestrator.client_app_downloader.handle_prereleases.return_value = [
+            prerelease
+        ]
+        orchestrator.client_app_downloader.should_download_prerelease.return_value = (
+            True
+        )
+        orchestrator.client_app_downloader.get_assets.side_effect = (
+            lambda release: release.assets
+        )
+        orchestrator.client_app_downloader.should_download_asset.return_value = True
+        success_result = Mock(spec=DownloadResult)
+        success_result.success = True
+        success_result.was_skipped = False
+        orchestrator.client_app_downloader.download_app.return_value = success_result
+
+        orchestrator._process_client_app_downloads()
+
+        # Every selected asset is passed to download_app with the prerelease.
+        download_calls = orchestrator.client_app_downloader.download_app.call_args_list
+        assert len(download_calls) == 2
+        assert all(call.args[0] is prerelease for call in download_calls)
+
+        # Tracking updates exactly once, only after all assets succeed.
+        orchestrator.client_app_downloader.update_prerelease_tracking.assert_called_once_with(
+            "v2.8.0-closed.8"
+        )
+
+        # Latest pointer updates exactly once with the prerelease, after completion.
+        orchestrator.client_app_downloader.update_latest_pointer_for_release.assert_called_once_with(
+            prerelease
+        )
+
+        # Transaction ordering on the single downloader mock:
+        # every download_app precedes tracking precedes the latest pointer.
+        names = [c[0] for c in orchestrator.client_app_downloader.mock_calls]
+        last_download = max(i for i, n in enumerate(names) if n == "download_app")
+        tracking_idx = names.index("update_prerelease_tracking")
+        pointer_idx = names.index("update_latest_pointer_for_release")
+        assert last_download < tracking_idx < pointer_idx
+
+    def test_higher_minor_prerelease_partial_failure_advances_neither_tracking_nor_latest(
+        self, orchestrator
+    ):
+        """Case 21: when one of the prerelease assets fails, tracking and the latest
+        pointer must not advance.
+
+        GREEN: the orchestrator's all-or-nothing guard (prerelease_results and all
+        succeed) already enforces this; this locks the contract on the reproduction
+        fixture.  Genuinely missing coverage — no existing test covers partial asset
+        failure within a single client-app prerelease.
+        """
+        asset_apk = Mock()
+        asset_apk.name = "app.apk"
+        asset_dmg = Mock()
+        asset_dmg.name = "app.dmg"
+        prerelease = Release(
+            tag_name="v2.8.0-closed.8",
+            prerelease=True,
+            assets=[asset_apk, asset_dmg],
+        )
+        stable = Release(tag_name="v2.7.14", prerelease=False, assets=[])
+
+        orchestrator.client_app_downloader.get_releases.return_value = [stable]
+        orchestrator.client_app_downloader.update_release_history.return_value = {}
+        orchestrator.client_app_downloader.ensure_release_notes.return_value = None
+        orchestrator.client_app_downloader.format_release_log_suffix.return_value = ""
+        orchestrator.client_app_downloader.is_release_complete.return_value = True
+        orchestrator.client_app_downloader.handle_prereleases.return_value = [
+            prerelease
+        ]
+        orchestrator.client_app_downloader.should_download_prerelease.return_value = (
+            True
+        )
+        orchestrator.client_app_downloader.get_assets.side_effect = (
+            lambda release: release.assets
+        )
+        orchestrator.client_app_downloader.should_download_asset.return_value = True
+        success_result = Mock(spec=DownloadResult)
+        success_result.success = True
+        success_result.was_skipped = False
+        failure_result = Mock(spec=DownloadResult)
+        failure_result.success = False
+        failure_result.was_skipped = False
+        orchestrator.client_app_downloader.download_app.side_effect = [
+            success_result,
+            failure_result,
+        ]
+
+        orchestrator._process_client_app_downloads()
+
+        # Both assets were attempted (the orchestrator downloads all, then checks).
+        assert orchestrator.client_app_downloader.download_app.call_count == 2
+
+        # Partial failure rolls back the whole prerelease transaction.
+        orchestrator.client_app_downloader.update_prerelease_tracking.assert_not_called()
+        orchestrator.client_app_downloader.update_latest_pointer_for_release.assert_not_called()
+
 
 class TestFirmwarePrereleaseBaselineRegression:
     """Regression tests for the repo-prerelease baseline selection fix.

--- a/tests/test_unified_storage_cleanup.py
+++ b/tests/test_unified_storage_cleanup.py
@@ -529,3 +529,30 @@ def test_production_stable_with_higher_base_prerelease_retained_with_latest(tmp_
     assert prerelease_dir.exists()
     assert latest.is_symlink()
     assert (prerelease_base / os.readlink(latest)).exists()
+
+
+def test_latest_pointer_to_regular_file_is_removed(tmp_path):
+    """Case 20: a latest pointer at a retained name that is a file, not a dir.
+
+    ``os.path.exists`` returns True for a regular file named like a retained
+    tag, so the pre-fix check left ``latest`` pointing somewhere that cannot
+    serve as a release directory. Require a directory via ``os.path.isdir``
+    so the pointer is removed instead.
+    """
+    dl = _make_downloader(tmp_path)
+    app_dir = tmp_path / APP_DIR_NAME
+    app_dir.mkdir(parents=True)
+    # Degenerate but possible: a regular file occupying a retained tag name.
+    file_target = app_dir / "v2.7.14"
+    file_target.write_text("not-a-directory")
+    latest = app_dir / LATEST_POINTER_NAME
+    try:
+        os.symlink("v2.7.14", latest)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks are not supported in this test environment")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[Release(tag_name="v2.7.14", prerelease=False)]
+    )
+
+    assert not latest.is_symlink()

--- a/tests/test_unified_storage_cleanup.py
+++ b/tests/test_unified_storage_cleanup.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from fetchtastic.constants import APP_DIR_NAME
+from fetchtastic.constants import APP_DIR_NAME, LATEST_POINTER_NAME
 from fetchtastic.download.cache import CacheManager
 from fetchtastic.download.client_app import MeshtasticClientAppDownloader
 from fetchtastic.download.interfaces import Asset, Release
@@ -224,3 +224,188 @@ def test_legacy_platform_classes_use_client_app_lifecycle(tmp_path):
     assert isinstance(
         MeshtasticDesktopDownloader(config, cache), MeshtasticClientAppDownloader
     )
+
+
+# Regression coverage for required cleanup cases 12-19. These exercise the
+# desired post-hotfix behavior: higher-minor prerelease directories are retained
+# on their own merits (not over-filtered through handle_prereleases), and the
+# managed "latest" pointer is validated only after removals so dangling, unsafe,
+# or non-retained symlinks are removed via remove_latest_pointer while valid and
+# non-symlink latest entries are preserved. Against current production the
+# missing-behavior cases fail (red); the preserve-valid cases lock existing
+# correct behavior.
+
+
+def test_higher_minor_prerelease_dir_is_retained_alongside_stable(tmp_path):
+    """Case 12: retain v2.8.0-closed.8 directory while stable v2.7.14 is current."""
+    dl = _make_downloader(tmp_path)
+    prerelease_base = tmp_path / APP_DIR_NAME / "prerelease"
+    higher_minor = prerelease_base / "v2.8.0-closed.8"
+    higher_minor.mkdir(parents=True)
+    (higher_minor / "app-universal.apk").write_bytes(b"apk")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[
+            Release(tag_name="v2.7.14", prerelease=False),
+            Release(tag_name="v2.8.0-closed.8", prerelease=True),
+        ]
+    )
+
+    assert higher_minor.exists()
+    assert (higher_minor / "app-universal.apk").exists()
+
+
+def test_same_base_superseded_prerelease_dir_is_removed(tmp_path):
+    """Case 13: remove a superseded same-base build, retain the current one."""
+    dl = _make_downloader(tmp_path)
+    prerelease_base = tmp_path / APP_DIR_NAME / "prerelease"
+    superseded = prerelease_base / "v2.8.0-closed.7"
+    current = prerelease_base / "v2.8.0-closed.8"
+    for directory in (superseded, current):
+        directory.mkdir(parents=True)
+        (directory / "app-universal.apk").write_bytes(b"apk")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[
+            Release(tag_name="v2.7.14", prerelease=False),
+            Release(tag_name="v2.8.0-closed.8", prerelease=True),
+        ]
+    )
+
+    assert not superseded.exists()
+    assert current.exists()
+
+
+def test_older_prerelease_base_removed_when_newer_active_base_exists(tmp_path):
+    """Case 14: drop the older prerelease base when a newer active base exists."""
+    dl = _make_downloader(tmp_path)
+    prerelease_base = tmp_path / APP_DIR_NAME / "prerelease"
+    older_base = prerelease_base / "v2.7.15-open.1"
+    newer_base = prerelease_base / "v2.8.0-closed.8"
+    for directory in (older_base, newer_base):
+        directory.mkdir(parents=True)
+        (directory / "app-universal.apk").write_bytes(b"apk")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[
+            Release(tag_name="v2.7.14", prerelease=False),
+            Release(tag_name="v2.7.15-open.1", prerelease=True),
+            Release(tag_name="v2.8.0-closed.8", prerelease=True),
+        ]
+    )
+
+    assert not older_base.exists()
+    assert newer_base.exists()
+
+
+def test_valid_latest_pointer_to_retained_directory_is_preserved(tmp_path):
+    """Case 15: a latest pointer at a retained directory survives cleanup."""
+    dl = _make_downloader(tmp_path)
+    app_dir = tmp_path / APP_DIR_NAME
+    retained = app_dir / "v2.7.14"
+    retained.mkdir(parents=True)
+    (retained / "app-universal.apk").write_bytes(b"apk")
+    latest = app_dir / LATEST_POINTER_NAME
+    try:
+        os.symlink("v2.7.14", latest)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks are not supported in this test environment")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[Release(tag_name="v2.7.14", prerelease=False)]
+    )
+
+    assert latest.is_symlink()
+    assert os.readlink(latest) == "v2.7.14"
+    assert retained.exists()
+
+
+def test_latest_pointer_whose_target_was_deleted_is_removed(tmp_path):
+    """Case 16: a latest pointer left dangling by removals must be removed too."""
+    dl = _make_downloader(tmp_path)
+    app_dir = tmp_path / APP_DIR_NAME
+    stale = app_dir / "v2.7.13"
+    retained = app_dir / "v2.7.14"
+    for directory in (stale, retained):
+        directory.mkdir(parents=True)
+        (directory / "app-universal.apk").write_bytes(b"apk")
+    latest = app_dir / LATEST_POINTER_NAME
+    try:
+        os.symlink("v2.7.13", latest)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks are not supported in this test environment")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[Release(tag_name="v2.7.14", prerelease=False)]
+    )
+
+    assert not stale.exists()
+    assert not latest.is_symlink()
+
+
+def test_preexisting_dangling_latest_pointer_is_removed(tmp_path):
+    """Case 17: a latest pointer that was already dangling gets cleaned up."""
+    dl = _make_downloader(tmp_path)
+    app_dir = tmp_path / APP_DIR_NAME
+    retained = app_dir / "v2.7.14"
+    retained.mkdir(parents=True)
+    (retained / "app-universal.apk").write_bytes(b"apk")
+    latest = app_dir / LATEST_POINTER_NAME
+    try:
+        os.symlink("v2.7.99", latest)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks are not supported in this test environment")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[Release(tag_name="v2.7.14", prerelease=False)]
+    )
+
+    assert not latest.is_symlink()
+    assert retained.exists()
+
+
+def test_non_symlink_latest_entry_is_preserved(tmp_path):
+    """Case 18: a user-managed non-symlink latest entry is never removed."""
+    dl = _make_downloader(tmp_path)
+    app_dir = tmp_path / APP_DIR_NAME
+    retained = app_dir / "v2.7.14"
+    retained.mkdir(parents=True)
+    (retained / "app-universal.apk").write_bytes(b"apk")
+    latest = app_dir / LATEST_POINTER_NAME
+    latest.write_text("user-managed-not-a-symlink")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[Release(tag_name="v2.7.14", prerelease=False)]
+    )
+
+    assert latest.exists()
+    assert not latest.is_symlink()
+    assert latest.read_text() == "user-managed-not-a-symlink"
+    assert retained.exists()
+
+
+def test_unsafe_latest_pointer_target_removed_without_following(tmp_path):
+    """Case 19: an unsafe latest symlink is removed without following its target."""
+    dl = _make_downloader(tmp_path)
+    app_dir = tmp_path / APP_DIR_NAME
+    retained = app_dir / "v2.7.14"
+    retained.mkdir(parents=True)
+    (retained / "app-universal.apk").write_bytes(b"apk")
+    # Real target lives outside the managed app tree but inside tmp_path so the
+    # test never mutates outside the temporary directory.
+    outside_target = tmp_path / "outside-target"
+    outside_target.write_text("precious")
+    latest = app_dir / LATEST_POINTER_NAME
+    try:
+        os.symlink(os.path.relpath(outside_target, app_dir), latest)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks are not supported in this test environment")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[Release(tag_name="v2.7.14", prerelease=False)]
+    )
+
+    assert not latest.is_symlink()
+    assert outside_target.exists()
+    assert outside_target.read_text() == "precious"
+    assert retained.exists()

--- a/tests/test_unified_storage_cleanup.py
+++ b/tests/test_unified_storage_cleanup.py
@@ -409,3 +409,123 @@ def test_unsafe_latest_pointer_target_removed_without_following(tmp_path):
     assert outside_target.exists()
     assert outside_target.read_text() == "precious"
     assert retained.exists()
+
+
+# Regression coverage for cleanup/latest-pointer behavior when prerelease tags
+# spell the same semantic base at different component widths. v2.8-open.1 and
+# v2.8.0-closed.1 are both semantic base 2.8, and v2.7.0-open.1 shares base 2.7
+# with the stable v2.7 release. The selector normalizes release tuples to a
+# fixed width-6 form, so (2, 8) and (2, 8, 0) collapse into one stream and
+# (2, 7, 0) compares equal to the stable (2, 7); these equivalent bases are
+# treated as one. The cleanup guard locks the already-correct production path.
+
+
+def test_equivalent_semantic_base_prerelease_dir_removed_with_latest(tmp_path):
+    """Stable v2.7 supersedes local v2.7.0-open.1 on the same semantic base.
+
+    The prerelease directory and the latest pointer targeting it are removed
+    once the equivalent base (2.7) is recognized as covered by the stable
+    release: width-6 normalization makes (2, 7, 0) equal to the stable tuple
+    (2, 7), so the prerelease is superseded.
+    """
+    dl = _make_downloader(tmp_path)
+    app_dir = tmp_path / APP_DIR_NAME
+    prerelease_base = app_dir / "prerelease"
+    stable_dir = app_dir / "v2.7"
+    stable_dir.mkdir(parents=True)
+    (stable_dir / "app-universal.apk").write_bytes(b"apk")
+    equivalent_prerelease = prerelease_base / "v2.7.0-open.1"
+    equivalent_prerelease.mkdir(parents=True)
+    (equivalent_prerelease / "app-universal.apk").write_bytes(b"apk")
+    latest = prerelease_base / LATEST_POINTER_NAME
+    try:
+        os.symlink("v2.7.0-open.1", latest)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks are not supported in this test environment")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[
+            Release(tag_name="v2.7", prerelease=False),
+            Release(tag_name="v2.7.0-open.1", prerelease=True),
+        ]
+    )
+
+    assert not equivalent_prerelease.exists()
+    assert not latest.is_symlink()
+    assert stable_dir.exists()
+
+
+def test_equivalent_semantic_base_prerelease_dirs_retained_with_latest(tmp_path):
+    """Equivalent winning spellings of semantic base 2.8 are all retained.
+
+    v2.8-open.1, v2.8.0-closed.1, and v2.8.0.0 all resolve to semantic base 2.8
+    and win over the older stable v2.7.14, so every equivalent-base directory
+    survives and the latest pointer targeting a retained directory stays valid:
+    width-6 normalization collapses (2, 8) and (2, 8, 0) into one stream so
+    every spelling is retained.
+    """
+    dl = _make_downloader(tmp_path)
+    app_dir = tmp_path / APP_DIR_NAME
+    prerelease_base = app_dir / "prerelease"
+    stable_dir = app_dir / "v2.7.14"
+    stable_dir.mkdir(parents=True)
+    (stable_dir / "app-universal.apk").write_bytes(b"apk")
+    equivalent_tags = ["v2.8-open.1", "v2.8.0-closed.1", "v2.8.0.0"]
+    for tag in equivalent_tags:
+        version_dir = prerelease_base / tag
+        version_dir.mkdir(parents=True)
+        (version_dir / "app-universal.apk").write_bytes(b"apk")
+    latest = prerelease_base / LATEST_POINTER_NAME
+    try:
+        os.symlink("v2.8.0-closed.1", latest)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks are not supported in this test environment")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[
+            Release(tag_name="v2.7.14", prerelease=False),
+            *[Release(tag_name=tag, prerelease=True) for tag in equivalent_tags],
+        ]
+    )
+
+    for tag in equivalent_tags:
+        assert (prerelease_base / tag).exists()
+    assert latest.is_symlink()
+    assert (prerelease_base / os.readlink(latest)).exists()
+    assert stable_dir.exists()
+
+
+def test_production_stable_with_higher_base_prerelease_retained_with_latest(tmp_path):
+    """Cleanup guard: stable v2.7.14 + winning v2.8.0-closed.8 stay valid.
+
+    Locks the already-correct production path so the semantic-base
+    normalization fix cannot regress the ordinary higher-base prerelease
+    retention case. Both directories survive and the latest pointer targeting
+    the retained prerelease directory remains valid.
+    """
+    dl = _make_downloader(tmp_path)
+    app_dir = tmp_path / APP_DIR_NAME
+    prerelease_base = app_dir / "prerelease"
+    stable_dir = app_dir / "v2.7.14"
+    stable_dir.mkdir(parents=True)
+    (stable_dir / "app-universal.apk").write_bytes(b"apk")
+    prerelease_dir = prerelease_base / "v2.8.0-closed.8"
+    prerelease_dir.mkdir(parents=True)
+    (prerelease_dir / "app-universal.apk").write_bytes(b"apk")
+    latest = prerelease_base / LATEST_POINTER_NAME
+    try:
+        os.symlink("v2.8.0-closed.8", latest)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks are not supported in this test environment")
+
+    dl.cleanup_prerelease_directories(
+        cached_releases=[
+            Release(tag_name="v2.7.14", prerelease=False),
+            Release(tag_name="v2.8.0-closed.8", prerelease=True),
+        ]
+    )
+
+    assert stable_dir.exists()
+    assert prerelease_dir.exists()
+    assert latest.is_symlink()
+    assert (prerelease_base / os.readlink(latest)).exists()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR hardens client-app prerelease selection and cleanup by using a single deterministic “highest eligible base” policy end-to-end (selection, orchestration ordering, and latest-pointer updates), and by validating/removing unsafe managed `latest` symlinks during prerelease directory cleanup. It also updates tests to cover the revised eligibility rules, deterministic ordering, and correct behavior on partial download failures.

## Key changes

**Features**
- Rewrote prerelease selection to compute the latest genuine stable base deterministically and select the “active” prereleases from the single highest eligible prerelease base using version-tuple comparisons.
- Updated `handle_prereleases()` and `get_latest_prerelease_tag()` to follow the same selection policy, including explicit handling of snapshot prereleases and parseable vs. unparseable prerelease/stable versions.
- Enhanced `handle_prereleases()` to optionally narrow results using commit short-hashes extracted from `recent_commits`.
- Added/expanded tests validating selection eligibility, snapshot exclusion, deterministic ordering (by `published_at` then tag tie-break), agreement between `handle_prereleases()` and `get_latest_prerelease_tag()`, and version normalization invariants.

**Fixes**
- Fixed cleanup safety around “latest” pointers by importing and using `remove_latest_pointer` to validate and remove managed `latest` symlinks when:
  - their target is missing/unsafe/not in the retained set, or
  - the `latest` entry itself is invalid
  - (applied for prerelease directory cleanup, including checks in both stable app and prerelease directories).
- Ensured higher (minor/patch) prereleases can remain eligible over older stable releases when they are on a higher eligible version base.
- Prevented transaction side effects on partial failures: orchestration advances prerelease tracking and updates the latest pointer only after all selected prerelease assets download successfully; on a failure, it attempts the assets but does not advance tracking/pointer.

**Refactors**
- Centralized and updated prerelease selection logic in `client_app.py` to rely on version-tuple comparisons (including width-6 normalization behavior) rather than string-prefix ranking.
- Updated and expanded test coverage to reflect the new policy and contracts across downloading, reporting, storage path expectations, and unified cleanup behavior.

## Breaking changes / migration
None indicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->