### PR TITLE
Add opt-in firmware nightlies and fix prerelease selection across version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Downloads are organized in a clean structure:
 │   ├── v2.3.2/
 │   ├── v2.3.1/
 │   ├── repo-dls/      # Repository browser downloads
-│   └── prerelease/    # Prerelease firmware (optional)
+│   ├── prerelease/    # Prerelease firmware (optional)
+│   └── nightlies/     # Rolling experimental firmware nightlies (opt-in)
 ```
 
 APKs and desktop installers intentionally share `app/<version>/` because they are treated as client app assets from the same release pipeline.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,8 +85,23 @@ Use `SELECTED_APP_ASSETS` for new configs. It is the authoritative client app se
 | `FILTER_REVOKED_RELEASES`             | `true`       | Excludes revoked firmware releases from normal selection and latest eligibility.             |
 | `ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES` | `true`       | Adds channel suffixes such as `-beta` or `-rc` to firmware directory names where needed.     |
 | `PRESERVE_LEGACY_FIRMWARE_BASE_DIRS`  | `true`       | Keeps legacy firmware base directories during cleanup when channel-suffixed storage is used. |
+| `CHECK_FIRMWARE_NIGHTLIES`            | `false`      | Opt-in for rolling experimental firmware nightly builds. Disabled unless explicitly enabled. |
+| `FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP`   | `1`          | Number of nightly build directories to retain when nightlies are enabled. Minimum 1.         |
+| `NOTIFY_ON_FIRMWARE_NIGHTLIES`        | `false`      | Include firmware nightly builds in NTFY notifications. Does not affect local logs or counts. |
 
 Firmware `latest` points only to a complete release with at least one selected non-manifest firmware payload asset. Manifest-only releases and revoked-release skips do not qualify.
+
+### Firmware Nightly Builds
+
+When `CHECK_FIRMWARE_NIGHTLIES` is enabled, Fetchtastic checks a rolling experimental firmware source at `meshtastic.github.io/firmware-nightly`. This is a flat directory that is replaced on every push to the firmware `main` branch; it is not a GitHub Release, not a tagged release, and not a production release. Existing configurations remain disabled unless you opt in.
+
+Nightly builds are stored separately from stable and prerelease firmware under `firmware/nightlies/<build_id>/`, where `<build_id>` is the immutable build identity parsed from the single release-level manifest (`firmware-<version>.<hash>.json`, for example `firmware-2.8.0.f52e2ea.json` → `2.8.0.f52e2ea`). A best-effort `latest_firmware_nightly.json` pointer is written inside `firmware/nightlies/`.
+
+`FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP` (default `1`, minimum `1` when nightlies are enabled) controls how many nightly build directories are retained when cleanup runs. Because each push replaces the rolling build, older build directories are pruned as new builds arrive.
+
+`NOTIFY_ON_FIRMWARE_NIGHTLIES` (default `false`) controls whether nightly downloads trigger NTFY notifications. When disabled, nightly downloads are still logged locally and counted in download summaries, but no push notification is sent.
+
+Nightly asset selection reuses `SELECTED_FIRMWARE_ASSETS` patterns; there is no separate selection key for nightlies.
 
 ## Firmware Extraction
 
@@ -115,6 +130,10 @@ There are two prerelease paths:
 | `FIRMWARE_PRERELEASE_EXCLUDE_PATTERNS` | unset               | Optional exclude filter for firmware repo-prerelease directory names. |
 
 Repo-prerelease latest is chronology-first. Fetchtastic prefers prerelease history `added_at` / commit chronology for real active history entries, and falls back to deterministic prerelease directory ordering only when chronology is unavailable.
+
+### Prerelease Admission
+
+Firmware repo-prerelease selection admits any active prerelease base whose parsed release is strictly newer than the latest stable release. This includes higher minor versions: for example, when the latest stable firmware is `2.7.26`, an active `2.8.x` prerelease base is admitted. Bases equal to or older than stable, and bases that cannot be parsed, are rejected. The latest stable release is the admission floor; there is no separate higher-minor cutoff.
 
 ## Download Reliability
 
@@ -164,6 +183,11 @@ FIRMWARE_VERSIONS_TO_KEEP: 2
 KEEP_LAST_BETA: false
 FILTER_REVOKED_RELEASES: true
 CREATE_LATEST_SYMLINKS: true
+
+# Firmware nightly builds (opt-in, disabled by default)
+CHECK_FIRMWARE_NIGHTLIES: false
+FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP: 1
+NOTIFY_ON_FIRMWARE_NIGHTLIES: false
 
 AUTO_EXTRACT: true
 EXTRACT_PATTERNS:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,7 +95,10 @@ Firmware `latest` points only to a complete release with at least one selected n
 
 When `CHECK_FIRMWARE_NIGHTLIES` is enabled, Fetchtastic checks a rolling experimental firmware source at `meshtastic.github.io/firmware-nightly`. This is a flat directory that is replaced on every push to the firmware `main` branch; it is not a GitHub Release, not a tagged release, and not a production release. Existing configurations remain disabled unless you opt in.
 
-Nightly builds are stored separately from stable and prerelease firmware under `firmware/nightlies/<build_id>/`, where `<build_id>` is the immutable build identity parsed from the single release-level manifest (`firmware-<version>.<hash>.json`, for example `firmware-2.8.0.f52e2ea.json` → `2.8.0.f52e2ea`). A best-effort `latest_firmware_nightly.json` pointer is written inside `firmware/nightlies/`.
+Nightly builds are stored separately from stable and prerelease firmware under `firmware/nightlies/<build_id>/`, where `<build_id>` is the immutable build identity parsed from the single release-level manifest (`firmware-<version>.<hash>.json`, for example `firmware-2.8.0.f52e2ea.json` → `2.8.0.f52e2ea`). Two distinct artifacts track the newest nightly, and they must not be confused:
+
+- **Cache tracking file** `latest_firmware_nightly.json` lives in the fetchtastic cache directory and records the build-id that has been fully downloaded and tracked. It is written only after every selected asset downloads and validates successfully.
+- **Filesystem `latest` pointer** is an optional relative symlink `firmware/nightlies/latest` pointing at the retained build directory. It is created only when `CREATE_LATEST_SYMLINKS` is enabled, and only after the same successful transaction that writes the cache tracking file.
 
 `FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP` (default `1`, minimum `1` when nightlies are enabled) controls how many nightly build directories are retained when cleanup runs. Because each push replaces the rolling build, older build directories are pruned as new builds arrive.
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -168,8 +168,10 @@ Fetchtastic organizes downloads in a structured way:
 │   ├── v2.3.1/
 │   ├── repo-dls/
 │   │   └── firmware/
-│   └── prerelease/ (if enabled)
-│       └── v2.3.3.abcdef/
+│   ├── prerelease/ (if enabled)
+│   │   └── v2.3.3.abcdef/
+│   └── nightlies/ (if enabled)
+│       └── 2.8.0.f52e2ea/    # rolling experimental nightly build
 ```
 
 APKs and desktop installers intentionally share `app/<version>/` because they are treated as client app assets from the same release pipeline.
@@ -294,7 +296,11 @@ Tips:
 
 ### Pre-release Downloads
 
-Enable pre-release downloads to get the latest development firmware from meshtastic.github.io.
+Enable pre-release downloads to get the latest development firmware from meshtastic.github.io. Firmware repo-prerelease selection admits any active prerelease base strictly newer than the latest stable release, including higher minor versions (for example, a `2.8.x` base when stable is `2.7.x`); bases equal to or older than stable are rejected.
+
+### Firmware Nightly Builds
+
+Separate from prereleases, Fetchtastic can download rolling experimental firmware nightly builds from `meshtastic.github.io/firmware-nightly`. These are not production releases: the rolling directory is replaced on every push to firmware `main`. The feature is opt-in (`CHECK_FIRMWARE_NIGHTLIES`, default off) and stores builds under `firmware/nightlies/<build_id>/`. `FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP` (default `1`) controls how many builds are kept, and `NOTIFY_ON_FIRMWARE_NIGHTLIES` (default off) controls NTFY notifications. See the [Configuration Reference](configuration.md) for details.
 
 ### Multiple Asset Types
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -75,7 +75,7 @@ fetchtastic setup
 
 **Auto-extraction**: Automatically extract specific files from firmware zip archives
 
-**Pre-releases**: Download pre-release firmware from meshtastic.github.io
+**Prereleases**: Download prerelease firmware from meshtastic.github.io
 
 **Notifications**: Set up NTFY push notifications
 
@@ -294,9 +294,9 @@ Tips:
 - Device patterns like `heltec-` automatically match both firmware files (`firmware-heltec-*`) and LittleFS files (`littlefs-heltec-*`) - no need to specify both.
 - You can adjust patterns later by re-running `fetchtastic setup` and updating your selections.
 
-### Pre-release Downloads
+### Prerelease Downloads
 
-Enable pre-release downloads to get the latest development firmware from meshtastic.github.io. Firmware repo-prerelease selection admits any active prerelease base strictly newer than the latest stable release, including higher minor versions (for example, a `2.8.x` base when stable is `2.7.x`); bases equal to or older than stable are rejected.
+Enable prerelease downloads to get the latest development firmware from meshtastic.github.io. Firmware repo-prerelease selection admits any active prerelease base strictly newer than the latest stable release, including higher minor versions (for example, a `2.8.x` base when stable is `2.7.x`); bases equal to or older than stable are rejected.
 
 ### Firmware Nightly Builds
 

--- a/src/fetchtastic/constants.py
+++ b/src/fetchtastic/constants.py
@@ -5,6 +5,8 @@ This module contains all hardcoded values, URLs, timeouts, and other constants
 used throughout the application.
 """
 
+from enum import Enum
+
 # GitHub API URLs
 GITHUB_API_BASE = "https://api.github.com/repos"
 MESHTASTIC_ANDROID_RELEASES_URL = (
@@ -324,3 +326,17 @@ ANDROID_ARCHITECTURES = {
 }
 
 DEFAULT_ARCH_PREFERENCE = "universal"
+
+
+class NightlyRunState(Enum):
+    """Run-scoped state of the firmware-nightly transaction.
+
+    Reported outcomes are derived from this state rather than from individual
+    nightly asset download results, so that only a fully finalized transaction
+    (every asset valid AND tracking persisted) is surfaced as a download.
+    """
+
+    UNCHECKED = "unchecked"
+    ALREADY_COMPLETE = "already_complete"
+    ATTEMPTED_INCOMPLETE = "attempted_incomplete"
+    FINALIZED = "finalized"

--- a/src/fetchtastic/constants.py
+++ b/src/fetchtastic/constants.py
@@ -333,10 +333,37 @@ class NightlyRunState(Enum):
 
     Reported outcomes are derived from this state rather than from individual
     nightly asset download results, so that only a fully finalized transaction
-    (every asset valid AND tracking persisted) is surfaced as a download.
+    (every asset valid AND tracking persisted) with at least one genuinely
+    downloaded asset (``was_skipped=False``) is surfaced as a download.
+
+    State hierarchy:
+
+    - ``UNCHECKED`` — nightlies not processed (disabled, or pipeline not reached).
+    - ``CHECK_FAILED`` — source fetch error, malformed listing, or ambiguous
+      generation (zero/multiple unique build-ids). Not a download; not
+      "up to date"; distinct from an empty-but-valid listing.
+    - ``MAINTENANCE_ONLY`` — build already tracked and complete; retention,
+      pointer, and executable-metadata repair ran without rewriting tracking
+      or reporting a download. Also set when a transaction finalizes but every
+      selected asset was ``was_skipped=True`` (reconciliation, not download).
+    - ``ALREADY_COMPLETE`` — legacy alias retained for tests that predate
+      ``MAINTENANCE_ONLY``; set when ``should_process_nightly`` returns False
+      before maintenance runs.
+    - ``ATTEMPTED_INCOMPLETE`` — assets were downloaded but at least one
+      failed; tracking, pointer, and cleanup deferred. Tracking failure
+      during finalization also lands here.
+    - ``FINALIZED_WITH_DOWNLOAD`` — every selected asset valid, tracking
+      persisted, and at least one asset was genuinely downloaded
+      (``was_skipped=False``). This is the only state that surfaces as a
+      download in reporting/notifications.
+    - ``FINALIZED`` — retained for backward compatibility with existing
+      tests; production code sets ``FINALIZED_WITH_DOWNLOAD`` instead.
     """
 
     UNCHECKED = "unchecked"
+    CHECK_FAILED = "check_failed"
     ALREADY_COMPLETE = "already_complete"
+    MAINTENANCE_ONLY = "maintenance_only"
     ATTEMPTED_INCOMPLETE = "attempted_incomplete"
+    FINALIZED_WITH_DOWNLOAD = "finalized_with_download"
     FINALIZED = "finalized"

--- a/src/fetchtastic/constants.py
+++ b/src/fetchtastic/constants.py
@@ -50,6 +50,11 @@ DESKTOP_PRERELEASES_DIR_NAME = "prerelease"
 APP_SNAPSHOTS_DIR_NAME = "snapshots"
 FIRMWARE_DIR_PREFIX = "firmware-"
 FIRMWARE_DIR_NAME = "firmware"
+# Opt-in rolling firmware-nightly source (meshtastic.github.io/firmware-nightly).
+# Separate from the CI workflow named "nightly", from stable firmware releases,
+# and from prerelease firmware directories.
+FIRMWARE_NIGHTLY_SOURCE_DIR = "firmware-nightly"
+FIRMWARE_NIGHTLIES_DIR_NAME = "nightlies"
 APKS_DIR_NAME = "apks"
 APP_DIR_NAME = "app"
 LATEST_POINTER_NAME = "latest"
@@ -62,6 +67,7 @@ DESKTOP_DIR_NAME = APP_DIR_NAME
 LATEST_ANDROID_RELEASE_JSON_FILE = "latest_android_release.json"
 LATEST_ANDROID_PRERELEASE_JSON_FILE = "latest_android_prerelease.json"
 LATEST_FIRMWARE_PRERELEASE_JSON_FILE = "latest_firmware_prerelease.json"
+LATEST_FIRMWARE_NIGHTLY_JSON_FILE = "latest_firmware_nightly.json"
 LATEST_FIRMWARE_RELEASE_JSON_FILE = "latest_firmware_release.json"
 LATEST_DESKTOP_RELEASE_JSON_FILE = "latest_desktop_release.json"
 LATEST_DESKTOP_PRERELEASE_JSON_FILE = "latest_desktop_prerelease.json"
@@ -99,6 +105,10 @@ DEFAULT_CHECK_APP_PRERELEASES = True
 DEFAULT_CHECK_APP_SNAPSHOTS = False
 DEFAULT_NOTIFY_ON_SNAPSHOTS = False
 DEFAULT_APP_SNAPSHOT_VERSIONS_TO_KEEP = 1
+# Opt-in firmware-nightly defaults: disabled, non-notifying, keep latest build only.
+DEFAULT_CHECK_FIRMWARE_NIGHTLIES = False
+DEFAULT_NOTIFY_ON_FIRMWARE_NIGHTLIES = False
+DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP = 1
 DEFAULT_DESKTOP_VERSIONS_TO_KEEP = 2
 DEFAULT_ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES = True
 DEFAULT_PRESERVE_LEGACY_FIRMWARE_BASE_DIRS = True
@@ -110,6 +120,13 @@ EXECUTABLE_PERMISSIONS = 0o755
 
 # Snapshot debug-build versionCode pattern (shared to avoid divergence)
 SNAPSHOT_VERSION_CODE_PATTERN = r"-debug-(\d+)\.apk$"
+
+# Firmware-nightly release-manifest build-id pattern.
+# Matches only the single release-level manifest (firmware-<version>.<hash>.json)
+# and rejects per-device manifests (firmware-<device>-<version>.<hash>.mt.json),
+# firmware zips, and unrelated files.  The captured build-id (e.g. 2.8.0.f52e2ea)
+# is the immutable identity for the whole nightly build.  Apply with re.IGNORECASE.
+FIRMWARE_NIGHTLY_MANIFEST_PATTERN = r"^firmware-(\d+\.\d+\.\d+\.[a-f0-9]{6,})\.json$"
 
 # Download configuration defaults
 DEFAULT_CONNECT_RETRIES = 5
@@ -257,6 +274,14 @@ FILE_TYPE_FIRMWARE = "firmware"
 FILE_TYPE_FIRMWARE_PRERELEASE = "firmware_prerelease"
 FILE_TYPE_FIRMWARE_PRERELEASE_REPO = "firmware_prerelease_repo"
 FILE_TYPE_FIRMWARE_MANIFEST = "firmware_manifest"
+# Rolling firmware-nightly build (identity is the build-id, not a release tag).
+# Deliberately NOT a member of FIRMWARE_FILE_TYPES: that set drives the stable/
+# prerelease notification-summary path in cli_integration (the is_firmware
+# branch treats every member as a versioned firmware release).  Nightly builds
+# are a separate rolling identity and notify off by default, so they follow the
+# FILE_TYPE_APP_SNAPSHOT precedent: a standalone type handled by a dedicated
+# path rather than the generic firmware-summary bucket.
+FILE_TYPE_FIRMWARE_NIGHTLY = "firmware_nightly"
 FILE_TYPE_DESKTOP = "desktop"
 FILE_TYPE_DESKTOP_PRERELEASE = "desktop_prerelease"
 FILE_TYPE_REPOSITORY = "repository"

--- a/src/fetchtastic/download/cli_integration.py
+++ b/src/fetchtastic/download/cli_integration.py
@@ -22,6 +22,7 @@ from fetchtastic.client_release_discovery import (
 from fetchtastic.constants import (
     ANDROID_FILE_TYPES,
     CLIENT_APP_FILE_TYPES,
+    DEFAULT_NOTIFY_ON_FIRMWARE_NIGHTLIES,
     DEFAULT_NOTIFY_ON_SNAPSHOTS,
     DESKTOP_FILE_TYPES,
     FILE_TYPE_ANDROID,
@@ -33,6 +34,7 @@ from fetchtastic.constants import (
     FILE_TYPE_DESKTOP_PRERELEASE,
     FILE_TYPE_FIRMWARE,
     FILE_TYPE_FIRMWARE_MANIFEST,
+    FILE_TYPE_FIRMWARE_NIGHTLY,
     FILE_TYPE_FIRMWARE_PRERELEASE,
     FILE_TYPE_FIRMWARE_PRERELEASE_REPO,
     FILE_TYPE_REPOSITORY,
@@ -437,7 +439,38 @@ class DownloadCLIIntegration:
             else []
         )
 
-        # Actual download count includes snapshots for local reporting.
+        # Firmware nightly builds — collected explicitly (kept out of
+        # FIRMWARE_FILE_TYPES) like app snapshots.  Always counted locally;
+        # NTFY inclusion is gated by NOTIFY_ON_FIRMWARE_NIGHTLIES (default
+        # False).
+        downloaded_firmware_nightlies: list[str] = []
+        if self.orchestrator:
+            for result in self.orchestrator.download_results:
+                if (
+                    getattr(result, "file_type", "") == FILE_TYPE_FIRMWARE_NIGHTLY
+                    and getattr(result, "success", False)
+                    and not getattr(result, "was_skipped", False)
+                ):
+                    tag = getattr(result, "release_tag", None)
+                    if tag and tag not in downloaded_firmware_nightlies:
+                        downloaded_firmware_nightlies.append(tag)
+
+        notified_firmware_nightlies = (
+            downloaded_firmware_nightlies
+            if (
+                self.config
+                and coerce_bool(
+                    self.config.get(
+                        "NOTIFY_ON_FIRMWARE_NIGHTLIES",
+                        DEFAULT_NOTIFY_ON_FIRMWARE_NIGHTLIES,
+                    )
+                )
+            )
+            else []
+        )
+
+        # Actual download count includes snapshots and firmware nightlies for
+        # local reporting.
         downloaded_count = (
             len(downloaded_firmwares)
             + len(downloaded_apks)
@@ -446,12 +479,15 @@ class DownloadCLIIntegration:
             + len(downloaded_apk_prereleases)
             + len(downloaded_desktop_prereleases)
             + len(downloaded_app_snapshots)
+            + len(downloaded_firmware_nightlies)
         )
-        # Notifiable count excludes snapshots when NOTIFY_ON_SNAPSHOTS is False.
+        # Notifiable count excludes snapshots/nightlies when their gates are False.
         notifiable_count = (
             downloaded_count
             - len(downloaded_app_snapshots)
             + len(notified_app_snapshots)
+            - len(downloaded_firmware_nightlies)
+            + len(notified_firmware_nightlies)
         )
         if downloaded_count > 0:
             log.info(f"Downloaded {downloaded_count} new versions")
@@ -495,6 +531,12 @@ class DownloadCLIIntegration:
                 ", ".join(downloaded_app_snapshots),
             )
 
+        if downloaded_firmware_nightlies:
+            log.info(
+                "Downloaded firmware nightly builds: %s",
+                ", ".join(downloaded_firmware_nightlies),
+            )
+
         if failed_downloads:
             log.info(f"{len(failed_downloads)} downloads failed:")
             for failure in failed_downloads:
@@ -534,6 +576,7 @@ class DownloadCLIIntegration:
                     downloaded_desktop,
                     downloaded_desktop_prereleases,
                     downloaded_app_snapshots=notified_app_snapshots,
+                    downloaded_firmware_nightlies=notified_firmware_nightlies,
                 )
             elif downloaded_count > 0:
                 # Downloads occurred (e.g. snapshot-only with notifications

--- a/src/fetchtastic/download/cli_integration.py
+++ b/src/fetchtastic/download/cli_integration.py
@@ -440,15 +440,16 @@ class DownloadCLIIntegration:
         )
 
         # Firmware nightly builds — reported only when the transaction
-        # finalized (every asset valid AND tracking persisted). Asset-level
-        # DownloadResults remain on the orchestrator for diagnostics but are
-        # NOT reported here, so a partially-downloaded or unfinalized nightly
-        # is never surfaced as a completed build. NTFY inclusion is gated by
+        # finalized WITH an actual download (at least one asset had
+        # ``was_skipped=False``). ``MAINTENANCE_ONLY`` (tracking-only
+        # reconciliation / already-complete maintenance) and ``CHECK_FAILED``
+        # never surface as a download. NTFY inclusion is gated by
         # NOTIFY_ON_FIRMWARE_NIGHTLIES (default False).
         downloaded_firmware_nightlies: list[str] = []
         if (
             self.orchestrator
-            and self.orchestrator.nightly_run_state == NightlyRunState.FINALIZED
+            and self.orchestrator.nightly_run_state
+            == NightlyRunState.FINALIZED_WITH_DOWNLOAD
             and self.orchestrator.latest_firmware_nightly_build_id
         ):
             downloaded_firmware_nightlies.append(
@@ -550,13 +551,18 @@ class DownloadCLIIntegration:
                     f"URL={url} retryable={retryable} http_status={http_status} error={error}"
                 )
 
-        # A nightly transaction that was attempted but not finalized must
-        # suppress the generic up-to-date log/NTFY — it is a distinct failure
-        # state, not "up to date".
+        # A nightly transaction that was attempted but not finalized, or whose
+        # source check failed, must suppress the generic up-to-date log/NTFY —
+        # these are distinct failure states, not "up to date". MAINTENANCE_ONLY
+        # (already-complete reconciliation) is NOT incomplete and allows the
+        # up-to-date message when nothing else was downloaded.
         nightly_incomplete = (
             self.orchestrator is not None
             and self.orchestrator.nightly_run_state
-            == NightlyRunState.ATTEMPTED_INCOMPLETE
+            in (
+                NightlyRunState.ATTEMPTED_INCOMPLETE,
+                NightlyRunState.CHECK_FAILED,
+            )
         )
 
         if downloaded_count == 0 and not failed_downloads and not nightly_incomplete:
@@ -566,6 +572,28 @@ class DownloadCLIIntegration:
             )
         elif downloaded_count == 0 and failed_downloads:
             log.info("All attempted downloads failed; check logs for details.")
+        elif (
+            downloaded_count == 0
+            and not failed_downloads
+            and nightly_incomplete
+            and self.orchestrator is not None
+        ):
+            # Zero downloads, no asset-level failures, but the nightly
+            # transaction itself is incomplete or the source check failed.
+            # Emit a local summary so the user sees the distinct state
+            # instead of silence. Up-to-date is excluded; the existing
+            # all-attempted-failed branch above handles asset failures.
+            nightly_state = self.orchestrator.nightly_run_state
+            if nightly_state == NightlyRunState.CHECK_FAILED:
+                log.info(
+                    "Firmware nightly check failed; see logs for details. "
+                    "No new versions downloaded."
+                )
+            else:
+                log.info(
+                    "Firmware nightly build incomplete; tracking, latest "
+                    "pointer, and cleanup deferred. No new versions downloaded."
+                )
 
         new_versions_available = bool(
             (new_firmware_versions or [])

--- a/src/fetchtastic/download/cli_integration.py
+++ b/src/fetchtastic/download/cli_integration.py
@@ -34,13 +34,13 @@ from fetchtastic.constants import (
     FILE_TYPE_DESKTOP_PRERELEASE,
     FILE_TYPE_FIRMWARE,
     FILE_TYPE_FIRMWARE_MANIFEST,
-    FILE_TYPE_FIRMWARE_NIGHTLY,
     FILE_TYPE_FIRMWARE_PRERELEASE,
     FILE_TYPE_FIRMWARE_PRERELEASE_REPO,
     FILE_TYPE_REPOSITORY,
     FIRMWARE_DIR_PREFIX,
     FIRMWARE_FILE_TYPES,
     SNAPSHOT_VERSION_CODE_PATTERN,
+    NightlyRunState,
 )
 from fetchtastic.log_utils import logger
 from fetchtastic.notifications import (
@@ -439,21 +439,21 @@ class DownloadCLIIntegration:
             else []
         )
 
-        # Firmware nightly builds — collected explicitly (kept out of
-        # FIRMWARE_FILE_TYPES) like app snapshots.  Always counted locally;
-        # NTFY inclusion is gated by NOTIFY_ON_FIRMWARE_NIGHTLIES (default
-        # False).
+        # Firmware nightly builds — reported only when the transaction
+        # finalized (every asset valid AND tracking persisted). Asset-level
+        # DownloadResults remain on the orchestrator for diagnostics but are
+        # NOT reported here, so a partially-downloaded or unfinalized nightly
+        # is never surfaced as a completed build. NTFY inclusion is gated by
+        # NOTIFY_ON_FIRMWARE_NIGHTLIES (default False).
         downloaded_firmware_nightlies: list[str] = []
-        if self.orchestrator:
-            for result in self.orchestrator.download_results:
-                if (
-                    getattr(result, "file_type", "") == FILE_TYPE_FIRMWARE_NIGHTLY
-                    and getattr(result, "success", False)
-                    and not getattr(result, "was_skipped", False)
-                ):
-                    tag = getattr(result, "release_tag", None)
-                    if tag and tag not in downloaded_firmware_nightlies:
-                        downloaded_firmware_nightlies.append(tag)
+        if (
+            self.orchestrator
+            and self.orchestrator.nightly_run_state == NightlyRunState.FINALIZED
+            and self.orchestrator.latest_firmware_nightly_build_id
+        ):
+            downloaded_firmware_nightlies.append(
+                self.orchestrator.latest_firmware_nightly_build_id
+            )
 
         notified_firmware_nightlies = (
             downloaded_firmware_nightlies
@@ -550,7 +550,16 @@ class DownloadCLIIntegration:
                     f"URL={url} retryable={retryable} http_status={http_status} error={error}"
                 )
 
-        if downloaded_count == 0 and not failed_downloads:
+        # A nightly transaction that was attempted but not finalized must
+        # suppress the generic up-to-date log/NTFY — it is a distinct failure
+        # state, not "up to date".
+        nightly_incomplete = (
+            self.orchestrator is not None
+            and self.orchestrator.nightly_run_state
+            == NightlyRunState.ATTEMPTED_INCOMPLETE
+        )
+
+        if downloaded_count == 0 and not failed_downloads and not nightly_incomplete:
             log.info(
                 "All assets are up to date.\n%s",
                 time.strftime("%Y-%m-%dT%H:%M:%S%z"),
@@ -589,7 +598,11 @@ class DownloadCLIIntegration:
                     self.orchestrator.available_new_apk_versions,
                     downloads_skipped_reason="Downloads skipped: not connected to Wi-Fi.",
                 )
-            elif not failed_downloads and not new_versions_available:
+            elif (
+                not failed_downloads
+                and not new_versions_available
+                and not nightly_incomplete
+            ):
                 send_up_to_date_notification(self.config)
 
         summary = get_api_request_summary()

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -2789,10 +2789,15 @@ class FirmwareReleaseDownloader(BaseDownloader):
             github_token=self.config.get("GITHUB_TOKEN"),
             allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
         )
-        if not contents:
+        # Validate type before emptiness: a falsy non-list response ("", {},
+        # 0, False, (), set()) must NOT be collapsed into a successful empty
+        # listing. Only ``None`` and ``[]`` are valid empty source results.
+        if contents is None:
             return []
         if not isinstance(contents, list):
             raise ValueError("firmware-nightly source response is not a list")
+        if not contents:
+            return []
         validated: List[Dict[str, Any]] = []
         for entry in contents:
             if not isinstance(entry, dict):

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -64,10 +64,17 @@ from fetchtastic.utils import (
 
 from .base import BaseDownloader
 from .cache import CacheManager, parse_iso_datetime_utc
-from .files import build_storage_tag_with_channel, get_channel_suffix
+from .files import (
+    _is_within_base,
+    _prepare_for_redownload,
+    _safe_rmtree,
+    build_storage_tag_with_channel,
+    get_channel_suffix,
+    is_zip_intact,
+)
 from .github_source import GithubReleaseSource, create_release_from_github_data
 from .interfaces import Asset, DownloadResult, FirmwareManifest, Release
-from .latest_pointer import update_latest_pointer
+from .latest_pointer import remove_latest_pointer, update_latest_pointer
 from .prerelease_history import PrereleaseHistoryManager
 from .release_history import ReleaseHistoryManager
 from .version import VersionManager
@@ -2400,15 +2407,20 @@ class FirmwareReleaseDownloader(BaseDownloader):
         )
 
         deleted_dirs = self._get_deleted_prerelease_dirs_from_history(history_entries)
-        active_candidate_dirs = [
-            entry.get("directory")
-            for entry in history_entries
-            if isinstance(entry.get("directory"), str)
-            and entry.get("directory") not in deleted_dirs
-            and (entry.get("status") == "active" or entry.get("active") is True)
-            and entry.get("status") != "deleted"
-            and not entry.get("removed_at")
-        ]
+        active_candidate_dirs: List[str] = []
+        for entry in history_entries:
+            directory_value: Any = entry.get("directory")
+            if not isinstance(directory_value, str):
+                continue
+            if directory_value in deleted_dirs:
+                continue
+            if not (entry.get("status") == "active" or entry.get("active") is True):
+                continue
+            if entry.get("status") == "deleted":
+                continue
+            if entry.get("removed_at"):
+                continue
+            active_candidate_dirs.append(directory_value)
         latest_active_dir = self._select_latest_prerelease_dir(
             active_candidate_dirs, history_entries
         )
@@ -2801,18 +2813,65 @@ class FirmwareReleaseDownloader(BaseDownloader):
         return None
 
     def _ensure_nightly_base_dir(self) -> str:
-        """Create (if absent) and return ``firmware/nightlies/``."""
+        """Create (if absent) and return ``firmware/nightlies/`` after safety checks."""
         base = os.path.join(
             self.download_dir, FIRMWARE_DIR_NAME, FIRMWARE_NIGHTLIES_DIR_NAME
         )
         os.makedirs(base, exist_ok=True)
         return base
 
-    def _resolve_nightly_dir(self, build_id: str) -> str:
-        """Create (if absent) and return ``firmware/nightlies/<build_id>/``."""
-        build_dir = os.path.join(self._ensure_nightly_base_dir(), build_id)
+    def _nightly_root_for_safety(self) -> str:
+        """Return the nightly root path without creating it (for safety checks)."""
+        return os.path.join(
+            self.download_dir, FIRMWARE_DIR_NAME, FIRMWARE_NIGHTLIES_DIR_NAME
+        )
+
+    def _validate_nightly_path_safety(self, build_id: str) -> str:
+        """
+        Validate the build-id and the managed path tree, then create and return
+        ``firmware/nightlies/<build_id>/``.
+
+        Safety rules:
+          - build_id must match the strict nightly build-id regex;
+          - the nightly root, firmware parent, and every managed ancestor must
+            be non-symlink directories;
+          - the resolved build path must remain under the resolved nightly root.
+
+        Raises ValueError on any violation so callers abort the transaction
+        rather than write through an escaped path.
+        """
+        if not isinstance(build_id, str) or not _NIGHTLY_BUILD_ID_RX.match(build_id):
+            raise ValueError(f"Unsafe firmware-nightly build_id: {build_id!r}")
+
+        root = self._nightly_root_for_safety()
+        firmware_parent = os.path.join(self.download_dir, FIRMWARE_DIR_NAME)
+        # Reject any symlink in the managed ancestor chain (root, firmware
+        # parent, download dir). Do not follow — that would allow escapes.
+        for ancestor in (root, firmware_parent, self.download_dir):
+            if os.path.islink(ancestor):
+                raise ValueError(
+                    f"Refusing firmware-nightly path through symlink ancestor: {ancestor}"
+                )
+
+        os.makedirs(root, exist_ok=True)
+        real_root = os.path.realpath(root)
+        build_dir = os.path.join(root, build_id)
+        if os.path.islink(build_dir):
+            raise ValueError(
+                f"Refusing firmware-nightly build path that is a symlink: {build_dir}"
+            )
+        real_build = os.path.realpath(build_dir)
+        if not _is_within_base(real_root, real_build):
+            raise ValueError(
+                f"Refusing firmware-nightly build path outside managed tree: {build_dir}"
+            )
+
         os.makedirs(build_dir, exist_ok=True)
         return build_dir
+
+    def _resolve_nightly_dir(self, build_id: str) -> str:
+        """Create (if absent) and safely return ``firmware/nightlies/<build_id>/``."""
+        return self._validate_nightly_path_safety(build_id)
 
     def get_nightly_target_path(
         self, build_id: str, name: str, *, create: bool = False
@@ -2820,8 +2879,8 @@ class FirmwareReleaseDownloader(BaseDownloader):
         """
         Resolve the storage path for a nightly asset under
         ``firmware/nightlies/<build_id>/<name>``.  When ``create`` is True the
-        build directory is created; otherwise the path is computed without
-        touching the filesystem.
+        build directory is created after passing path-safety validation;
+        otherwise the path is computed without touching the filesystem.
         """
         if create:
             base = self._resolve_nightly_dir(build_id)
@@ -3002,24 +3061,115 @@ class FirmwareReleaseDownloader(BaseDownloader):
         }
         return self.cache_manager.atomic_write_json(self._nightly_tracking_path(), data)
 
+    def _remove_nightly_target_and_hash(self, target_path: str) -> None:
+        """Remove a nightly asset target and its hash metadata without following symlinks.
+
+        A symlink at ``target_path`` (dangling or pointing outside the build
+        directory) is unlinked directly via ``os.unlink`` — the link itself is
+        removed, the external target is never touched or followed. After the
+        symlink (if any) is gone, the shared ``_prepare_for_redownload`` helper
+        removes any remaining regular file plus the current and legacy hash
+        sidecars and orphaned temp files so the next download starts clean.
+
+        This is the nightly-scoped cleanup seam: it does not alter the behavior
+        of ``_prepare_for_redownload`` for non-nightly callers, and it closes
+        the dangling-symlink gap (``_prepare_for_redownload`` alone uses
+        ``os.path.exists`` which follows symlinks and reports False for a
+        dangling link, leaving the link in place).
+        """
+        if os.path.islink(target_path):
+            try:
+                os.unlink(target_path)
+                logger.debug(
+                    "Removed nightly symlink target (link only): %s", target_path
+                )
+            except OSError as exc:
+                logger.warning(
+                    "Could not remove nightly symlink target %s: %s",
+                    target_path,
+                    exc,
+                )
+        _prepare_for_redownload(target_path)
+
+    def _validate_nightly_asset(
+        self, target_path: str, name: str, expected_size: Any
+    ) -> Tuple[bool, str]:
+        """
+        Validate a nightly asset on disk. Shared by the skip, fresh-download,
+        and retry paths so they apply identical rules.
+
+        Rules (all must hold):
+          - target must be a regular file and not a symlink;
+          - when ``expected_size`` is a positive int, the on-disk size must
+            match exactly;
+          - existing integrity / hash verification must pass;
+          - ZIP archives must pass ZIP integrity;
+          - release-level manifests (``firmware-<build>.json``) must be valid
+            JSON objects.
+
+        Returns ``(True, "")`` on success, otherwise ``(False, reason)``. The
+        caller is responsible for removing the target and any stored hash when
+        validation fails.
+        """
+        if os.path.islink(target_path) or not os.path.isfile(target_path):
+            return False, "target is not a regular file (symlink or missing)"
+
+        try:
+            actual_size = os.path.getsize(target_path)
+        except OSError as exc:
+            return False, f"could not stat target: {exc}"
+
+        if isinstance(expected_size, int) and expected_size > 0:
+            if actual_size != expected_size:
+                return False, (
+                    f"size mismatch: expected {expected_size}, got {actual_size}"
+                )
+
+        lower = name.lower()
+
+        if lower.endswith(".zip"):
+            if not is_zip_intact(target_path):
+                return False, "ZIP integrity check failed"
+
+        if self.parse_nightly_build_id(name) is not None:
+            try:
+                with open(target_path, "r", encoding="utf-8") as manifest_file:
+                    data = json.load(manifest_file)
+                if not isinstance(data, dict):
+                    return False, "release manifest is not a JSON object"
+            except (json.JSONDecodeError, OSError, ValueError) as exc:
+                return False, f"release manifest is not valid JSON: {exc}"
+
+        if not verify_file_integrity(target_path):
+            return False, "hash/integrity verification failed"
+
+        return True, ""
+
     def download_nightly_asset(
         self, entry: Dict[str, Any], build_id: str
     ) -> DownloadResult:
         """
         Download a single firmware-nightly entry into the build's directory and
-        return a structured DownloadResult.  Reuses the shared retry/integrity
-        helpers used by the prerelease path.
+        return a structured DownloadResult.
+
+        Path-safety, size, ZIP, manifest-JSON, and hash integrity are all
+        validated through :meth:`_validate_nightly_asset`. On any validation
+        failure the target and its stored hash are removed and the result is
+        marked non-retryable (``ERROR_TYPE_VALIDATION``). Network/download
+        failures remain retryable. The executable bit for ``*.sh`` payloads is
+        applied only after validation succeeds.
         """
         name = str(entry.get("name") or "")
         url = entry.get("download_url") or entry.get("browser_download_url")
         size = entry.get("size")
+        nightly_root = os.path.join(
+            self.download_dir, FIRMWARE_DIR_NAME, FIRMWARE_NIGHTLIES_DIR_NAME
+        )
         if not name or not url:
             return self.create_download_result(
                 success=False,
                 release_tag=build_id,
-                file_path=os.path.join(
-                    self.download_dir, FIRMWARE_DIR_NAME, FIRMWARE_NIGHTLIES_DIR_NAME
-                ),
+                file_path=nightly_root,
                 error_message="nightly entry missing name or download_url",
                 download_url=str(url) if url else None,
                 file_size=size,
@@ -3028,17 +3178,42 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 error_type=ERROR_TYPE_VALIDATION,
             )
 
-        target_path = self.get_nightly_target_path(build_id, name, create=True)
+        try:
+            target_path = self.get_nightly_target_path(build_id, name, create=True)
+        except ValueError as exc:
+            logger.error("Unsafe firmware-nightly path for %s: %s", name, exc)
+            return self.create_download_result(
+                success=False,
+                release_tag=build_id,
+                file_path=nightly_root,
+                error_message=f"unsafe nightly path: {exc}",
+                download_url=str(url),
+                file_size=size,
+                file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+                is_retryable=False,
+                error_type=ERROR_TYPE_VALIDATION,
+            )
 
-        # Skip if already present and intact.
+        # Reject any pre-existing symlink target before touching it. Unlink the
+        # link directly (never following it) so a dangling or escaping symlink is
+        # gone before any download could write through it.
+        if os.path.islink(target_path):
+            self._remove_nightly_target_and_hash(target_path)
+            return self.create_download_result(
+                success=False,
+                release_tag=build_id,
+                file_path=target_path,
+                error_message="nightly target is a symlink; refused and removed",
+                download_url=str(url),
+                file_size=size,
+                file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+                is_retryable=False,
+                error_type=ERROR_TYPE_VALIDATION,
+            )
+
+        # Skip if already present and fully valid.
         if os.path.exists(target_path):
-            ok = verify_file_integrity(target_path)
-            if ok and name.lower().endswith(".zip"):
-                try:
-                    with zipfile.ZipFile(target_path, "r") as zf:
-                        ok = zf.testzip() is None
-                except (zipfile.BadZipFile, IOError, OSError):
-                    ok = False
+            ok, reason = self._validate_nightly_asset(target_path, name, size)
             if ok:
                 logger.debug("Nightly asset already present and valid: %s", name)
                 return self.create_download_result(
@@ -3050,35 +3225,15 @@ class FirmwareReleaseDownloader(BaseDownloader):
                     file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
                     was_skipped=True,
                 )
+            logger.warning(
+                "Existing nightly asset %s failed validation (%s); re-downloading",
+                name,
+                reason,
+            )
+            self._remove_nightly_target_and_hash(target_path)
 
         try:
-            if download_file_with_retry(str(url), target_path):
-                if name.lower().endswith(".sh") and os.name != "nt":
-                    try:
-                        os.chmod(target_path, EXECUTABLE_PERMISSIONS)
-                    except OSError:
-                        pass
-                logger.info("Downloaded nightly asset %s", name)
-                return self.create_download_result(
-                    success=True,
-                    release_tag=build_id,
-                    file_path=target_path,
-                    download_url=str(url),
-                    file_size=size,
-                    file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
-                )
-            logger.error("Download failed for nightly asset %s", name)
-            return self.create_download_result(
-                success=False,
-                release_tag=build_id,
-                file_path=target_path,
-                error_message="download_file_with_retry returned False",
-                download_url=str(url),
-                file_size=size,
-                file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
-                is_retryable=True,
-                error_type=ERROR_TYPE_NETWORK,
-            )
+            downloaded = download_file_with_retry(str(url), target_path)
         except (requests.RequestException, OSError, ValueError) as exc:
             if isinstance(exc, requests.RequestException):
                 error_type = ERROR_TYPE_NETWORK
@@ -3101,6 +3256,57 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 error_type=error_type,
             )
 
+        if not downloaded:
+            logger.error("Download failed for nightly asset %s", name)
+            return self.create_download_result(
+                success=False,
+                release_tag=build_id,
+                file_path=target_path,
+                error_message="download_file_with_retry returned False",
+                download_url=str(url),
+                file_size=size,
+                file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+                is_retryable=True,
+                error_type=ERROR_TYPE_NETWORK,
+            )
+
+        # Deterministic post-download validation. A failure here means the
+        # response itself was wrong; remove the bad file + stored hash and
+        # treat it as non-retryable so a retry cannot silently replace it.
+        ok, reason = self._validate_nightly_asset(target_path, name, size)
+        if not ok:
+            self._remove_nightly_target_and_hash(target_path)
+            logger.error(
+                "Nightly asset %s failed post-download validation: %s", name, reason
+            )
+            return self.create_download_result(
+                success=False,
+                release_tag=build_id,
+                file_path=target_path,
+                error_message=f"nightly validation failed: {reason}",
+                download_url=str(url),
+                file_size=size,
+                file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+                is_retryable=False,
+                error_type=ERROR_TYPE_VALIDATION,
+            )
+
+        # Executable bit only after the file has been validated.
+        if name.lower().endswith(".sh") and os.name != "nt":
+            try:
+                os.chmod(target_path, EXECUTABLE_PERMISSIONS)
+            except OSError:
+                pass
+        logger.info("Downloaded nightly asset %s", name)
+        return self.create_download_result(
+            success=True,
+            release_tag=build_id,
+            file_path=target_path,
+            download_url=str(url),
+            file_size=size,
+            file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+        )
+
     def update_latest_pointer_for_nightly(self, build_id: str) -> bool:
         """Best-effort update of the ``latest`` pointer inside ``nightlies/``."""
         if not coerce_bool(
@@ -3120,14 +3326,22 @@ class FirmwareReleaseDownloader(BaseDownloader):
     ) -> int:
         """
         Remove old nightly build directories under ``firmware/nightlies/``,
-        keeping the newest ``FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP`` (floor 1).
+        keeping an exact maximum of ``FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP``
+        (floor 1). The current build always occupies one slot.
+
+        Selection: at most ``keep_limit`` managed build directories survive,
+        selected by deterministic directory mtime (newest first) with a stable
+        name tiebreak — never hash chronology. When ``current_build_id`` is
+        supplied it reserves one slot; at most ``keep_limit - 1`` other
+        directories are retained alongside it.
 
         Safety rules:
           - never follow the ``nightlies/`` root if it is a symlink;
           - never delete the ``latest`` pointer or any non-build-id directory;
-          - never follow per-entry symlinks;
-          - never delete ``current_build_id`` even when same-base hashes sort
-            it below the keep window (hashes are not chronological).
+          - never follow per-entry symlinks (uses ``_safe_rmtree``);
+          - never delete ``current_build_id``;
+          - remove an invalid managed ``latest`` symlink via
+            ``remove_latest_pointer`` when its target is gone.
 
         Returns the number of build directories removed.
         """
@@ -3148,44 +3362,88 @@ class FirmwareReleaseDownloader(BaseDownloader):
         if keep_limit < 1:
             keep_limit = 1
 
-        version_manager = VersionManager()
-        build_dirs: List[Tuple[Any, str]] = []
-        non_build_entries: List[str] = []
+        # Collect managed build directories with deterministic (mtime, name)
+        # ordering metadata. Non-build directories and symlinks are preserved.
+        candidates: List[Tuple[float, str]] = []
         try:
             with os.scandir(base) as it:
                 for entry in it:
                     if entry.is_symlink():
-                        # latest pointer or any symlink — preserve
                         continue
-                    if not entry.is_dir():
+                    if not entry.is_dir(follow_symlinks=False):
                         continue
                     if not _NIGHTLY_BUILD_ID_RX.match(entry.name):
-                        non_build_entries.append(entry.name)
                         continue
-                    release_tuple = version_manager.get_release_tuple(entry.name) or ()
-                    build_dirs.append((release_tuple, entry.name))
+                    try:
+                        mtime = entry.stat().st_mtime
+                    except OSError:
+                        mtime = 0.0
+                    candidates.append((mtime, entry.name))
         except (FileNotFoundError, NotADirectoryError):
             return 0
         except OSError as exc:
             logger.debug("Error scanning nightlies dir %s: %s", base, exc)
             return 0
 
-        if not build_dirs:
+        if not candidates:
             return 0
 
-        build_dirs.sort(key=lambda item: (item[0], item[1]))
-        keep_names = {name for _, name in build_dirs[-keep_limit:]}
-        if current_build_id:
-            keep_names.add(current_build_id)
+        # Sort newest mtime first; stable name tiebreak (descending) so the
+        # selection is deterministic regardless of hash chronology.
+        candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
+
+        current = (
+            current_build_id
+            if isinstance(current_build_id, str)
+            and _NIGHTLY_BUILD_ID_RX.match(current_build_id)
+            else None
+        )
+
+        other_budget = keep_limit - 1 if current else keep_limit
+        other_budget = max(0, other_budget)
+
+        keep_names: set[str] = set()
+        if current:
+            keep_names.add(current)
+        kept_others = 0
+        for _mtime, name in candidates:
+            if name == current:
+                continue
+            if kept_others < other_budget:
+                keep_names.add(name)
+                kept_others += 1
+
         removed = 0
-        for _, name in build_dirs:
+        removed_names: List[str] = []
+        for _mtime, name in candidates:
             if name in keep_names:
                 continue
             path = os.path.join(base, name)
-            try:
-                shutil.rmtree(path)
+            if _safe_rmtree(path, base, name):
                 removed += 1
+                removed_names.append(name)
                 logger.info("Removed old nightly build: %s", name)
-            except OSError as exc:
-                logger.error("Error removing nightly build %s: %s", name, exc)
+
+        # Drop the managed latest pointer if it no longer points at a retained
+        # build directory. Never remove a non-symlink latest entry.
+        if removed_names:
+            retained = {name for _mtime, name in candidates if name in keep_names}
+            self._cleanup_invalid_nightly_latest_pointer(base, retained)
+
         return removed
+
+    def _cleanup_invalid_nightly_latest_pointer(
+        self, base_dir: str, retained_names: set[str]
+    ) -> None:
+        """Remove the managed ``latest`` symlink when its target is missing or unsafe."""
+        link_path = os.path.join(base_dir, LATEST_POINTER_NAME)
+        if not os.path.islink(link_path):
+            return
+        try:
+            target = os.readlink(link_path)
+        except OSError:
+            remove_latest_pointer(base_dir)
+            return
+        if target in retained_names:
+            return
+        remove_latest_pointer(base_dir)

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -2763,22 +2763,25 @@ class FirmwareReleaseDownloader(BaseDownloader):
         """
         Fetch the flat GitHub Contents listing of the rolling firmware-nightly directory.
 
-        Returns an empty list when the feature is disabled (no API call is made).
-        Each entry preserves the live GitHub Contents API shape (``name``,
-        ``download_url``, ``size``, ``type``).
+        Returns an empty list when the feature is disabled (no API call is made)
+        or when the listing is genuinely empty. Each entry preserves the live
+        GitHub Contents API shape (``name``, ``download_url``, ``size``,
+        ``type``).
+
+        Source failures (``RequestException``, ``OSError``, ``ValueError``) are
+        **not** collapsed into an empty list — they propagate so the orchestrator
+        can mark the run ``CHECK_FAILED`` and log context. An empty success
+        (listing is ``None`` or ``[]``) is distinct from a failure: the
+        orchestrator treats it as "no candidate published yet" (not an error).
         """
         if not self._nightlies_enabled():
             return []
-        try:
-            contents = self.cache_manager.get_repo_contents(
-                FIRMWARE_NIGHTLY_SOURCE_DIR,
-                force_refresh=False,
-                github_token=self.config.get("GITHUB_TOKEN"),
-                allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
-            )
-        except (requests.RequestException, OSError, ValueError, TypeError) as exc:
-            logger.debug("Failed to fetch firmware-nightly listing: %s", exc)
-            return []
+        contents = self.cache_manager.get_repo_contents(
+            FIRMWARE_NIGHTLY_SOURCE_DIR,
+            force_refresh=False,
+            github_token=self.config.get("GITHUB_TOKEN"),
+            allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
+        )
         return [c for c in contents if isinstance(c, dict)] if contents else []
 
     @staticmethod
@@ -2811,24 +2814,48 @@ class FirmwareReleaseDownloader(BaseDownloader):
     def get_nightly_build_id(self, entries: List[Dict[str, Any]]) -> Optional[str]:
         """
         Scan a nightly listing and return the build-id parsed from the single
-        release-level manifest, or ``None`` when no manifest is present.
+        release-level manifest.
+
+        Returns ``None`` when no manifest is present **and the listing is
+        empty** (no candidate published yet). For a nonempty listing with zero
+        manifests, raises ``ValueError`` (malformed generation). For multiple
+        unique build-ids, raises ``ValueError`` (ambiguous generation). Exact
+        duplicate manifest entries (same build-id) are deduplicated and treated
+        as one.
         """
-        for entry in entries or []:
+        listing = entries or []
+        build_ids: list[str] = []
+        seen: set[str] = set()
+        for entry in listing:
             if not isinstance(entry, dict):
                 continue
             name = entry.get("name")
             if not isinstance(name, str):
                 continue
             build_id = self.parse_nightly_build_id(name)
-            if build_id:
-                return build_id
-        return None
+            if build_id and build_id not in seen:
+                seen.add(build_id)
+                build_ids.append(build_id)
+
+        if not build_ids:
+            if not listing:
+                return None
+            raise ValueError("firmware-nightly listing has no release-level manifest")
+        if len(build_ids) > 1:
+            raise ValueError(
+                f"firmware-nightly listing has multiple unique build-ids: {build_ids}"
+            )
+        return build_ids[0]
 
     def _ensure_nightly_base_dir(self) -> str:
         """Create (if absent) and return ``firmware/nightlies/`` after safety checks."""
-        base = os.path.join(
-            self.download_dir, FIRMWARE_DIR_NAME, FIRMWARE_NIGHTLIES_DIR_NAME
-        )
+        base = self._nightly_root_for_safety()
+        firmware_parent = os.path.join(self.download_dir, FIRMWARE_DIR_NAME)
+        for ancestor in (base, firmware_parent, self.download_dir):
+            if os.path.islink(ancestor):
+                raise ValueError(
+                    f"Refusing firmware-nightly path through symlink ancestor: {ancestor}"
+                )
         os.makedirs(base, exist_ok=True)
         return base
 
@@ -2838,33 +2865,102 @@ class FirmwareReleaseDownloader(BaseDownloader):
             self.download_dir, FIRMWARE_DIR_NAME, FIRMWARE_NIGHTLIES_DIR_NAME
         )
 
-    def _validate_nightly_path_safety(self, build_id: str) -> str:
+    def _resolve_nightly_target(self, build_id: str, name: str, *, create: bool) -> str:
         """
-        Validate the build-id and the managed path tree, then create and return
-        ``firmware/nightlies/<build_id>/``.
+        Unified managed-path resolver for nightly assets.
 
-        Safety rules:
-          - build_id must match the strict nightly build-id regex;
-          - the nightly root, firmware parent, and every managed ancestor must
-            be non-symlink directories;
-          - the resolved build path must remain under the resolved nightly root.
+        Returns the canonical target path
+        ``firmware/nightlies/<build_id>/<safe_name>`` after validating every
+        managed ancestor. In write mode (``create=True``) the nightly root and
+        build directory are created; in non-write mode (``create=False``)
+        nothing is created and missing ancestors are allowed (the caller will
+        detect the missing file separately), but any **unsafe** condition
+        still raises ``ValueError`` so non-write callers never trust a path
+        through a symlink or an escaped build directory.
 
-        Raises ValueError on any violation so callers abort the transaction
-        rather than write through an escaped path.
+        Safety rules (enforced in both modes):
+          - ``build_id`` must match the strict nightly build-id regex;
+          - ``DOWNLOAD_DIR``, ``firmware/``, ``firmware/nightlies/`` must not
+            be symlinks;
+          - the build directory must not be a symlink;
+          - the resolved build path must remain under the resolved nightly root
+            (containment);
+          - ``name`` must be a single safe path component (no separators,
+            no ``..``).
+
+        Raises ``ValueError`` on any violation.
         """
         if not isinstance(build_id, str) or not _NIGHTLY_BUILD_ID_RX.match(build_id):
             raise ValueError(f"Unsafe firmware-nightly build_id: {build_id!r}")
 
+        safe_name = self._sanitize_required(name, "nightly asset name")
+        # Reject multi-component names (path traversal).
+        if safe_name != os.path.basename(safe_name) or safe_name in ("", ".", ".."):
+            raise ValueError(
+                f"Unsafe firmware-nightly asset name (multi-component): {name!r}"
+            )
+
         root = self._nightly_root_for_safety()
         firmware_parent = os.path.join(self.download_dir, FIRMWARE_DIR_NAME)
-        # Reject any symlink in the managed ancestor chain (root, firmware
-        # parent, download dir). Do not follow — that would allow escapes.
+        # Reject any symlink in the managed ancestor chain (download dir,
+        # firmware parent, nightly root). Do not follow — that would allow
+        # escapes.
         for ancestor in (root, firmware_parent, self.download_dir):
             if os.path.islink(ancestor):
                 raise ValueError(
                     f"Refusing firmware-nightly path through symlink ancestor: {ancestor}"
                 )
 
+        build_dir = os.path.join(root, build_id)
+        if os.path.islink(build_dir):
+            raise ValueError(
+                f"Refusing firmware-nightly build path that is a symlink: {build_dir}"
+            )
+
+        # Containment: the realpath of the build dir must stay under the
+        # realpath of the nightly root. In non-write mode the root may not
+        # exist yet — compute realpath of the parent chain that does exist.
+        if create:
+            os.makedirs(root, exist_ok=True)
+            real_root = os.path.realpath(root)
+            os.makedirs(build_dir, exist_ok=True)
+            real_build = os.path.realpath(build_dir)
+        else:
+            # Non-write: validate containment without creating anything.
+            # If the root doesn't exist yet, the build is "missing" (not
+            # unsafe) — return the path so the caller can check existence.
+            if not os.path.isdir(root):
+                return os.path.join(build_dir, safe_name)
+            real_root = os.path.realpath(root)
+            real_build = os.path.realpath(build_dir)
+        if not _is_within_base(real_root, real_build):
+            raise ValueError(
+                f"Refusing firmware-nightly build path outside managed tree: {build_dir}"
+            )
+
+        target_path = os.path.join(build_dir, safe_name)
+        # Reject a symlink at the target itself in non-write mode. In write
+        # mode the caller (download_nightly_asset / _retry_nightly_failure)
+        # is responsible for detecting and removing the symlink before
+        # downloading — checking here would prevent that cleanup.
+        if not create and os.path.islink(target_path):
+            raise ValueError(
+                f"Refusing firmware-nightly target that is a symlink: {target_path}"
+            )
+
+        return target_path
+
+    def _resolve_nightly_dir(self, build_id: str) -> str:
+        """Create (if absent) and safely return ``firmware/nightlies/<build_id>/``."""
+        if not isinstance(build_id, str) or not _NIGHTLY_BUILD_ID_RX.match(build_id):
+            raise ValueError(f"Unsafe firmware-nightly build_id: {build_id!r}")
+        root = self._nightly_root_for_safety()
+        firmware_parent = os.path.join(self.download_dir, FIRMWARE_DIR_NAME)
+        for ancestor in (root, firmware_parent, self.download_dir):
+            if os.path.islink(ancestor):
+                raise ValueError(
+                    f"Refusing firmware-nightly path through symlink ancestor: {ancestor}"
+                )
         os.makedirs(root, exist_ok=True)
         real_root = os.path.realpath(root)
         build_dir = os.path.join(root, build_id)
@@ -2877,13 +2973,8 @@ class FirmwareReleaseDownloader(BaseDownloader):
             raise ValueError(
                 f"Refusing firmware-nightly build path outside managed tree: {build_dir}"
             )
-
         os.makedirs(build_dir, exist_ok=True)
         return build_dir
-
-    def _resolve_nightly_dir(self, build_id: str) -> str:
-        """Create (if absent) and safely return ``firmware/nightlies/<build_id>/``."""
-        return self._validate_nightly_path_safety(build_id)
 
     def get_nightly_target_path(
         self, build_id: str, name: str, *, create: bool = False
@@ -2892,19 +2983,11 @@ class FirmwareReleaseDownloader(BaseDownloader):
         Resolve the storage path for a nightly asset under
         ``firmware/nightlies/<build_id>/<name>``.  When ``create`` is True the
         build directory is created after passing path-safety validation;
-        otherwise the path is computed without touching the filesystem.
+        otherwise the path is computed via the shared resolver without
+        creating anything — but symlink/containment/name violations still
+        raise ``ValueError`` so non-write callers never trust an unsafe path.
         """
-        if create:
-            base = self._resolve_nightly_dir(build_id)
-        else:
-            base = os.path.join(
-                self.download_dir,
-                FIRMWARE_DIR_NAME,
-                FIRMWARE_NIGHTLIES_DIR_NAME,
-                build_id,
-            )
-        safe_name = self._sanitize_required(name, "nightly asset name")
-        return os.path.join(base, safe_name)
+        return self._resolve_nightly_target(build_id, name, create=create)
 
     def _get_nightly_selection_patterns(self) -> List[str]:
         """Selection patterns from SELECTED_FIRMWARE_ASSETS (same key as stable/prerelease)."""
@@ -2971,13 +3054,15 @@ class FirmwareReleaseDownloader(BaseDownloader):
         listing in hand.  This helper is the side-effect-free predicate used by
         callers that only know the build-id.
         """
+        if not isinstance(build_id, str) or not _NIGHTLY_BUILD_ID_RX.match(build_id):
+            return False
         build_dir = os.path.join(
             self.download_dir,
             FIRMWARE_DIR_NAME,
             FIRMWARE_NIGHTLIES_DIR_NAME,
             build_id,
         )
-        if not os.path.isdir(build_dir):
+        if not os.path.isdir(build_dir) or os.path.islink(build_dir):
             return False
         try:
             with os.scandir(build_dir) as it:
@@ -3465,3 +3550,75 @@ class FirmwareReleaseDownloader(BaseDownloader):
         # dangling symlink to a deleted-but-retained name is repaired.
         if not os.path.isdir(os.path.join(base_dir, target)):
             remove_latest_pointer(base_dir)
+
+    def repair_nightly_executable_metadata(
+        self, build_id: str, entries: List[Dict[str, Any]]
+    ) -> int:
+        """
+        Best-effort repair of the executable bit on ``*.sh`` nightly assets
+        that are already present and fully valid. Does NOT redownload — the
+        file is only chmodded when it passes content validation. Invalid or
+        missing assets are left untouched. Windows is unchanged.
+
+        Returns the number of assets repaired.
+        """
+        if os.name == "nt":
+            return 0
+        repaired = 0
+        for entry in entries or []:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str) or not name.lower().endswith(".sh"):
+                continue
+            try:
+                target = self.get_nightly_target_path(build_id, name, create=False)
+            except ValueError:
+                continue
+            ok, _reason = self._validate_nightly_asset(target, name, entry.get("size"))
+            if not ok:
+                continue
+            try:
+                current_mode = os.stat(target).st_mode
+                if not (current_mode & 0o111):
+                    os.chmod(target, EXECUTABLE_PERMISSIONS)
+                    repaired += 1
+            except OSError:
+                continue
+        return repaired
+
+    def recreate_latest_pointer_for_nightly(self, build_id: str) -> bool:
+        """
+        Recreate the ``latest`` pointer for a build when it is missing or
+        points to a different build. Preserves a non-symlink ``latest`` entry.
+
+        Returns True when the pointer was created or already correct.
+        """
+        if not coerce_bool(
+            self.config.get("CREATE_LATEST_SYMLINKS", DEFAULT_CREATE_LATEST_SYMLINKS),
+            DEFAULT_CREATE_LATEST_SYMLINKS,
+        ):
+            return False
+        try:
+            parent = self._ensure_nightly_base_dir()
+        except (OSError, ValueError) as exc:
+            logger.debug("Skipping firmware-nightly latest pointer repair: %s", exc)
+            return False
+        link_path = os.path.join(parent, LATEST_POINTER_NAME)
+        if os.path.islink(link_path):
+            try:
+                target = os.readlink(link_path)
+            except OSError:
+                remove_latest_pointer(parent)
+                target = None
+            if target == build_id:
+                return True
+            remove_latest_pointer(parent)
+        elif os.path.exists(link_path):
+            # Non-symlink latest: preserve, do not overwrite.
+            return False
+        try:
+            return update_latest_pointer(parent, build_id, LATEST_POINTER_NAME)
+        except (OSError, ValueError, TypeError) as exc:
+            logger.debug("Failed to recreate firmware-nightly latest pointer: %s", exc)
+            return False

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -92,6 +92,9 @@ _FIRMWARE_SUFFIX_PATTERN = re.compile(
 _NIGHTLY_MANIFEST_RX = re.compile(FIRMWARE_NIGHTLY_MANIFEST_PATTERN, re.IGNORECASE)
 # A nightly build-id on its own (used to validate build directories under nightlies/).
 _NIGHTLY_BUILD_ID_RX = re.compile(r"^\d+\.\d+\.\d+\.[a-f0-9]{6,}$", re.IGNORECASE)
+# Detects a nightly build token (e.g. ``2.8.0.f52e2ea``) embedded anywhere in
+# an asset filename so the selector can reject stale generations.
+_NIGHTLY_BUILD_TOKEN_RX = re.compile(r"(\d+\.\d+\.\d+\.[a-f0-9]{6,})", re.IGNORECASE)
 
 
 class FirmwareReleaseDownloader(BaseDownloader):
@@ -2764,15 +2767,19 @@ class FirmwareReleaseDownloader(BaseDownloader):
         Fetch the flat GitHub Contents listing of the rolling firmware-nightly directory.
 
         Returns an empty list when the feature is disabled (no API call is made)
-        or when the listing is genuinely empty. Each entry preserves the live
-        GitHub Contents API shape (``name``, ``download_url``, ``size``,
-        ``type``).
+        or when the listing is genuinely empty (``None`` or ``[]``). Each entry
+        preserves the live GitHub Contents API shape (``name``, ``download_url``,
+        ``size``, ``type``).
 
-        Source failures (``RequestException``, ``OSError``, ``ValueError``) are
-        **not** collapsed into an empty list — they propagate so the orchestrator
-        can mark the run ``CHECK_FAILED`` and log context. An empty success
-        (listing is ``None`` or ``[]``) is distinct from a failure: the
-        orchestrator treats it as "no candidate published yet" (not an error).
+        **Fail-closed policy for malformed source responses:** a non-list
+        response or a nonempty list containing any malformed entry (non-dict
+        or dict with a non-string ``name``) raises ``ValueError`` rather than
+        silently filtering. The orchestrator catches this and marks the run
+        ``CHECK_FAILED`` so a corrupt listing is never mistaken for "no
+        candidate published yet" (which an empty list represents). This is
+        a strict mixed-list fail-closed: one bad entry rejects the entire
+        listing, because silently dropping entries could hide a missing
+        release manifest and produce an incoherent download set.
         """
         if not self._nightlies_enabled():
             return []
@@ -2782,7 +2789,23 @@ class FirmwareReleaseDownloader(BaseDownloader):
             github_token=self.config.get("GITHUB_TOKEN"),
             allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
         )
-        return [c for c in contents if isinstance(c, dict)] if contents else []
+        if not contents:
+            return []
+        if not isinstance(contents, list):
+            raise ValueError("firmware-nightly source response is not a list")
+        validated: List[Dict[str, Any]] = []
+        for entry in contents:
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"firmware-nightly source response has non-dict entry: {entry!r}"
+                )
+            name = entry.get("name")
+            if not isinstance(name, str) or not name:
+                raise ValueError(
+                    "firmware-nightly source response has entry with invalid name"
+                )
+            validated.append(entry)
+        return validated
 
     @staticmethod
     def parse_nightly_build_id(name: str) -> Optional[str]:
@@ -2997,18 +3020,30 @@ class FirmwareReleaseDownloader(BaseDownloader):
         return list(patterns) if isinstance(patterns, list) else []
 
     def get_selected_nightly_assets(
-        self, entries: List[Dict[str, Any]]
+        self, entries: List[Dict[str, Any]], build_id: str
     ) -> List[Dict[str, Any]]:
         """
-        Select nightly entries by configured patterns, plus the release-level
-        manifest (always included so target metadata stays available).
+        Select nightly entries for a single build generation.
 
-        Selection rules:
-          - ``SELECTED_FIRMWARE_ASSETS`` — the same production key used by
-            stable and prerelease firmware downloads.
-          - ``EXCLUDE_PATTERNS`` removes case-insensitive glob matches.
-          - The release manifest is always included even when no pattern matches.
+        Selection rules (build-aware, deterministic):
+          - ``build_id`` must match the strict nightly build-id regex;
+            otherwise the result is empty.
+          - The release manifest for *this* build (``firmware-<build_id>.json``)
+            is always included exactly once, even when no pattern matches.
+          - Per-device manifests (``*.mt.json``) are always excluded — they
+            are never individually selected for nightly download.
+          - Any versioned asset whose embedded build token differs from
+            ``build_id`` is excluded (stale generation), even if it matches
+            a selection pattern.
+          - ZIP archives from the same build remain eligible under
+            ``SELECTED_FIRMWARE_ASSETS`` / ``EXCLUDE_PATTERNS``.
+          - Build-agnostic helper files (no build token, e.g. ``device-install.sh``)
+            remain eligible under the same patterns.
+          - Results are deduplicated by name and sorted alphabetically.
         """
+        if not isinstance(build_id, str) or not _NIGHTLY_BUILD_ID_RX.match(build_id):
+            return []
+
         patterns = self._get_nightly_selection_patterns()
         exclude_patterns = self._get_exclude_patterns()
 
@@ -3020,6 +3055,23 @@ class FirmwareReleaseDownloader(BaseDownloader):
             name = entry.get("name")
             if not isinstance(name, str) or not name or name in seen_names:
                 continue
+            lower = name.lower()
+
+            # Always include exactly the release manifest for this build.
+            if self.parse_nightly_build_id(name) == build_id:
+                selected.append(entry)
+                seen_names.add(name)
+                continue
+
+            # Per-device manifests are never individually selected.
+            if lower.endswith(".mt.json"):
+                continue
+
+            # Reject stale versioned assets from a different build generation.
+            token_match = _NIGHTLY_BUILD_TOKEN_RX.search(name)
+            if token_match and token_match.group(1).lower() != build_id:
+                continue
+
             if exclude_patterns and self._matches_exclude_patterns(
                 name, exclude_patterns
             ):
@@ -3028,51 +3080,57 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 selected.append(entry)
                 seen_names.add(name)
 
-        # Always include the release-level manifest if it is present in the listing.
-        for entry in entries or []:
-            if not isinstance(entry, dict):
-                continue
-            name = entry.get("name")
-            if (
-                isinstance(name, str)
-                and name not in seen_names
-                and self.parse_nightly_build_id(name) is not None
-            ):
-                selected.append(entry)
-                seen_names.add(name)
-                break
-
+        selected.sort(key=lambda e: str(e.get("name", "")))
         return selected
 
     def is_nightly_complete(self, build_id: str) -> bool:
         """
         Lightweight on-disk completeness probe: returns True iff the build
-        directory exists and contains at least one non-empty asset.
+        directory exists and contains at least one non-empty regular file.
 
-        The strict selected-set check (``all selected files present with expected
-        size``) is performed by :meth:`should_process_nightly`, which has the
-        listing in hand.  This helper is the side-effect-free predicate used by
-        callers that only know the build-id.
+        Uses the shared non-writing root/build policy: rejects any symlink
+        in the managed ancestor chain (``DOWNLOAD_DIR``, ``firmware/``,
+        ``firmware/nightlies/``, build dir), rejects containment escapes,
+        and never creates directories. File entries are checked with
+        ``follow_symlinks=False`` so a symlink inside the build dir is
+        never counted as a real asset.
+
+        The strict selected-set check is performed by
+        :meth:`should_process_nightly`, which has the listing in hand.
         """
         if not isinstance(build_id, str) or not _NIGHTLY_BUILD_ID_RX.match(build_id):
             return False
-        build_dir = os.path.join(
-            self.download_dir,
-            FIRMWARE_DIR_NAME,
-            FIRMWARE_NIGHTLIES_DIR_NAME,
-            build_id,
-        )
-        if not os.path.isdir(build_dir) or os.path.islink(build_dir):
+        root = self._nightly_root_for_safety()
+        firmware_parent = os.path.join(self.download_dir, FIRMWARE_DIR_NAME)
+        for ancestor in (self.download_dir, firmware_parent, root):
+            if os.path.islink(ancestor):
+                return False
+        build_dir = os.path.join(root, build_id)
+        if os.path.islink(build_dir):
+            return False
+        if not os.path.isdir(build_dir):
+            return False
+        try:
+            real_root = os.path.realpath(root)
+            real_build = os.path.realpath(build_dir)
+            if not _is_within_base(real_root, real_build):
+                return False
+        except (OSError, ValueError):
             return False
         try:
             with os.scandir(build_dir) as it:
                 for entry in it:
-                    if entry.is_file() and entry.name != LATEST_POINTER_NAME:
-                        try:
-                            if entry.stat().st_size > 0:
-                                return True
-                        except OSError:
-                            continue
+                    if entry.name == LATEST_POINTER_NAME:
+                        continue
+                    if entry.is_symlink():
+                        continue
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    try:
+                        if entry.stat(follow_symlinks=False).st_size > 0:
+                            return True
+                    except OSError:
+                        continue
         except (FileNotFoundError, NotADirectoryError):
             return False
         except OSError as exc:
@@ -3130,7 +3188,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
             return True
 
         # Same identity: backfill if any selected asset is not fully valid.
-        selected = self.get_selected_nightly_assets(entries)
+        selected = self.get_selected_nightly_assets(entries, build_id)
         for entry in selected:
             name = entry.get("name")
             if not isinstance(name, str) or not name:
@@ -3445,7 +3503,22 @@ class FirmwareReleaseDownloader(BaseDownloader):
         base = os.path.join(
             self.download_dir, FIRMWARE_DIR_NAME, FIRMWARE_NIGHTLIES_DIR_NAME
         )
-        if not os.path.isdir(base) or os.path.islink(base):
+        firmware_parent = os.path.join(self.download_dir, FIRMWARE_DIR_NAME)
+        # Validate the full non-writing managed ancestor chain before any
+        # scan/delete/latest mutation. Reject any symlink, containment
+        # ambiguity, or missing unsafe root. Create nothing; return 0 and
+        # do not alter latest.
+        for ancestor in (self.download_dir, firmware_parent, base):
+            if os.path.islink(ancestor):
+                return 0
+        if not os.path.isdir(base):
+            return 0
+        try:
+            real_download = os.path.realpath(self.download_dir)
+            real_base = os.path.realpath(base)
+            if not _is_within_base(real_download, real_base):
+                return 0
+        except (OSError, ValueError):
             return 0
 
         keep_limit = self.config.get(
@@ -3560,14 +3633,17 @@ class FirmwareReleaseDownloader(BaseDownloader):
         file is only chmodded when it passes content validation. Invalid or
         missing assets are left untouched. Windows is unchanged.
 
+        Only assets in the build-aware selected set (same generation as
+        ``build_id``) are examined, so stale or unmanaged files are never
+        touched.
+
         Returns the number of assets repaired.
         """
         if os.name == "nt":
             return 0
+        selected = self.get_selected_nightly_assets(entries, build_id)
         repaired = 0
-        for entry in entries or []:
-            if not isinstance(entry, dict):
-                continue
+        for entry in selected:
             name = entry.get("name")
             if not isinstance(name, str) or not name.lower().endswith(".sh"):
                 continue

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -2796,6 +2796,18 @@ class FirmwareReleaseDownloader(BaseDownloader):
         m = _NIGHTLY_MANIFEST_RX.match(name)
         return m.group(1).lower() if m else None
 
+    @staticmethod
+    def validate_nightly_build_id(build_id: Any) -> bool:
+        """Return True only when ``build_id`` matches the strict nightly build-id regex.
+
+        Non-writing check used by the retry path to confirm a failed result's
+        release tag is a genuine build-id before re-deriving its canonical path.
+        """
+        return (
+            isinstance(build_id, str)
+            and _NIGHTLY_BUILD_ID_RX.match(build_id) is not None
+        )
+
     def get_nightly_build_id(self, entries: List[Dict[str, Any]]) -> Optional[str]:
         """
         Scan a nightly listing and return the build-id parsed from the single
@@ -3010,8 +3022,13 @@ class FirmwareReleaseDownloader(BaseDownloader):
         Short-circuits to False when nightlies are disabled or build_id is
         empty.  Otherwise:
           - identity changed (build_id differs from tracked)  -> True
-          - identity same, all selected assets present          -> False (skip)
-          - identity same, any selected asset missing/empty     -> True (backfill)
+          - identity same, all selected assets fully valid     -> False (skip)
+          - identity same, any selected asset missing/unsafe/
+            corrupt/hash-mismatched/invalid ZIP or manifest    -> True (backfill)
+
+        Same-identity skip uses the shared :meth:`_validate_nightly_asset`
+        against the non-writing managed target path so a tracked build is only
+        skipped when every selected asset passes path/content validation.
         """
         if not self._nightlies_enabled() or not build_id:
             return False
@@ -3027,23 +3044,18 @@ class FirmwareReleaseDownloader(BaseDownloader):
         if tracked != build_id:
             return True
 
-        # Same identity: backfill if any selected asset is missing or empty.
+        # Same identity: backfill if any selected asset is not fully valid.
         selected = self.get_selected_nightly_assets(entries)
         for entry in selected:
             name = entry.get("name")
             if not isinstance(name, str) or not name:
                 continue
-            target = self.get_nightly_target_path(build_id, name, create=False)
-            if not os.path.exists(target):
-                return True
             try:
-                expected = entry.get("size")
-                actual = os.path.getsize(target)
-                if actual == 0:
-                    return True
-                if isinstance(expected, int) and expected > 0 and actual != expected:
-                    return True
-            except OSError:
+                target = self.get_nightly_target_path(build_id, name, create=False)
+            except ValueError:
+                return True
+            ok, _reason = self._validate_nightly_asset(target, name, entry.get("size"))
+            if not ok:
                 return True
         return False
 
@@ -3385,9 +3397,6 @@ class FirmwareReleaseDownloader(BaseDownloader):
             logger.debug("Error scanning nightlies dir %s: %s", base, exc)
             return 0
 
-        if not candidates:
-            return 0
-
         # Sort newest mtime first; stable name tiebreak (descending) so the
         # selection is deterministic regardless of hash chronology.
         candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
@@ -3414,28 +3423,33 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 kept_others += 1
 
         removed = 0
-        removed_names: List[str] = []
         for _mtime, name in candidates:
             if name in keep_names:
                 continue
             path = os.path.join(base, name)
             if _safe_rmtree(path, base, name):
                 removed += 1
-                removed_names.append(name)
                 logger.info("Removed old nightly build: %s", name)
 
-        # Drop the managed latest pointer if it no longer points at a retained
-        # build directory. Never remove a non-symlink latest entry.
-        if removed_names:
-            retained = {name for _mtime, name in candidates if name in keep_names}
-            self._cleanup_invalid_nightly_latest_pointer(base, retained)
+        # Always validate the managed latest pointer against the retained set,
+        # even when zero directories were removed or no candidates existed.
+        # Removes unsafe/dangling/unretained symlinks; preserves a valid
+        # retained target and any non-symlink latest entry. Never followed.
+        retained = {name for _mtime, name in candidates if name in keep_names}
+        self._cleanup_invalid_nightly_latest_pointer(base, retained)
 
         return removed
 
     def _cleanup_invalid_nightly_latest_pointer(
         self, base_dir: str, retained_names: set[str]
     ) -> None:
-        """Remove the managed ``latest`` symlink when its target is missing or unsafe."""
+        """Remove the managed ``latest`` symlink when its target is missing or unsafe.
+
+        A non-symlink ``latest`` entry is always preserved. A symlink is removed
+        when its target is unreadable, dangling (target directory absent), or not
+        in the retained set. The link itself is removed; external targets are
+        never followed.
+        """
         link_path = os.path.join(base_dir, LATEST_POINTER_NAME)
         if not os.path.islink(link_path):
             return
@@ -3444,6 +3458,10 @@ class FirmwareReleaseDownloader(BaseDownloader):
         except OSError:
             remove_latest_pointer(base_dir)
             return
-        if target in retained_names:
+        if target not in retained_names:
+            remove_latest_pointer(base_dir)
             return
-        remove_latest_pointer(base_dir)
+        # Target is retained — still confirm the directory actually exists so a
+        # dangling symlink to a deleted-but-retained name is repaired.
+        if not os.path.isdir(os.path.join(base_dir, target)):
+            remove_latest_pointer(base_dir)

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -17,8 +17,10 @@ import requests  # type: ignore[import-untyped]
 
 from fetchtastic.constants import (
     DEFAULT_ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES,
+    DEFAULT_CHECK_FIRMWARE_NIGHTLIES,
     DEFAULT_CREATE_LATEST_SYMLINKS,
     DEFAULT_FILTER_REVOKED_RELEASES,
+    DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP,
     DEFAULT_PRESERVE_LEGACY_FIRMWARE_BASE_DIRS,
     DEVICE_HARDWARE_API_URL,
     DEVICE_HARDWARE_CACHE_HOURS,
@@ -30,12 +32,17 @@ from fetchtastic.constants import (
     EXECUTABLE_PERMISSIONS,
     FILE_TYPE_FIRMWARE,
     FILE_TYPE_FIRMWARE_MANIFEST,
+    FILE_TYPE_FIRMWARE_NIGHTLY,
     FILE_TYPE_FIRMWARE_PRERELEASE,
     FIRMWARE_DIR_NAME,
     FIRMWARE_DIR_PREFIX,
     FIRMWARE_MANIFEST_EXTENSION,
+    FIRMWARE_NIGHTLIES_DIR_NAME,
+    FIRMWARE_NIGHTLY_MANIFEST_PATTERN,
+    FIRMWARE_NIGHTLY_SOURCE_DIR,
     FIRMWARE_PRERELEASES_DIR_NAME,
     FIRMWARE_RELEASE_HISTORY_JSON_FILE,
+    LATEST_FIRMWARE_NIGHTLY_JSON_FILE,
     LATEST_FIRMWARE_PRERELEASE_JSON_FILE,
     LATEST_FIRMWARE_RELEASE_JSON_FILE,
     LATEST_POINTER_NAME,
@@ -72,6 +79,12 @@ _FIRMWARE_SUFFIX_PARTS = [
 _FIRMWARE_SUFFIX_PATTERN = re.compile(
     rf"(?:{'|'.join(re.escape(f'-{suffix}') for suffix in _FIRMWARE_SUFFIX_PARTS)})+$"
 )
+
+# Release-level nightly manifest: firmware-<version>.<hash>.json (build-id capture).
+# Device manifests (.mt.json) and zips are rejected.  See FIRMWARE_NIGHTLY_MANIFEST_PATTERN.
+_NIGHTLY_MANIFEST_RX = re.compile(FIRMWARE_NIGHTLY_MANIFEST_PATTERN, re.IGNORECASE)
+# A nightly build-id on its own (used to validate build directories under nightlies/).
+_NIGHTLY_BUILD_ID_RX = re.compile(r"^\d+\.\d+\.\d+\.[a-f0-9]{6,}$", re.IGNORECASE)
 
 
 class FirmwareReleaseDownloader(BaseDownloader):
@@ -1474,6 +1487,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
                     and entry.name
                     not in {
                         FIRMWARE_PRERELEASES_DIR_NAME,
+                        FIRMWARE_NIGHTLIES_DIR_NAME,
                         LATEST_POINTER_NAME,
                         REPO_DOWNLOADS_DIR,
                     }
@@ -1506,6 +1520,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 for entry in entries:
                     if entry.name in {
                         FIRMWARE_PRERELEASES_DIR_NAME,
+                        FIRMWARE_NIGHTLIES_DIR_NAME,
                         REPO_DOWNLOADS_DIR,
                     }:
                         continue
@@ -1900,17 +1915,26 @@ class FirmwareReleaseDownloader(BaseDownloader):
             version_manager.extract_clean_version(latest_release_tag)
             or latest_release_tag
         )
+        # History APIs now admit any prerelease base strictly newer than the
+        # latest stable release, so pass the cleaned stable tag (e.g. "v2.7.26")
+        # rather than the legacy next-patch derivation.  The next-patch value is
+        # retained only as a display label in the summary/log and as a parseability
+        # gate: if it cannot be derived the input tag is too malformed to admit.
         expected_version = version_manager.calculate_expected_prerelease_version(
             clean_latest_release
         )
         if not expected_version:
             return [], [], None, None
 
-        logger.debug("Expected prerelease version: %s", expected_version)
+        logger.debug(
+            "Prerelease admission floor: stable=%s (next-patch label=%s)",
+            clean_latest_release,
+            expected_version,
+        )
 
         latest_active_dir, history_entries = (
             prerelease_manager.get_latest_active_prerelease_from_history(
-                expected_version,
+                clean_latest_release,
                 cache_manager=self.cache_manager,
                 github_token=self.config.get("GITHUB_TOKEN"),
                 allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
@@ -1950,7 +1974,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 else:
                     fallback_repo_dirs = [d for d in dirs if isinstance(d, str)]
                 matches = prerelease_manager.scan_prerelease_directories(
-                    [d for d in dirs if isinstance(d, str)], expected_version
+                    [d for d in dirs if isinstance(d, str)], clean_latest_release
                 )
                 if matches:
                     # Choose newest by tuple then string
@@ -2015,7 +2039,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 matching_repo_dirs = [
                     f"{FIRMWARE_DIR_PREFIX}{identifier}"
                     for identifier in prerelease_manager.scan_prerelease_directories(
-                        repo_dirs, expected_version
+                        repo_dirs, clean_latest_release
                     )
                 ]
                 active_dirs_set = set(active_dirs)
@@ -2705,3 +2729,463 @@ class FirmwareReleaseDownloader(BaseDownloader):
         except (OSError, ValueError) as e:
             logger.error(f"Error cleaning up superseded prereleases: {e}")
             return False
+
+    # ==================================================================
+    # Firmware-nightly: rolling build published at firmware-nightly/
+    # ==================================================================
+
+    def _nightlies_enabled(self) -> bool:
+        """Return True when CHECK_FIRMWARE_NIGHTLIES is enabled (opt-in, default off)."""
+        return coerce_bool(
+            self.config.get(
+                "CHECK_FIRMWARE_NIGHTLIES", DEFAULT_CHECK_FIRMWARE_NIGHTLIES
+            ),
+            DEFAULT_CHECK_FIRMWARE_NIGHTLIES,
+        )
+
+    def _nightly_tracking_path(self) -> str:
+        """Cache path to the latest firmware-nightly tracking JSON."""
+        return self.cache_manager.get_cache_file_path(LATEST_FIRMWARE_NIGHTLY_JSON_FILE)
+
+    def fetch_firmware_nightlies(self) -> List[Dict[str, Any]]:
+        """
+        Fetch the flat GitHub Contents listing of the rolling firmware-nightly directory.
+
+        Returns an empty list when the feature is disabled (no API call is made).
+        Each entry preserves the live GitHub Contents API shape (``name``,
+        ``download_url``, ``size``, ``type``).
+        """
+        if not self._nightlies_enabled():
+            return []
+        try:
+            contents = self.cache_manager.get_repo_contents(
+                FIRMWARE_NIGHTLY_SOURCE_DIR,
+                force_refresh=False,
+                github_token=self.config.get("GITHUB_TOKEN"),
+                allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
+            )
+        except (requests.RequestException, OSError, ValueError, TypeError) as exc:
+            logger.debug("Failed to fetch firmware-nightly listing: %s", exc)
+            return []
+        return [c for c in contents if isinstance(c, dict)] if contents else []
+
+    @staticmethod
+    def parse_nightly_build_id(name: str) -> Optional[str]:
+        """
+        Extract the immutable build-id (e.g. ``2.8.0.f52e2ea``) from a release-level
+        nightly manifest filename (``firmware-<build-id>.json``).
+
+        Returns ``None`` for per-device manifests (``*.mt.json``), firmware zips,
+        helper scripts, and any other non-manifest filename.  Matching is
+        case-insensitive.
+        """
+        if not isinstance(name, str) or not name:
+            return None
+        m = _NIGHTLY_MANIFEST_RX.match(name)
+        return m.group(1).lower() if m else None
+
+    def get_nightly_build_id(self, entries: List[Dict[str, Any]]) -> Optional[str]:
+        """
+        Scan a nightly listing and return the build-id parsed from the single
+        release-level manifest, or ``None`` when no manifest is present.
+        """
+        for entry in entries or []:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str):
+                continue
+            build_id = self.parse_nightly_build_id(name)
+            if build_id:
+                return build_id
+        return None
+
+    def _ensure_nightly_base_dir(self) -> str:
+        """Create (if absent) and return ``firmware/nightlies/``."""
+        base = os.path.join(
+            self.download_dir, FIRMWARE_DIR_NAME, FIRMWARE_NIGHTLIES_DIR_NAME
+        )
+        os.makedirs(base, exist_ok=True)
+        return base
+
+    def _resolve_nightly_dir(self, build_id: str) -> str:
+        """Create (if absent) and return ``firmware/nightlies/<build_id>/``."""
+        build_dir = os.path.join(self._ensure_nightly_base_dir(), build_id)
+        os.makedirs(build_dir, exist_ok=True)
+        return build_dir
+
+    def get_nightly_target_path(
+        self, build_id: str, name: str, *, create: bool = False
+    ) -> str:
+        """
+        Resolve the storage path for a nightly asset under
+        ``firmware/nightlies/<build_id>/<name>``.  When ``create`` is True the
+        build directory is created; otherwise the path is computed without
+        touching the filesystem.
+        """
+        if create:
+            base = self._resolve_nightly_dir(build_id)
+        else:
+            base = os.path.join(
+                self.download_dir,
+                FIRMWARE_DIR_NAME,
+                FIRMWARE_NIGHTLIES_DIR_NAME,
+                build_id,
+            )
+        safe_name = self._sanitize_required(name, "nightly asset name")
+        return os.path.join(base, safe_name)
+
+    def _get_nightly_selection_patterns(self) -> List[str]:
+        """Selection patterns from SELECTED_FIRMWARE_ASSETS (same key as stable/prerelease)."""
+        patterns = self.config.get("SELECTED_FIRMWARE_ASSETS", [])
+        if isinstance(patterns, str):
+            return [patterns]
+        return list(patterns) if isinstance(patterns, list) else []
+
+    def get_selected_nightly_assets(
+        self, entries: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """
+        Select nightly entries by configured patterns, plus the release-level
+        manifest (always included so target metadata stays available).
+
+        Selection rules:
+          - ``SELECTED_FIRMWARE_ASSETS`` — the same production key used by
+            stable and prerelease firmware downloads.
+          - ``EXCLUDE_PATTERNS`` removes case-insensitive glob matches.
+          - The release manifest is always included even when no pattern matches.
+        """
+        patterns = self._get_nightly_selection_patterns()
+        exclude_patterns = self._get_exclude_patterns()
+
+        selected: List[Dict[str, Any]] = []
+        seen_names: set[str] = set()
+        for entry in entries or []:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str) or not name or name in seen_names:
+                continue
+            if exclude_patterns and self._matches_exclude_patterns(
+                name, exclude_patterns
+            ):
+                continue
+            if matches_selected_patterns(name, patterns):
+                selected.append(entry)
+                seen_names.add(name)
+
+        # Always include the release-level manifest if it is present in the listing.
+        for entry in entries or []:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if (
+                isinstance(name, str)
+                and name not in seen_names
+                and self.parse_nightly_build_id(name) is not None
+            ):
+                selected.append(entry)
+                seen_names.add(name)
+                break
+
+        return selected
+
+    def is_nightly_complete(self, build_id: str) -> bool:
+        """
+        Lightweight on-disk completeness probe: returns True iff the build
+        directory exists and contains at least one non-empty asset.
+
+        The strict selected-set check (``all selected files present with expected
+        size``) is performed by :meth:`should_process_nightly`, which has the
+        listing in hand.  This helper is the side-effect-free predicate used by
+        callers that only know the build-id.
+        """
+        build_dir = os.path.join(
+            self.download_dir,
+            FIRMWARE_DIR_NAME,
+            FIRMWARE_NIGHTLIES_DIR_NAME,
+            build_id,
+        )
+        if not os.path.isdir(build_dir):
+            return False
+        try:
+            with os.scandir(build_dir) as it:
+                for entry in it:
+                    if entry.is_file() and entry.name != LATEST_POINTER_NAME:
+                        try:
+                            if entry.stat().st_size > 0:
+                                return True
+                        except OSError:
+                            continue
+        except (FileNotFoundError, NotADirectoryError):
+            return False
+        except OSError as exc:
+            logger.debug("Error scanning nightly build dir %s: %s", build_dir, exc)
+            return False
+        return False
+
+    def should_download_nightly(self, build_id: str) -> bool:
+        """
+        Return True when nightlies are enabled AND the supplied build-id differs
+        from the tracked one.  A missing or unreadable tracking file is treated
+        as "download" (identity unknown).
+        """
+        if not self._nightlies_enabled() or not build_id:
+            return False
+        tracking_file = self._nightly_tracking_path()
+        try:
+            data = self.cache_manager.read_json(tracking_file)
+        except (OSError, ValueError, json.JSONDecodeError):
+            return True
+        if not isinstance(data, dict):
+            return True
+        tracked = data.get("build_id")
+        return tracked != build_id
+
+    def should_process_nightly(
+        self, entries: List[Dict[str, Any]], build_id: str
+    ) -> bool:
+        """
+        Decide whether a nightly build should be processed.
+
+        Short-circuits to False when nightlies are disabled or build_id is
+        empty.  Otherwise:
+          - identity changed (build_id differs from tracked)  -> True
+          - identity same, all selected assets present          -> False (skip)
+          - identity same, any selected asset missing/empty     -> True (backfill)
+        """
+        if not self._nightlies_enabled() or not build_id:
+            return False
+        tracking_file = self._nightly_tracking_path()
+        tracked: Optional[str] = None
+        try:
+            data = self.cache_manager.read_json(tracking_file)
+            if isinstance(data, dict):
+                tracked = data.get("build_id")
+        except (OSError, ValueError, json.JSONDecodeError):
+            tracked = None
+
+        if tracked != build_id:
+            return True
+
+        # Same identity: backfill if any selected asset is missing or empty.
+        selected = self.get_selected_nightly_assets(entries)
+        for entry in selected:
+            name = entry.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            target = self.get_nightly_target_path(build_id, name, create=False)
+            if not os.path.exists(target):
+                return True
+            try:
+                expected = entry.get("size")
+                actual = os.path.getsize(target)
+                if actual == 0:
+                    return True
+                if isinstance(expected, int) and expected > 0 and actual != expected:
+                    return True
+            except OSError:
+                return True
+        return False
+
+    def update_nightly_tracking(self, build_id: str) -> bool:
+        """
+        Persist the supplied build-id to the nightly tracking JSON.  Callers must
+        only invoke this after all selected assets have downloaded successfully.
+        """
+        if not build_id:
+            return False
+        data = {
+            "build_id": build_id,
+            "file_type": FILE_TYPE_FIRMWARE_NIGHTLY,
+            "last_updated": self._get_current_iso_timestamp(),
+        }
+        return self.cache_manager.atomic_write_json(self._nightly_tracking_path(), data)
+
+    def download_nightly_asset(
+        self, entry: Dict[str, Any], build_id: str
+    ) -> DownloadResult:
+        """
+        Download a single firmware-nightly entry into the build's directory and
+        return a structured DownloadResult.  Reuses the shared retry/integrity
+        helpers used by the prerelease path.
+        """
+        name = str(entry.get("name") or "")
+        url = entry.get("download_url") or entry.get("browser_download_url")
+        size = entry.get("size")
+        if not name or not url:
+            return self.create_download_result(
+                success=False,
+                release_tag=build_id,
+                file_path=os.path.join(
+                    self.download_dir, FIRMWARE_DIR_NAME, FIRMWARE_NIGHTLIES_DIR_NAME
+                ),
+                error_message="nightly entry missing name or download_url",
+                download_url=str(url) if url else None,
+                file_size=size,
+                file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+                is_retryable=False,
+                error_type=ERROR_TYPE_VALIDATION,
+            )
+
+        target_path = self.get_nightly_target_path(build_id, name, create=True)
+
+        # Skip if already present and intact.
+        if os.path.exists(target_path):
+            ok = verify_file_integrity(target_path)
+            if ok and name.lower().endswith(".zip"):
+                try:
+                    with zipfile.ZipFile(target_path, "r") as zf:
+                        ok = zf.testzip() is None
+                except (zipfile.BadZipFile, IOError, OSError):
+                    ok = False
+            if ok:
+                logger.debug("Nightly asset already present and valid: %s", name)
+                return self.create_download_result(
+                    success=True,
+                    release_tag=build_id,
+                    file_path=target_path,
+                    download_url=str(url),
+                    file_size=size,
+                    file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+                    was_skipped=True,
+                )
+
+        try:
+            if download_file_with_retry(str(url), target_path):
+                if name.lower().endswith(".sh") and os.name != "nt":
+                    try:
+                        os.chmod(target_path, EXECUTABLE_PERMISSIONS)
+                    except OSError:
+                        pass
+                logger.info("Downloaded nightly asset %s", name)
+                return self.create_download_result(
+                    success=True,
+                    release_tag=build_id,
+                    file_path=target_path,
+                    download_url=str(url),
+                    file_size=size,
+                    file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+                )
+            logger.error("Download failed for nightly asset %s", name)
+            return self.create_download_result(
+                success=False,
+                release_tag=build_id,
+                file_path=target_path,
+                error_message="download_file_with_retry returned False",
+                download_url=str(url),
+                file_size=size,
+                file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+                is_retryable=True,
+                error_type=ERROR_TYPE_NETWORK,
+            )
+        except (requests.RequestException, OSError, ValueError) as exc:
+            if isinstance(exc, requests.RequestException):
+                error_type = ERROR_TYPE_NETWORK
+                is_retryable = True
+            elif isinstance(exc, OSError):
+                error_type = ERROR_TYPE_FILESYSTEM
+                is_retryable = False
+            else:
+                error_type = ERROR_TYPE_VALIDATION
+                is_retryable = False
+            return self.create_download_result(
+                success=False,
+                release_tag=build_id,
+                file_path=target_path,
+                error_message=str(exc),
+                download_url=str(url),
+                file_size=size,
+                file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+                is_retryable=is_retryable,
+                error_type=error_type,
+            )
+
+    def update_latest_pointer_for_nightly(self, build_id: str) -> bool:
+        """Best-effort update of the ``latest`` pointer inside ``nightlies/``."""
+        if not coerce_bool(
+            self.config.get("CREATE_LATEST_SYMLINKS", DEFAULT_CREATE_LATEST_SYMLINKS),
+            DEFAULT_CREATE_LATEST_SYMLINKS,
+        ):
+            return False
+        try:
+            parent = self._ensure_nightly_base_dir()
+            return update_latest_pointer(parent, build_id, LATEST_POINTER_NAME)
+        except (OSError, ValueError, TypeError) as exc:
+            logger.debug("Skipping firmware-nightly latest pointer: %s", exc)
+            return False
+
+    def cleanup_superseded_nightlies(
+        self, current_build_id: Optional[str] = None
+    ) -> int:
+        """
+        Remove old nightly build directories under ``firmware/nightlies/``,
+        keeping the newest ``FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP`` (floor 1).
+
+        Safety rules:
+          - never follow the ``nightlies/`` root if it is a symlink;
+          - never delete the ``latest`` pointer or any non-build-id directory;
+          - never follow per-entry symlinks;
+          - never delete ``current_build_id`` even when same-base hashes sort
+            it below the keep window (hashes are not chronological).
+
+        Returns the number of build directories removed.
+        """
+        base = os.path.join(
+            self.download_dir, FIRMWARE_DIR_NAME, FIRMWARE_NIGHTLIES_DIR_NAME
+        )
+        if not os.path.isdir(base) or os.path.islink(base):
+            return 0
+
+        keep_limit = self.config.get(
+            "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP",
+            DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP,
+        )
+        try:
+            keep_limit = int(keep_limit)
+        except (TypeError, ValueError):
+            keep_limit = DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP
+        if keep_limit < 1:
+            keep_limit = 1
+
+        version_manager = VersionManager()
+        build_dirs: List[Tuple[Any, str]] = []
+        non_build_entries: List[str] = []
+        try:
+            with os.scandir(base) as it:
+                for entry in it:
+                    if entry.is_symlink():
+                        # latest pointer or any symlink — preserve
+                        continue
+                    if not entry.is_dir():
+                        continue
+                    if not _NIGHTLY_BUILD_ID_RX.match(entry.name):
+                        non_build_entries.append(entry.name)
+                        continue
+                    release_tuple = version_manager.get_release_tuple(entry.name) or ()
+                    build_dirs.append((release_tuple, entry.name))
+        except (FileNotFoundError, NotADirectoryError):
+            return 0
+        except OSError as exc:
+            logger.debug("Error scanning nightlies dir %s: %s", base, exc)
+            return 0
+
+        if not build_dirs:
+            return 0
+
+        build_dirs.sort(key=lambda item: (item[0], item[1]))
+        keep_names = {name for _, name in build_dirs[-keep_limit:]}
+        if current_build_id:
+            keep_names.add(current_build_id)
+        removed = 0
+        for _, name in build_dirs:
+            if name in keep_names:
+                continue
+            path = os.path.join(base, name)
+            try:
+                shutil.rmtree(path)
+                removed += 1
+                logger.info("Removed old nightly build: %s", name)
+            except OSError as exc:
+                logger.error("Error removing nightly build %s: %s", name, exc)
+        return removed

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -1110,6 +1110,20 @@ class DownloadOrchestrator:
         :meth:`_finalize_nightly_transaction_if_complete` can finalize the
         transaction exactly once after the retry phase, subject to the same
         all-assets-complete + tracking-succeeded conditions.
+
+        State mapping:
+          - source fetch error / malformed listing / ambiguous generation
+            → ``CHECK_FAILED`` (logged, no fake asset failure, no download
+            report, suppresses up-to-date).
+          - empty listing (no candidate yet) → ``UNCHECKED`` (not an error).
+          - build already tracked + complete → ``MAINTENANCE_ONLY`` after
+            running retention/pointer/chmod repair (no download report).
+          - all assets valid + tracking persisted + ≥1 downloaded asset →
+            ``FINALIZED_WITH_DOWNLOAD``.
+          - all assets valid + tracking persisted + all skipped →
+            ``MAINTENANCE_ONLY`` (reconciliation, not download).
+          - any asset failure or tracking failure →
+            ``ATTEMPTED_INCOMPLETE``.
         """
         if not coerce_bool(
             self.config.get(
@@ -1121,16 +1135,25 @@ class DownloadOrchestrator:
         try:
             entries = self.firmware_downloader.fetch_firmware_nightlies()
             if not entries:
+                # Empty-but-valid listing: no candidate published yet. Not a
+                # failure — leave state as UNCHECKED.
                 return
             build_id = self.firmware_downloader.get_nightly_build_id(entries)
             if not build_id:
-                logger.debug(
-                    "No firmware-nightly release manifest in listing; skipping"
+                # Nonempty listing with no manifest: malformed generation.
+                self.nightly_run_state = NightlyRunState.CHECK_FAILED
+                logger.warning(
+                    "Firmware-nightly listing is nonempty but has no "
+                    "release-level manifest; marking check as failed"
                 )
                 return
             if not self.firmware_downloader.should_process_nightly(entries, build_id):
-                logger.debug("Firmware-nightly build %s already complete", build_id)
-                self.nightly_run_state = NightlyRunState.ALREADY_COMPLETE
+                logger.debug(
+                    "Firmware-nightly build %s already complete; running maintenance",
+                    build_id,
+                )
+                self._run_nightly_maintenance(build_id, entries)
+                self.nightly_run_state = NightlyRunState.MAINTENANCE_ONLY
                 return
             selected = self.firmware_downloader.get_selected_nightly_assets(entries)
             if not selected:
@@ -1163,7 +1186,7 @@ class DownloadOrchestrator:
             self._finalize_nightly_transaction(build_id, selected)
         except (requests.RequestException, OSError, ValueError, TypeError) as e:
             logger.error(f"Error processing firmware nightlies: {e}", exc_info=True)
-            self.nightly_run_state = NightlyRunState.ATTEMPTED_INCOMPLETE
+            self.nightly_run_state = NightlyRunState.CHECK_FAILED
 
     def _finalize_nightly_transaction(
         self, build_id: str, selected: List[Dict[str, Any]]
@@ -1178,6 +1201,13 @@ class DownloadOrchestrator:
         On any failure (partial assets, wrong size, tracking failure) nothing
         is finalized and the pending transaction is cleared so the next run
         retries from a clean state.
+
+        The run state is set to ``FINALIZED_WITH_DOWNLOAD`` only when at least
+        one selected asset was genuinely downloaded (``was_skipped=False``) in
+        this run. When every selected asset was already present and valid
+        (all ``was_skipped=True``), the state is ``MAINTENANCE_ONLY`` — the
+        transaction reconciled tracking/pointer/cleanup but no download is
+        reported.
         """
         # Every selected asset must be successful AND currently on-disk valid.
         for entry in selected:
@@ -1228,8 +1258,65 @@ class DownloadOrchestrator:
         self.latest_firmware_nightly_build_id = build_id
         self._pending_nightly_build_id = None
         self._pending_nightly_entries = []
-        self.nightly_run_state = NightlyRunState.FINALIZED
+
+        # Determine whether at least one asset was genuinely downloaded in
+        # this run (not skipped). Only then is this a "download" outcome.
+        any_downloaded = self._nightly_had_actual_download(selected)
+        if any_downloaded:
+            self.nightly_run_state = NightlyRunState.FINALIZED_WITH_DOWNLOAD
+        else:
+            self.nightly_run_state = NightlyRunState.MAINTENANCE_ONLY
         return True
+
+    def _nightly_had_actual_download(self, selected: List[Dict[str, Any]]) -> bool:
+        """Return True iff at least one nightly asset result in this run has
+        ``success=True`` and ``was_skipped=False`` for a URL in ``selected``."""
+        selected_urls = {
+            str(entry.get("download_url") or entry.get("browser_download_url") or "")
+            for entry in selected
+        }
+        for result in self.download_results:
+            if (
+                getattr(result, "file_type", None) == FILE_TYPE_FIRMWARE_NIGHTLY
+                and result.success
+                and not getattr(result, "was_skipped", False)
+                and str(result.download_url or "") in selected_urls
+            ):
+                return True
+        return False
+
+    def _run_nightly_maintenance(
+        self, build_id: str, entries: List[Dict[str, Any]]
+    ) -> None:
+        """
+        Run retention cleanup, latest-pointer repair/recreate, and executable-
+        metadata repair for an already-complete nightly build. Does NOT rewrite
+        tracking and does NOT report a download. Preserves a non-symlink
+        ``latest`` entry.
+        """
+        try:
+            self.firmware_downloader.cleanup_superseded_nightlies(build_id)
+        except (OSError, ValueError, TypeError) as exc:
+            logger.debug("Nightly retention cleanup failed for %s: %s", build_id, exc)
+        try:
+            self.firmware_downloader.recreate_latest_pointer_for_nightly(build_id)
+        except (OSError, ValueError, TypeError) as exc:
+            logger.debug(
+                "Nightly latest pointer repair failed for %s: %s", build_id, exc
+            )
+        try:
+            repaired = self.firmware_downloader.repair_nightly_executable_metadata(
+                build_id, entries
+            )
+            if repaired:
+                logger.info(
+                    "Repaired executable metadata for %d nightly .sh asset(s)",
+                    repaired,
+                )
+        except (OSError, ValueError, TypeError) as exc:
+            logger.debug(
+                "Nightly executable metadata repair failed for %s: %s", build_id, exc
+            )
 
     def _finalize_nightly_transaction_if_complete(self) -> None:
         """
@@ -1936,6 +2023,15 @@ class DownloadOrchestrator:
             )
 
         basename = os.path.basename(target_path)
+
+        # Reject any symlink at the target itself before calling the resolver.
+        # The non-write resolver raises ValueError on a symlinked target; we
+        # need to remove the link (never following it) before the resolver
+        # so the retry reports the right failure and the link is cleaned up.
+        target_was_symlink = os.path.islink(target_path)
+        if target_was_symlink:
+            fd._remove_nightly_target_and_hash(target_path)
+
         try:
             canonical = fd.get_nightly_target_path(build_id, basename, create=False)
         except ValueError as exc:
@@ -1945,7 +2041,7 @@ class DownloadOrchestrator:
                 url,
                 file_type,
                 "Retry attempt failed",
-                f"Unsafe firmware-nightly basename: {exc}",
+                f"Unsafe firmware-nightly path: {exc}",
                 is_retryable_override=False,
             )
 
@@ -1960,15 +2056,11 @@ class DownloadOrchestrator:
                 is_retryable_override=False,
             )
 
-        # Reject any symlink in the managed path chain (root/build/target)
-        # before any download attempt. A symlink at the target itself is
-        # removed (link only, never followed); deeper symlinks are refused
-        # without removal. Download never proceeds through a symlink.
+        # Reject any symlink in the managed path chain (build dir, nightly
+        # root) before any download attempt. The target symlink was already
+        # removed above. Download never proceeds through a symlink.
         build_dir = os.path.dirname(canonical)
         nightly_root = os.path.dirname(build_dir)
-        target_was_symlink = os.path.islink(canonical)
-        if target_was_symlink:
-            fd._remove_nightly_target_and_hash(canonical)
         if (
             target_was_symlink
             or os.path.islink(build_dir)
@@ -2686,6 +2778,33 @@ class DownloadOrchestrator:
         except (OSError, ValueError, TypeError) as e:
             logger.error(f"Error cleaning up old versions: {e}")
 
+    def _derive_firmware_prerelease_admission_floor(
+        self, latest_firmware_release: Optional[str]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Derive the clean stable release tag and the expected prerelease base
+        version used as the admission floor for firmware prerelease cleanup
+        and status display.
+
+        Takes ``latest_firmware_release`` (the raw tag from
+        ``get_latest_release_tag()``) so callers that already fetched it do not
+        pay a second call. Returns ``(clean_latest_release, expected_version)``
+        where either may be ``None`` when the tag is missing or too malformed
+        to derive a next-patch base. Callers use ``expected_version`` as a
+        parseability gate: a ``None`` value means the tag is too malformed to
+        admit any prerelease base, so the caller should early-return.
+        """
+        if not latest_firmware_release:
+            return None, None
+        clean_latest_release = (
+            self.version_manager.extract_clean_version(latest_firmware_release)
+            or latest_firmware_release
+        )
+        expected_version = self.version_manager.calculate_expected_prerelease_version(
+            clean_latest_release
+        )
+        return clean_latest_release, expected_version
+
     def _cleanup_deleted_prereleases(self) -> None:
         """
         Remove local firmware prerelease directories that are recorded as deleted in prerelease history.
@@ -2697,19 +2816,12 @@ class DownloadOrchestrator:
             latest_firmware_release = self.firmware_downloader.get_latest_release_tag()
             if not latest_firmware_release:
                 return
-
-            clean_latest_release = (
-                self.version_manager.extract_clean_version(latest_firmware_release)
-                or latest_firmware_release
-            )
-            # Retained as a parseability gate: if the next-patch derivation fails
-            # the tag is too malformed to admit any prerelease base.
-            expected_version = (
-                self.version_manager.calculate_expected_prerelease_version(
-                    clean_latest_release
+            clean_latest_release, expected_version = (
+                self._derive_firmware_prerelease_admission_floor(
+                    latest_firmware_release
                 )
             )
-            if not expected_version:
+            if not clean_latest_release or not expected_version:
                 return
 
             history = self.prerelease_manager.get_prerelease_commit_history(
@@ -2782,16 +2894,12 @@ class DownloadOrchestrator:
             firmware_prerelease = active_dir
 
         if latest_firmware_release and firmware_prerelease is None:
-            clean_latest_release = (
-                self.version_manager.extract_clean_version(latest_firmware_release)
-                or latest_firmware_release
-            )
-            expected_version = (
-                self.version_manager.calculate_expected_prerelease_version(
-                    clean_latest_release
+            clean_latest_release, expected_version = (
+                self._derive_firmware_prerelease_admission_floor(
+                    latest_firmware_release
                 )
             )
-            if expected_version:
+            if expected_version and clean_latest_release:
                 # Do not force refresh here to avoid API calls just for status display
                 active_dir, _ = (
                     self.prerelease_manager.get_latest_active_prerelease_from_history(

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -34,6 +34,7 @@ from fetchtastic.constants import (
     ERROR_TYPE_RETRY_FAILURE,
     ERROR_TYPE_REVOKED_RELEASE,
     ERROR_TYPE_UNKNOWN,
+    EXECUTABLE_PERMISSIONS,
     FILE_TYPE_APP_SNAPSHOT,
     FILE_TYPE_CLIENT_APP,
     FILE_TYPE_CLIENT_APP_PRERELEASE,
@@ -55,6 +56,7 @@ from fetchtastic.constants import (
     MAX_RETRY_DELAY,
     RELEASE_SCAN_COUNT,
     REPO_DOWNLOADS_DIR,
+    NightlyRunState,
 )
 from fetchtastic.log_utils import logger
 from fetchtastic.setup_config import is_termux
@@ -189,6 +191,12 @@ class DownloadOrchestrator:
         self.latest_available_firmware_prerelease_dir: Optional[str] = None
         # Run-scoped nightly build-id: set after successful nightly processing.
         self.latest_firmware_nightly_build_id: Optional[str] = None
+        # Run-scoped nightly transaction state. Reported outcomes are derived
+        # from this rather than from per-asset results so only a fully
+        # finalized transaction (all assets valid AND tracking persisted) is
+        # surfaced as a download; attempted-but-incomplete transactions
+        # suppress the generic up-to-date log/NTFY.
+        self.nightly_run_state: NightlyRunState = NightlyRunState.UNCHECKED
         # Run-scoped pending nightly transaction: populated when a nightly build
         # downloads but cannot finalize (failure or tracking pending). The
         # post-retry reconciliation finalizes it exactly once when every
@@ -234,6 +242,7 @@ class DownloadOrchestrator:
         self.wifi_skipped = False
         self.latest_available_firmware_prerelease_dir = None
         self.latest_firmware_nightly_build_id = None
+        self.nightly_run_state = NightlyRunState.UNCHECKED
         self._pending_nightly_build_id = None
         self._pending_nightly_entries = []
         self.available_new_firmware_versions = []
@@ -854,16 +863,23 @@ class DownloadOrchestrator:
         Ensure configured firmware releases and repository prereleases are present locally and remove unmanaged prerelease directories.
 
         Scans firmware releases according to retention and filtering settings, downloads missing release assets and repository prerelease firmware for the selected latest release, records each outcome in the orchestrator's result lists, and prunes prerelease subdirectories that do not match the managed naming and versioning conventions.
+
+        The stable/prerelease stage and the nightly stage are independent: a
+        stable discovery error or empty stable list cannot suppress nightly,
+        and a nightly error cannot break stable. Nightly is invoked exactly
+        once via ``finally`` so early returns inside the stable stage still
+        reach it; firmware must be enabled (``SAVE_FIRMWARE``) for nightly to
+        run at all.
         """
+        # Reset the selected releases at the start of each run
+        self.firmware_releases_selected = None
+        self.latest_available_firmware_prerelease_dir = None
+
+        if not self.config.get("SAVE_FIRMWARE", False):
+            logger.info("Firmware downloads are disabled in configuration")
+            return
+
         try:
-            # Reset the selected releases at the start of each run
-            self.firmware_releases_selected = None
-            self.latest_available_firmware_prerelease_dir = None
-
-            if not self.config.get("SAVE_FIRMWARE", False):
-                logger.info("Firmware downloads are disabled in configuration")
-                return
-
             logger.info("Scanning Firmware releases")
             keep_last_beta = self.config.get("KEEP_LAST_BETA", DEFAULT_KEEP_LAST_BETA)
             keep_limit = self._get_firmware_keep_limit()
@@ -1003,11 +1019,10 @@ class DownloadOrchestrator:
                         result, FILE_TYPE_FIRMWARE_PRERELEASE_REPO
                     )
 
-            # Opt-in rolling firmware-nightly builds (separate source, transactional).
-            self._process_firmware_nightlies()
-
+            # Stable-only up-to-date indicator. Scoped to releases (not
+            # nightlies) so it cannot contradict a nightly finalize/fail/incomplete.
             if not any_firmware_downloaded and not releases_to_download:
-                logger.info("All Firmware assets are up to date.")
+                logger.info("All Firmware releases are up to date.")
 
             # Remove prerelease directories whose version is <= the latest
             # release to prevent accumulation of old prereleases.
@@ -1068,6 +1083,13 @@ class DownloadOrchestrator:
 
         except (requests.RequestException, OSError, ValueError, TypeError) as e:
             logger.error(f"Error processing firmware downloads: {e}", exc_info=True)
+        finally:
+            # Opt-in rolling firmware-nightly builds (separate source,
+            # transactional). Invoked exactly once via finally so a stable
+            # discovery error, empty stable list, or early return cannot
+            # suppress nightly, and a nightly error (caught inside the method)
+            # cannot break already-completed stable work.
+            self._process_firmware_nightlies()
 
     def _process_firmware_nightlies(self) -> None:
         """
@@ -1108,6 +1130,7 @@ class DownloadOrchestrator:
                 return
             if not self.firmware_downloader.should_process_nightly(entries, build_id):
                 logger.debug("Firmware-nightly build %s already complete", build_id)
+                self.nightly_run_state = NightlyRunState.ALREADY_COMPLETE
                 return
             selected = self.firmware_downloader.get_selected_nightly_assets(entries)
             if not selected:
@@ -1134,11 +1157,13 @@ class DownloadOrchestrator:
                 # ultimately succeeds.
                 self._pending_nightly_build_id = build_id
                 self._pending_nightly_entries = list(selected)
+                self.nightly_run_state = NightlyRunState.ATTEMPTED_INCOMPLETE
                 return
 
             self._finalize_nightly_transaction(build_id, selected)
         except (requests.RequestException, OSError, ValueError, TypeError) as e:
             logger.error(f"Error processing firmware nightlies: {e}", exc_info=True)
+            self.nightly_run_state = NightlyRunState.ATTEMPTED_INCOMPLETE
 
     def _finalize_nightly_transaction(
         self, build_id: str, selected: List[Dict[str, Any]]
@@ -1169,6 +1194,7 @@ class DownloadOrchestrator:
                 )
                 self._pending_nightly_build_id = None
                 self._pending_nightly_entries = []
+                self.nightly_run_state = NightlyRunState.ATTEMPTED_INCOMPLETE
                 return False
             ok, reason = self.firmware_downloader._validate_nightly_asset(
                 target_path, name, entry.get("size")
@@ -1183,6 +1209,7 @@ class DownloadOrchestrator:
                 )
                 self._pending_nightly_build_id = None
                 self._pending_nightly_entries = []
+                self.nightly_run_state = NightlyRunState.ATTEMPTED_INCOMPLETE
                 return False
 
         if not self.firmware_downloader.update_nightly_tracking(build_id):
@@ -1193,6 +1220,7 @@ class DownloadOrchestrator:
             )
             self._pending_nightly_build_id = None
             self._pending_nightly_entries = []
+            self.nightly_run_state = NightlyRunState.ATTEMPTED_INCOMPLETE
             return False
 
         self.firmware_downloader.cleanup_superseded_nightlies(build_id)
@@ -1200,6 +1228,7 @@ class DownloadOrchestrator:
         self.latest_firmware_nightly_build_id = build_id
         self._pending_nightly_build_id = None
         self._pending_nightly_entries = []
+        self.nightly_run_state = NightlyRunState.FINALIZED
         return True
 
     def _finalize_nightly_transaction_if_complete(self) -> None:
@@ -1774,6 +1803,14 @@ class DownloadOrchestrator:
             ):
                 downloader = self.firmware_downloader
             if downloader:
+                # Nightly retries are handled as a self-contained branch:
+                # re-derive and validate the canonical managed path, reject
+                # symlinked paths before download, then download + validate +
+                # chmod. Non-nightly retries follow the generic path unchanged.
+                if file_type == FILE_TYPE_FIRMWARE_NIGHTLY:
+                    return self._retry_nightly_failure(
+                        failed_result, url, target_path, file_type
+                    )
                 ok = downloader.download(url, target_path)
                 if ok and downloader.verify(target_path):
                     if file_type in (
@@ -1834,30 +1871,6 @@ class DownloadOrchestrator:
                                 "Downloaded manifest is not valid JSON",
                                 is_retryable_override=False,
                             )
-                    if file_type == FILE_TYPE_FIRMWARE_NIGHTLY:
-                        # Apply the same focused validation the fresh-download
-                        # path uses (regular non-symlink file, exact positive
-                        # size, hash/integrity, ZIP integrity, manifest JSON).
-                        nightly_name = os.path.basename(target_path)
-                        ok, reason = self.firmware_downloader._validate_nightly_asset(
-                            target_path, nightly_name, failed_result.file_size
-                        )
-                        if not ok:
-                            # Remove the bad target plus its current and legacy
-                            # hash sidecars via the nightly-safe cleanup helper
-                            # (cleanup_file alone leaves stale hash metadata).
-                            self.firmware_downloader._remove_nightly_target_and_hash(
-                                target_path
-                            )
-                            return self._create_failure_result(
-                                failed_result,
-                                Path(target_path),
-                                url,
-                                file_type,
-                                "Retry attempt failed",
-                                f"Downloaded nightly asset failed validation: {reason}",
-                                is_retryable_override=False,
-                            )
                     return DownloadResult(
                         success=True,
                         release_tag=failed_result.release_tag,
@@ -1889,6 +1902,138 @@ class DownloadOrchestrator:
                 str(exc),
                 is_retryable_override=False,
             )
+
+    def _retry_nightly_failure(
+        self,
+        failed_result: DownloadResult,
+        url: str,
+        target_path: str,
+        file_type: str,
+    ) -> DownloadResult:
+        """
+        Retry a firmware-nightly asset failure with canonical path re-derivation.
+
+        Validates the failed result's release tag as a build-id, sanitizes the
+        expected basename, re-derives the canonical managed target via the
+        fresh path-safety helpers, and requires ``failed_result.file_path`` to
+        identify that exact canonical target. Root/parent/build/target symlinks
+        are rejected before any download attempt. After download the shared
+        nightly validator runs; on failure the bad target and its hash metadata
+        are removed. A validated ``*.sh`` payload regains executable mode only
+        after validation succeeds. Non-nightly retries are unaffected.
+        """
+        fd = self.firmware_downloader
+        build_id = failed_result.release_tag
+        if not isinstance(build_id, str) or not fd.validate_nightly_build_id(build_id):
+            return self._create_failure_result(
+                failed_result,
+                Path(target_path),
+                url,
+                file_type,
+                "Retry attempt failed",
+                f"Invalid firmware-nightly build-id: {build_id!r}",
+                is_retryable_override=False,
+            )
+
+        basename = os.path.basename(target_path)
+        try:
+            canonical = fd.get_nightly_target_path(build_id, basename, create=False)
+        except ValueError as exc:
+            return self._create_failure_result(
+                failed_result,
+                Path(target_path),
+                url,
+                file_type,
+                "Retry attempt failed",
+                f"Unsafe firmware-nightly basename: {exc}",
+                is_retryable_override=False,
+            )
+
+        if canonical != target_path:
+            return self._create_failure_result(
+                failed_result,
+                Path(target_path),
+                url,
+                file_type,
+                "Retry attempt failed",
+                "Firmware-nightly retry target is not the canonical managed path",
+                is_retryable_override=False,
+            )
+
+        # Reject any symlink in the managed path chain (root/build/target)
+        # before any download attempt. A symlink at the target itself is
+        # removed (link only, never followed); deeper symlinks are refused
+        # without removal. Download never proceeds through a symlink.
+        build_dir = os.path.dirname(canonical)
+        nightly_root = os.path.dirname(build_dir)
+        target_was_symlink = os.path.islink(canonical)
+        if target_was_symlink:
+            fd._remove_nightly_target_and_hash(canonical)
+        if (
+            target_was_symlink
+            or os.path.islink(build_dir)
+            or os.path.islink(nightly_root)
+        ):
+            return self._create_failure_result(
+                failed_result,
+                Path(target_path),
+                url,
+                file_type,
+                "Retry attempt failed",
+                "Firmware-nightly retry refused through symlink path",
+                is_retryable_override=False,
+            )
+
+        try:
+            ok = fd.download(url, canonical)
+        except (requests.RequestException, OSError, ValueError) as exc:
+            return self._create_failure_result(
+                failed_result,
+                Path(canonical),
+                url,
+                file_type,
+                "",
+                str(exc),
+            )
+        if not ok or not fd.verify(canonical):
+            return self._create_failure_result(
+                failed_result, Path(canonical), url, file_type, "Retry attempt failed"
+            )
+
+        ok_v, reason = fd._validate_nightly_asset(
+            canonical, basename, failed_result.file_size
+        )
+        if not ok_v:
+            fd._remove_nightly_target_and_hash(canonical)
+            return self._create_failure_result(
+                failed_result,
+                Path(canonical),
+                url,
+                file_type,
+                "Retry attempt failed",
+                f"Downloaded nightly asset failed validation: {reason}",
+                is_retryable_override=False,
+            )
+
+        # Executable bit only after the file has been validated.
+        if basename.lower().endswith(".sh") and os.name != "nt":
+            try:
+                os.chmod(canonical, EXECUTABLE_PERMISSIONS)
+            except OSError:
+                pass
+
+        return DownloadResult(
+            success=True,
+            release_tag=failed_result.release_tag,
+            file_path=Path(canonical),
+            download_url=url,
+            file_size=failed_result.file_size,
+            file_type=file_type,
+            retry_count=failed_result.retry_count,
+            retry_timestamp=failed_result.retry_timestamp,
+            error_message=None,
+            is_retryable=False,
+        )
 
     def _generate_retry_report(
         self,

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -1155,7 +1155,9 @@ class DownloadOrchestrator:
                 self._run_nightly_maintenance(build_id, entries)
                 self.nightly_run_state = NightlyRunState.MAINTENANCE_ONLY
                 return
-            selected = self.firmware_downloader.get_selected_nightly_assets(entries)
+            selected = self.firmware_downloader.get_selected_nightly_assets(
+                entries, build_id
+            )
             if not selected:
                 return
 
@@ -2000,14 +2002,19 @@ class DownloadOrchestrator:
         """
         Retry a firmware-nightly asset failure with canonical path re-derivation.
 
-        Validates the failed result's release tag as a build-id, sanitizes the
-        expected basename, re-derives the canonical managed target via the
-        fresh path-safety helpers, and requires ``failed_result.file_path`` to
-        identify that exact canonical target. Root/parent/build/target symlinks
-        are rejected before any download attempt. After download the shared
-        nightly validator runs; on failure the bad target and its hash metadata
-        are removed. A validated ``*.sh`` payload regains executable mode only
-        after validation succeeds. Non-nightly retries are unaffected.
+        Mutation order (outside paths are never touched until canonical proof):
+          1. Validate build-id and sanitize the basename.
+          2. Derive the canonical managed target (non-writing) and compare
+             the normalized failed path to it. If they differ, reject
+             immediately — nothing is removed, created, or downloaded.
+          3. Only after exact canonical proof: if the canonical target is a
+             symlink, unlink it link-only (never following it). External
+             targets are never touched.
+          4. Run the full resolver for ancestor/containment validation.
+          5. Reject any symlink in the managed ancestor chain.
+          6. Download + validate + chmod (same as the initial download path).
+
+        Non-nightly retries are unaffected.
         """
         fd = self.firmware_downloader
         build_id = failed_result.release_tag
@@ -2023,15 +2030,60 @@ class DownloadOrchestrator:
             )
 
         basename = os.path.basename(target_path)
+        # Sanitize name so we can compute the canonical path for comparison
+        # without calling the full resolver (which raises on a symlinked
+        # target in non-write mode).
+        try:
+            safe_name = fd._sanitize_required(basename, "nightly asset name")
+        except ValueError as exc:
+            return self._create_failure_result(
+                failed_result,
+                Path(target_path),
+                url,
+                file_type,
+                "Retry attempt failed",
+                f"Unsafe firmware-nightly asset name: {exc}",
+                is_retryable_override=False,
+            )
+        if safe_name != basename or safe_name in ("", ".", ".."):
+            return self._create_failure_result(
+                failed_result,
+                Path(target_path),
+                url,
+                file_type,
+                "Retry attempt failed",
+                "Firmware-nightly retry target has unsafe multi-component name",
+                is_retryable_override=False,
+            )
 
-        # Reject any symlink at the target itself before calling the resolver.
-        # The non-write resolver raises ValueError on a symlinked target; we
-        # need to remove the link (never following it) before the resolver
-        # so the retry reports the right failure and the link is cleaned up.
+        # Derive the canonical managed target (non-writing) for comparison.
+        canonical_expected = os.path.join(
+            fd._nightly_root_for_safety(), build_id, safe_name
+        )
+
+        # Compare normalized paths FIRST. Outside regular and symlink paths
+        # are untouched — nothing is removed or created until canonical proof.
+        if os.path.normpath(canonical_expected) != os.path.normpath(target_path):
+            return self._create_failure_result(
+                failed_result,
+                Path(target_path),
+                url,
+                file_type,
+                "Retry attempt failed",
+                "Firmware-nightly retry target is not the canonical managed path",
+                is_retryable_override=False,
+            )
+
+        # Only after exact canonical proof may the canonical symlink be
+        # unlinked (link-only, never following it). External targets are
+        # never touched.
         target_was_symlink = os.path.islink(target_path)
         if target_was_symlink:
             fd._remove_nightly_target_and_hash(target_path)
 
+        # Full validation via the shared resolver (ancestor checks,
+        # containment, target symlink). The target symlink was already
+        # removed above, so this validates the remaining ancestor chain.
         try:
             canonical = fd.get_nightly_target_path(build_id, basename, create=False)
         except ValueError as exc:
@@ -2045,20 +2097,9 @@ class DownloadOrchestrator:
                 is_retryable_override=False,
             )
 
-        if canonical != target_path:
-            return self._create_failure_result(
-                failed_result,
-                Path(target_path),
-                url,
-                file_type,
-                "Retry attempt failed",
-                "Firmware-nightly retry target is not the canonical managed path",
-                is_retryable_override=False,
-            )
-
         # Reject any symlink in the managed path chain (build dir, nightly
-        # root) before any download attempt. The target symlink was already
-        # removed above. Download never proceeds through a symlink.
+        # root). The target symlink was already removed above; if it was
+        # present, reject the retry so the next run downloads fresh.
         build_dir = os.path.dirname(canonical)
         nightly_root = os.path.dirname(build_dir)
         if (

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -26,6 +26,7 @@ from fetchtastic.client_release_discovery import (
 from fetchtastic.constants import (
     APKS_DIR_NAME,
     DEFAULT_APP_VERSIONS_TO_KEEP,
+    DEFAULT_CHECK_FIRMWARE_NIGHTLIES,
     DEFAULT_FILTER_REVOKED_RELEASES,
     DEFAULT_FIRMWARE_VERSIONS_TO_KEEP,
     DEFAULT_KEEP_LAST_BETA,
@@ -40,6 +41,7 @@ from fetchtastic.constants import (
     FILE_TYPE_DESKTOP_PRERELEASE,
     FILE_TYPE_FIRMWARE,
     FILE_TYPE_FIRMWARE_MANIFEST,
+    FILE_TYPE_FIRMWARE_NIGHTLY,
     FILE_TYPE_FIRMWARE_PRERELEASE,
     FILE_TYPE_FIRMWARE_PRERELEASE_REPO,
     FILE_TYPE_REPOSITORY,
@@ -48,6 +50,7 @@ from fetchtastic.constants import (
     FIRMWARE_DIR_PREFIX,
     FIRMWARE_MANIFEST_EXTENSION,
     FIRMWARE_PRERELEASES_DIR_NAME,
+    LATEST_FIRMWARE_NIGHTLY_JSON_FILE,
     LATEST_POINTER_NAME,
     MAX_RETRY_DELAY,
     RELEASE_SCAN_COUNT,
@@ -184,6 +187,8 @@ class DownloadOrchestrator:
         # Single-run only: cleared after _log_prerelease_summary()
         self.firmware_prerelease_summary: Optional[Dict[str, Any]] = None
         self.latest_available_firmware_prerelease_dir: Optional[str] = None
+        # Run-scoped nightly build-id: set after successful nightly processing.
+        self.latest_firmware_nightly_build_id: Optional[str] = None
         # Run-scoped selected set: reset at start of _process_firmware_downloads()
         self.firmware_releases_selected: Optional[List[Release]] = None
         self._client_app_downloads_processed = False
@@ -222,6 +227,7 @@ class DownloadOrchestrator:
         start_time = time.time()
         self.wifi_skipped = False
         self.latest_available_firmware_prerelease_dir = None
+        self.latest_firmware_nightly_build_id = None
         self.available_new_firmware_versions = []
         self.available_new_apk_versions = []
         self._client_app_downloads_processed = False
@@ -985,6 +991,9 @@ class DownloadOrchestrator:
                         result, FILE_TYPE_FIRMWARE_PRERELEASE_REPO
                     )
 
+            # Opt-in rolling firmware-nightly builds (separate source, transactional).
+            self._process_firmware_nightlies()
+
             if not any_firmware_downloaded and not releases_to_download:
                 logger.info("All Firmware assets are up to date.")
 
@@ -1047,6 +1056,70 @@ class DownloadOrchestrator:
 
         except (requests.RequestException, OSError, ValueError, TypeError) as e:
             logger.error(f"Error processing firmware downloads: {e}", exc_info=True)
+
+    def _process_firmware_nightlies(self) -> None:
+        """
+        Process opt-in rolling firmware-nightly builds transactionally.
+
+        When ``CHECK_FIRMWARE_NIGHTLIES`` is disabled (the default) this method
+        returns without touching the network.  When enabled it fetches the
+        firmware-nightly listing, parses the build-id, and — only when the
+        build should be processed — downloads every selected asset.  Tracking,
+        latest-pointer, and cleanup are advanced **only after all selected
+        assets succeed**; any failure defers all three so the next run can
+        retry the same build from a clean state.
+        """
+        if not coerce_bool(
+            self.config.get(
+                "CHECK_FIRMWARE_NIGHTLIES", DEFAULT_CHECK_FIRMWARE_NIGHTLIES
+            ),
+            DEFAULT_CHECK_FIRMWARE_NIGHTLIES,
+        ):
+            return
+        try:
+            entries = self.firmware_downloader.fetch_firmware_nightlies()
+            if not entries:
+                return
+            build_id = self.firmware_downloader.get_nightly_build_id(entries)
+            if not build_id:
+                logger.debug(
+                    "No firmware-nightly release manifest in listing; skipping"
+                )
+                return
+            if not self.firmware_downloader.should_process_nightly(entries, build_id):
+                logger.debug("Firmware-nightly build %s already complete", build_id)
+                return
+            selected = self.firmware_downloader.get_selected_nightly_assets(entries)
+            if not selected:
+                return
+
+            logger.info("Downloading firmware-nightly build %s", build_id)
+            all_success = True
+            for entry in selected:
+                result = self.firmware_downloader.download_nightly_asset(
+                    entry, build_id
+                )
+                self._handle_download_result(result, FILE_TYPE_FIRMWARE_NIGHTLY)
+                if not result.success:
+                    all_success = False
+
+            if not all_success:
+                logger.warning(
+                    "Firmware-nightly build %s has failed assets; "
+                    "tracking, latest pointer, and cleanup deferred",
+                    build_id,
+                )
+                return
+
+            if not self.firmware_downloader.update_nightly_tracking(build_id):
+                logger.warning(
+                    "Failed to update firmware-nightly tracking for %s", build_id
+                )
+            self.firmware_downloader.cleanup_superseded_nightlies(build_id)
+            self.firmware_downloader.update_latest_pointer_for_nightly(build_id)
+            self.latest_firmware_nightly_build_id = build_id
+        except (requests.RequestException, OSError, ValueError, TypeError) as e:
+            logger.error(f"Error processing firmware nightlies: {e}", exc_info=True)
 
     def _select_latest_release_by_version(
         self, releases: List[Release]
@@ -1886,6 +1959,7 @@ class DownloadOrchestrator:
                 if r.file_type
                 in (
                     FILE_TYPE_FIRMWARE,
+                    FILE_TYPE_FIRMWARE_NIGHTLY,
                     FILE_TYPE_FIRMWARE_PRERELEASE,
                     FILE_TYPE_FIRMWARE_PRERELEASE_REPO,
                     FILE_TYPE_FIRMWARE_MANIFEST,
@@ -1909,6 +1983,7 @@ class DownloadOrchestrator:
                 if f.file_type
                 in (
                     FILE_TYPE_FIRMWARE,
+                    FILE_TYPE_FIRMWARE_NIGHTLY,
                     FILE_TYPE_FIRMWARE_PRERELEASE,
                     FILE_TYPE_FIRMWARE_PRERELEASE_REPO,
                     FILE_TYPE_FIRMWARE_MANIFEST,
@@ -2339,16 +2414,22 @@ class DownloadOrchestrator:
             if not latest_firmware_release:
                 return
 
+            clean_latest_release = (
+                self.version_manager.extract_clean_version(latest_firmware_release)
+                or latest_firmware_release
+            )
+            # Retained as a parseability gate: if the next-patch derivation fails
+            # the tag is too malformed to admit any prerelease base.
             expected_version = (
                 self.version_manager.calculate_expected_prerelease_version(
-                    latest_firmware_release
+                    clean_latest_release
                 )
             )
             if not expected_version:
                 return
 
             history = self.prerelease_manager.get_prerelease_commit_history(
-                expected_version,
+                clean_latest_release,
                 cache_manager=self.cache_manager,
                 github_token=self.config.get("GITHUB_TOKEN"),
                 allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
@@ -2402,6 +2483,7 @@ class DownloadOrchestrator:
                 - "android": latest client app release tag (legacy compat key) or None
                 - "firmware": latest firmware release tag or None
                 - "firmware_prerelease": active firmware prerelease identifier (without "firmware-" prefix when applicable) or None
+                - "firmware_nightly": tracked firmware-nightly build-id or None
                 - "android_prerelease": latest client app prerelease tag (legacy compat key) or None
                 - "desktop": latest client app release tag (Desktop-classified, legacy compat key) or None
                 - "desktop_prerelease": latest client app prerelease tag (Desktop-classified, legacy compat key) or None
@@ -2429,7 +2511,7 @@ class DownloadOrchestrator:
                 # Do not force refresh here to avoid API calls just for status display
                 active_dir, _ = (
                     self.prerelease_manager.get_latest_active_prerelease_from_history(
-                        expected_version,
+                        clean_latest_release,
                         cache_manager=self.cache_manager,
                         github_token=self.config.get("GITHUB_TOKEN"),
                         allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
@@ -2440,6 +2522,8 @@ class DownloadOrchestrator:
                     firmware_prerelease = active_dir[len(FIRMWARE_DIR_PREFIX) :]
                 else:
                     firmware_prerelease = active_dir
+
+        firmware_nightly = self._get_latest_firmware_nightly_build_id()
 
         app_releases = (
             self.client_app_releases
@@ -2467,10 +2551,27 @@ class DownloadOrchestrator:
             "android": latest_app_release,
             "firmware": latest_firmware_release,
             "firmware_prerelease": firmware_prerelease,
+            "firmware_nightly": firmware_nightly,
             "android_prerelease": latest_app_prerelease,
             "desktop": latest_app_release,
             "desktop_prerelease": latest_app_prerelease,
         }
+
+    def _get_latest_firmware_nightly_build_id(self) -> Optional[str]:
+        """Return the tracked firmware-nightly build-id, preferring the run-scoped value."""
+        if self.latest_firmware_nightly_build_id:
+            return self.latest_firmware_nightly_build_id
+        try:
+            tracking_path = self.cache_manager.get_cache_file_path(
+                LATEST_FIRMWARE_NIGHTLY_JSON_FILE
+            )
+            data = self.cache_manager.read_json(tracking_path)
+        except (OSError, ValueError, TypeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        build_id = data.get("build_id")
+        return build_id if isinstance(build_id, str) and build_id else None
 
     def update_version_tracking(self) -> None:
         """

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -189,6 +189,12 @@ class DownloadOrchestrator:
         self.latest_available_firmware_prerelease_dir: Optional[str] = None
         # Run-scoped nightly build-id: set after successful nightly processing.
         self.latest_firmware_nightly_build_id: Optional[str] = None
+        # Run-scoped pending nightly transaction: populated when a nightly build
+        # downloads but cannot finalize (failure or tracking pending). The
+        # post-retry reconciliation finalizes it exactly once when every
+        # selected asset is successful and on-disk complete.
+        self._pending_nightly_build_id: Optional[str] = None
+        self._pending_nightly_entries: List[Dict[str, Any]] = []
         # Run-scoped selected set: reset at start of _process_firmware_downloads()
         self.firmware_releases_selected: Optional[List[Release]] = None
         self._client_app_downloads_processed = False
@@ -228,6 +234,8 @@ class DownloadOrchestrator:
         self.wifi_skipped = False
         self.latest_available_firmware_prerelease_dir = None
         self.latest_firmware_nightly_build_id = None
+        self._pending_nightly_build_id = None
+        self._pending_nightly_entries = []
         self.available_new_firmware_versions = []
         self.available_new_apk_versions = []
         self._client_app_downloads_processed = False
@@ -261,6 +269,10 @@ class DownloadOrchestrator:
 
         # Retry failed downloads
         self._retry_failed_downloads()
+
+        # Finalize any in-flight firmware-nightly transaction now that retries
+        # have run. No-op unless a nightly build is pending finalization.
+        self._finalize_nightly_transaction_if_complete()
 
         # Log summary
         self._log_download_summary(start_time)
@@ -1064,10 +1076,18 @@ class DownloadOrchestrator:
         When ``CHECK_FIRMWARE_NIGHTLIES`` is disabled (the default) this method
         returns without touching the network.  When enabled it fetches the
         firmware-nightly listing, parses the build-id, and — only when the
-        build should be processed — downloads every selected asset.  Tracking,
-        latest-pointer, and cleanup are advanced **only after all selected
-        assets succeed**; any failure defers all three so the next run can
-        retry the same build from a clean state.
+        build should be processed — downloads every selected asset.
+
+        Tracking, latest-pointer, cleanup, and the run-scoped build-id are
+        advanced **only after all selected assets download successfully AND
+        tracking is persisted**.  Any failure defers all four so the next run
+        can retry the same build from a clean state.
+
+        When assets fail but are eligible for retry, the pending build-id and
+        selected entries are stashed in ``_pending_nightly_*`` so that
+        :meth:`_finalize_nightly_transaction_if_complete` can finalize the
+        transaction exactly once after the retry phase, subject to the same
+        all-assets-complete + tracking-succeeded conditions.
         """
         if not coerce_bool(
             self.config.get(
@@ -1109,17 +1129,111 @@ class DownloadOrchestrator:
                     "tracking, latest pointer, and cleanup deferred",
                     build_id,
                 )
+                # Remember the in-flight transaction so the post-retry
+                # reconciliation can finalize it if every selected asset
+                # ultimately succeeds.
+                self._pending_nightly_build_id = build_id
+                self._pending_nightly_entries = list(selected)
                 return
 
-            if not self.firmware_downloader.update_nightly_tracking(build_id):
-                logger.warning(
-                    "Failed to update firmware-nightly tracking for %s", build_id
-                )
-            self.firmware_downloader.cleanup_superseded_nightlies(build_id)
-            self.firmware_downloader.update_latest_pointer_for_nightly(build_id)
-            self.latest_firmware_nightly_build_id = build_id
+            self._finalize_nightly_transaction(build_id, selected)
         except (requests.RequestException, OSError, ValueError, TypeError) as e:
             logger.error(f"Error processing firmware nightlies: {e}", exc_info=True)
+
+    def _finalize_nightly_transaction(
+        self, build_id: str, selected: List[Dict[str, Any]]
+    ) -> bool:
+        """
+        Finalize a nightly transaction exactly once: every selected asset must
+        be successful and on-disk complete, tracking must succeed, then
+        retention cleanup, the latest pointer, and the run-scoped build-id are
+        advanced together. Returns True only when the whole transaction was
+        finalized.
+
+        On any failure (partial assets, wrong size, tracking failure) nothing
+        is finalized and the pending transaction is cleared so the next run
+        retries from a clean state.
+        """
+        # Every selected asset must be successful AND currently on-disk valid.
+        for entry in selected:
+            name = entry.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            try:
+                target_path = self.firmware_downloader.get_nightly_target_path(
+                    build_id, name, create=False
+                )
+            except ValueError as exc:
+                logger.warning(
+                    "Firmware-nightly build %s cannot be finalized: %s", build_id, exc
+                )
+                self._pending_nightly_build_id = None
+                self._pending_nightly_entries = []
+                return False
+            ok, reason = self.firmware_downloader._validate_nightly_asset(
+                target_path, name, entry.get("size")
+            )
+            if not ok:
+                logger.warning(
+                    "Firmware-nightly build %s not complete (%s: %s); "
+                    "deferring tracking, latest pointer, and cleanup",
+                    build_id,
+                    name,
+                    reason,
+                )
+                self._pending_nightly_build_id = None
+                self._pending_nightly_entries = []
+                return False
+
+        if not self.firmware_downloader.update_nightly_tracking(build_id):
+            logger.warning(
+                "Failed to update firmware-nightly tracking for %s; "
+                "deferring latest pointer, cleanup, and run-scoped id",
+                build_id,
+            )
+            self._pending_nightly_build_id = None
+            self._pending_nightly_entries = []
+            return False
+
+        self.firmware_downloader.cleanup_superseded_nightlies(build_id)
+        self.firmware_downloader.update_latest_pointer_for_nightly(build_id)
+        self.latest_firmware_nightly_build_id = build_id
+        self._pending_nightly_build_id = None
+        self._pending_nightly_entries = []
+        return True
+
+    def _finalize_nightly_transaction_if_complete(self) -> None:
+        """
+        Post-retry reconciliation for the in-flight nightly transaction.
+
+        If a nightly build was downloaded but could not be finalized before the
+        retry phase, attempt finalization now. The transaction finalizes
+        exactly once, only when every selected asset is successful and on-disk
+        complete and tracking persists. Partial retries, wrong-size retries, or
+        tracking failures finalize nothing.
+        """
+        build_id = self._pending_nightly_build_id
+        selected = self._pending_nightly_entries
+        if not build_id or not selected:
+            return
+
+        # Confirm every selected asset is now in the success set.
+        successful_urls = {
+            str(r.download_url)
+            for r in self.download_results
+            if r.success and r.file_type == FILE_TYPE_FIRMWARE_NIGHTLY
+        }
+        all_selected_successful = True
+        for entry in selected:
+            url = entry.get("download_url") or entry.get("browser_download_url")
+            if not url or str(url) not in successful_urls:
+                all_selected_successful = False
+                break
+        if not all_selected_successful:
+            # Leave the pending state in place; nothing to finalize yet.
+            return
+
+        self._finalize_nightly_transaction(build_id, selected)
 
     def _select_latest_release_by_version(
         self, releases: List[Release]
@@ -1656,6 +1770,7 @@ class DownloadOrchestrator:
                 FILE_TYPE_FIRMWARE_PRERELEASE,
                 FILE_TYPE_FIRMWARE_MANIFEST,
                 FILE_TYPE_FIRMWARE_PRERELEASE_REPO,
+                FILE_TYPE_FIRMWARE_NIGHTLY,
             ):
                 downloader = self.firmware_downloader
             if downloader:
@@ -1717,6 +1832,30 @@ class DownloadOrchestrator:
                                 file_type,
                                 "Retry attempt failed",
                                 "Downloaded manifest is not valid JSON",
+                                is_retryable_override=False,
+                            )
+                    if file_type == FILE_TYPE_FIRMWARE_NIGHTLY:
+                        # Apply the same focused validation the fresh-download
+                        # path uses (regular non-symlink file, exact positive
+                        # size, hash/integrity, ZIP integrity, manifest JSON).
+                        nightly_name = os.path.basename(target_path)
+                        ok, reason = self.firmware_downloader._validate_nightly_asset(
+                            target_path, nightly_name, failed_result.file_size
+                        )
+                        if not ok:
+                            # Remove the bad target plus its current and legacy
+                            # hash sidecars via the nightly-safe cleanup helper
+                            # (cleanup_file alone leaves stale hash metadata).
+                            self.firmware_downloader._remove_nightly_target_and_hash(
+                                target_path
+                            )
+                            return self._create_failure_result(
+                                failed_result,
+                                Path(target_path),
+                                url,
+                                file_type,
+                                "Retry attempt failed",
+                                f"Downloaded nightly asset failed validation: {reason}",
                                 is_retryable_override=False,
                             )
                     return DownloadResult(

--- a/src/fetchtastic/download/prerelease_history.py
+++ b/src/fetchtastic/download/prerelease_history.py
@@ -254,7 +254,7 @@ class PrereleaseHistoryManager:
         *,
         directory: str,
         identifier: str,
-        expected_version: str,
+        base_version: str,
         short_hash: str,
         timestamp: Optional[str],
         sha: Optional[str],
@@ -268,7 +268,7 @@ class PrereleaseHistoryManager:
             entries (Dict[str, Dict[str, Any]]): Mapping of directory names to prerelease entry dictionaries to update.
             directory (str): Directory key under which to record the prerelease.
             identifier (str): Identifier for the prerelease (e.g., directory suffix or version).
-            expected_version (str): Base version expected for this prerelease; used when creating a default entry.
+            base_version (str): Actual base version of this prerelease (parsed from the commit); recorded on the default entry.
             short_hash (str): Short commit hash or identifier to store on default entry creation.
             timestamp (Optional[str]): Timestamp string to set as `added_at` if the entry does not already have it.
             sha (Optional[str]): Full commit SHA to set as `added_sha` if the entry does not already have it.
@@ -278,7 +278,7 @@ class PrereleaseHistoryManager:
             self._create_default_prerelease_entry(
                 directory=directory,
                 identifier=identifier,
-                base_version=expected_version,
+                base_version=base_version,
                 commit_hash=short_hash,
             ),
         )
@@ -297,7 +297,7 @@ class PrereleaseHistoryManager:
         *,
         directory: str,
         identifier: str,
-        expected_version: str,
+        base_version: str,
         short_hash: str,
         timestamp: Optional[str],
         sha: Optional[str],
@@ -309,7 +309,7 @@ class PrereleaseHistoryManager:
             entries (Dict[str, Dict[str, Any]]): Mapping of directory names to prerelease history entries to update.
             directory (str): Directory key under which the prerelease entry is stored/created.
             identifier (str): Prerelease identifier (e.g., directory suffix or ID) to store on a new entry.
-            expected_version (str): Base version that the prerelease is associated with; used when creating a default entry.
+            base_version (str): Actual base version of this prerelease (parsed from the commit); recorded on the default entry.
             short_hash (str): Short commit hash to store in a newly created default entry.
             timestamp (Optional[str]): ISO-8601 timestamp when the deletion occurred; set to `removed_at` if not already present.
             sha (Optional[str]): Full commit SHA associated with the deletion; set to `removed_sha` if not already present.
@@ -319,7 +319,7 @@ class PrereleaseHistoryManager:
             self._create_default_prerelease_entry(
                 directory=directory,
                 identifier=identifier,
-                base_version=expected_version,
+                base_version=base_version,
                 commit_hash=short_hash,
             ),
         )
@@ -331,15 +331,15 @@ class PrereleaseHistoryManager:
         entry["status"] = "deleted"
 
     def build_simplified_prerelease_history(
-        self, expected_version: str, commits: List[Dict[str, Any]]
+        self, stable_version: str, commits: List[Dict[str, Any]]
     ) -> Tuple[List[Dict[str, Any]], set[str]]:
         """
-        Construct a simplified prerelease history for a given base version by parsing commit messages.
+        Construct a simplified prerelease history for prereleases strictly newer than a stable release by parsing commit messages.
 
-        Scans commits from oldest to newest and records prerelease addition and deletion events that match expected_version; entries are merged per directory and sorted by added timestamp then directory.
+        Scans commits from oldest to newest and records prerelease addition and deletion events whose base version is strictly newer than stable_version; entries are merged per directory and sorted by added timestamp then directory.
 
         Parameters:
-            expected_version (str): Base firmware version to filter prerelease events (e.g., "1.2.3").
+            stable_version (str): Latest stable release used as the admission floor (e.g., "2.7.26"); prerelease events with a base strictly newer than this are recorded.
             commits (List[Dict[str, Any]]): List of commit objects to scan for prerelease add/remove messages.
 
         Returns:
@@ -368,7 +368,9 @@ class PrereleaseHistoryManager:
                 m_add = self._PRERELEASE_ADD_RX.match(line)
                 if m_add:
                     base_version, short_hash = m_add.group(1), m_add.group(2)
-                    if base_version != expected_version:
+                    if not self.version_manager.is_prerelease_base_newer_than_stable(
+                        base_version, stable_version
+                    ):
                         continue
                     identifier = f"{base_version}.{short_hash}".lower()
                     directory = f"{FIRMWARE_DIR_PREFIX}{identifier}"
@@ -376,7 +378,7 @@ class PrereleaseHistoryManager:
                         entries_by_dir,
                         directory=directory,
                         identifier=identifier,
-                        expected_version=expected_version,
+                        base_version=base_version,
                         short_hash=short_hash,
                         timestamp=timestamp,
                         sha=str(sha) if sha else None,
@@ -386,7 +388,9 @@ class PrereleaseHistoryManager:
                 m_del = self._PRERELEASE_DELETE_RX.match(line)
                 if m_del:
                     base_version, short_hash = m_del.group(1), m_del.group(2)
-                    if base_version != expected_version:
+                    if not self.version_manager.is_prerelease_base_newer_than_stable(
+                        base_version, stable_version
+                    ):
                         continue
                     identifier = f"{base_version}.{short_hash}".lower()
                     directory = f"{FIRMWARE_DIR_PREFIX}{identifier}"
@@ -394,7 +398,7 @@ class PrereleaseHistoryManager:
                         entries_by_dir,
                         directory=directory,
                         identifier=identifier,
-                        expected_version=expected_version,
+                        base_version=base_version,
                         short_hash=short_hash,
                         timestamp=timestamp,
                         sha=str(sha) if sha else None,
@@ -411,7 +415,7 @@ class PrereleaseHistoryManager:
 
     def get_prerelease_commit_history(
         self,
-        expected_version: str,
+        stable_version: str,
         *,
         cache_manager: Any,
         github_token: Optional[str] = None,
@@ -420,10 +424,10 @@ class PrereleaseHistoryManager:
         max_commits: int = DEFAULT_PRERELEASE_COMMITS_TO_FETCH,
     ) -> List[Dict[str, Any]]:
         """
-        Retrieve simplified prerelease history for a given base version, using a cached value when it is fresh.
+        Retrieve simplified prerelease history for bases strictly newer than a stable release, using a cached value when it is fresh.
 
         Parameters:
-            expected_version (str): Base firmware version to build history for.
+            stable_version (str): Latest stable release used as the admission floor; prereleases with base strictly newer than this are included.
             cache_manager (Any): Cache manager providing `cache_dir`, `read_json(path)` and `atomic_write_json(path, obj)` used to load and persist history.
             github_token (Optional[str]): GitHub token to use for API requests, if any.
             allow_env_token (bool): Whether to allow a token sourced from the environment when `github_token` is not provided.
@@ -431,7 +435,7 @@ class PrereleaseHistoryManager:
             max_commits (int): Maximum number of recent repository commits to fetch when rebuilding history.
 
         Returns:
-            List[Dict[str, Any]]: Simplified prerelease history entries for the specified base version.
+            List[Dict[str, Any]]: Simplified prerelease history entries admitted for the given stable release.
         """
         history_file = os.path.join(
             cache_manager.cache_dir, PRERELEASE_COMMIT_HISTORY_FILE
@@ -442,7 +446,7 @@ class PrereleaseHistoryManager:
         if not isinstance(cache, dict):
             cache = {}
 
-        cached_entry = cache.get(expected_version) if not force_refresh else None
+        cached_entry = cache.get(stable_version) if not force_refresh else None
         cache_was_stale = False
         if isinstance(cached_entry, dict) and not force_refresh:
             entries = cached_entry.get("entries")
@@ -456,14 +460,14 @@ class PrereleaseHistoryManager:
                     if age_s < PRERELEASE_COMMITS_CACHE_EXPIRY_SECONDS:
                         logger.debug(
                             "Using cached prerelease history for %s (cached %.0fs ago)",
-                            expected_version,
+                            stable_version,
                             age_s,
                         )
                         return entries
                     cache_was_stale = True
                     logger.debug(
                         "Prerelease history cache stale for %s (age %.0fs >= %ss); extending cache",
-                        expected_version,
+                        stable_version,
                         age_s,
                         PRERELEASE_COMMITS_CACHE_EXPIRY_SECONDS,
                     )
@@ -476,21 +480,21 @@ class PrereleaseHistoryManager:
             force_refresh=force_refresh,
         )
         entries, shas = self.build_simplified_prerelease_history(
-            expected_version, commits
+            stable_version, commits
         )
 
-        old_version_data = cache.get(expected_version)
-        old_entries = cache.get(expected_version, {}).get("entries")
+        old_version_data = cache.get(stable_version)
+        old_entries = cache.get(stable_version, {}).get("entries")
 
         # Only write if data has changed
         if old_entries == entries:
             if cache_was_stale and isinstance(old_version_data, dict):
                 logger.debug(
                     "Prerelease history data unchanged for %s; updating last_checked",
-                    expected_version,
+                    stable_version,
                 )
                 now_after_build = datetime.now(timezone.utc)
-                cache[expected_version] = {
+                cache[stable_version] = {
                     "entries": entries,
                     "cached_at": old_version_data.get("cached_at"),
                     "last_checked": now_after_build.isoformat(),
@@ -499,18 +503,18 @@ class PrereleaseHistoryManager:
                 if cache_manager.atomic_write_json(history_file, cache):
                     logger.debug(
                         "Extended prerelease history cache freshness for %s",
-                        expected_version,
+                        stable_version,
                     )
                 return entries
             logger.debug(
                 "Prerelease history cache unchanged for %s (total %d entries)",
-                expected_version,
+                stable_version,
                 len(cache),
             )
             return entries
 
         now_after_build = datetime.now(timezone.utc)
-        cache[expected_version] = {
+        cache[stable_version] = {
             "entries": entries,
             "cached_at": now_after_build.isoformat(),
             "last_checked": now_after_build.isoformat(),
@@ -520,13 +524,13 @@ class PrereleaseHistoryManager:
             logger.debug(
                 "Saved %d prerelease history entries to cache for %s",
                 len(entries),
-                expected_version,
+                stable_version,
             )
         return entries
 
     def get_latest_active_prerelease_from_history(
         self,
-        expected_version: str,
+        stable_version: str,
         *,
         cache_manager: Any,
         github_token: Optional[str] = None,
@@ -534,16 +538,16 @@ class PrereleaseHistoryManager:
         force_refresh: bool = False,
     ) -> Tuple[Optional[str], List[Dict[str, Any]]]:
         """
-        Return the most recent active prerelease directory for a base version and the full prerelease history.
+        Return the most recent active prerelease directory strictly newer than a stable release and the full prerelease history.
 
         Parameters:
-            expected_version (str): Base release version to match when selecting prerelease entries.
+            stable_version (str): Latest stable release used as the admission floor when selecting prerelease entries.
 
         Returns:
-            tuple: `latest_dir` is the directory string of the newest active prerelease for `expected_version`, or `None` if no active prerelease exists; `entries` is the list of prerelease history entry dictionaries.
+            tuple: `latest_dir` is the directory string of the newest active prerelease admitted for `stable_version`, or `None` if no active prerelease exists; `entries` is the list of prerelease history entry dictionaries.
         """
         entries = self.get_prerelease_commit_history(
-            expected_version,
+            stable_version,
             cache_manager=cache_manager,
             github_token=github_token,
             allow_env_token=allow_env_token,
@@ -989,17 +993,17 @@ class PrereleaseHistoryManager:
         return found_versions
 
     def scan_prerelease_directories(
-        self, directories: List[str], expected_version: str
+        self, directories: List[str], stable_version: str
     ) -> List[str]:
         """
-        Collect prerelease directory identifiers from a list of directory names that follow the meshtastic.github.io naming convention.
+        Collect prerelease directory identifiers whose base version is strictly newer than a stable release.
 
         Parameters:
             directories (List[str]): Iterable of directory names to inspect (e.g., "firmware-1.2.3.abcd12").
-            expected_version (str): Base version to match (e.g., "1.2.3").
+            stable_version (str): Latest stable release used as the admission floor (e.g., "2.7.26").
 
         Returns:
-            List[str]: List of directory suffixes matching the expected base version (the part after the "firmware-" prefix).
+            List[str]: List of admitted directory suffixes (the part after the "firmware-" prefix) whose parsed base is strictly newer than stable_version.
         """
         matching = []
         for raw_dir_name in directories:
@@ -1012,13 +1016,15 @@ class PrereleaseHistoryManager:
             if len(parts) < 4:
                 continue
             base_version = ".".join(parts[:3])
-            if base_version == expected_version:
+            if self.version_manager.is_prerelease_base_newer_than_stable(
+                base_version, stable_version
+            ):
                 matching.append(dir_name)
         return matching
 
     def find_latest_remote_prerelease_dir(
         self,
-        expected_version: str,
+        stable_version: str,
         *,
         cache_manager: Any,
         github_token: Optional[str] = None,
@@ -1032,7 +1038,7 @@ class PrereleaseHistoryManager:
         Prefers directories whose hash suffixes match identifiers seen in recent prerelease commit history, and falls back to repository directory listings when scoring candidates.
 
         Parameters:
-            expected_version (str): Base version to match against prerelease directory names.
+            stable_version (str): Latest stable release used as the admission floor; only prerelease directories with base strictly newer than this are considered.
             cache_manager: Cache manager used to retrieve repository directories and history.
 
         Returns:
@@ -1041,7 +1047,7 @@ class PrereleaseHistoryManager:
         preferred_hashes: set[str] = set()
         try:
             history_entries = self.get_prerelease_commit_history(
-                expected_version,
+                stable_version,
                 cache_manager=cache_manager,
                 github_token=github_token,
                 allow_env_token=allow_env_token,
@@ -1051,7 +1057,7 @@ class PrereleaseHistoryManager:
         except (requests.RequestException, OSError, ValueError, TypeError) as exc:
             logger.debug(
                 "Failed to build prerelease commit history for %s: %s",
-                expected_version,
+                stable_version,
                 exc,
             )
             history_entries = []
@@ -1077,13 +1083,13 @@ class PrereleaseHistoryManager:
         except (requests.RequestException, OSError, ValueError, TypeError) as exc:
             logger.debug(
                 "Failed to fetch prerelease directories for %s: %s",
-                expected_version,
+                stable_version,
                 exc,
             )
             return None
 
         candidate_suffixes = self.scan_prerelease_directories(
-            [d for d in repo_dirs if isinstance(d, str)], expected_version
+            [d for d in repo_dirs if isinstance(d, str)], stable_version
         )
         if not candidate_suffixes:
             return None

--- a/src/fetchtastic/download/prerelease_history.py
+++ b/src/fetchtastic/download/prerelease_history.py
@@ -762,7 +762,8 @@ class PrereleaseHistoryManager:
                 continue
             valid_current_prereleases.append(current)
             pv = current.get("prerelease_version")
-            current_prerelease_versions.add(pv)
+            if isinstance(pv, str):
+                current_prerelease_versions.add(pv)
 
         # Cleanup superseded/expired prereleases by comparing to current set.
         # Current prereleases are NEVER removed — their metadata is refreshed

--- a/src/fetchtastic/download/version.py
+++ b/src/fetchtastic/download/version.py
@@ -30,6 +30,19 @@ from fetchtastic.log_utils import logger
 from .files import _atomic_write_json
 
 
+def _strip_trailing_zeros(t: Tuple[int, ...]) -> Tuple[int, ...]:
+    """Normalize a release tuple by removing trailing zero components.
+
+    Ensures semantically equal releases compare equal regardless of component
+    count: ``(2, 7, 0)`` and ``(2, 7)`` both reduce to ``(2, 7)``. An all-zero
+    tuple reduces to ``(0,)`` so the result is never empty.
+    """
+    stripped = t
+    while len(stripped) > 1 and stripped[-1] == 0:
+        stripped = stripped[:-1]
+    return stripped
+
+
 class VersionManager:
     """
     Manages version parsing, comparison, and tracking for Meshtastic releases.
@@ -209,11 +222,13 @@ class VersionManager:
         """
         Admit a prerelease base only when its parsed release is strictly newer than the stable release.
 
-        Both inputs are parsed to integer release tuples via :meth:`get_release_tuple`.
-        If either value cannot be parsed the result is conservative (``False``) so
-        unparseable bases are never admitted. This is the single semantic rule for
-        prerelease admission: every base strictly newer than stable is admitted;
-        bases equal to or older than stable are rejected.
+        Both inputs are parsed to integer release tuples via :meth:`get_release_tuple`
+        and normalized by stripping trailing zero components so that semantically
+        equal releases compare equal regardless of component count (``2.7`` ==
+        ``2.7.0``). If either value cannot be parsed the result is conservative
+        (``False``) so unparseable bases are never admitted. This is the single
+        semantic rule for prerelease admission: every base strictly newer than
+        stable is admitted; bases equal to or older than stable are rejected.
 
         Parameters:
             base_version (str): Prerelease base version to admit or reject (e.g., "2.7.27").
@@ -222,13 +237,13 @@ class VersionManager:
 
         Returns:
             bool: ``True`` only when ``base_version`` parses to a release tuple strictly
-            greater than ``stable_version``'s release tuple.
+            greater than ``stable_version``'s normalized release tuple.
         """
         base_tuple = self.get_release_tuple(base_version)
         stable_tuple = self.get_release_tuple(stable_version)
         if base_tuple is None or stable_tuple is None:
             return False
-        return base_tuple > stable_tuple
+        return _strip_trailing_zeros(base_tuple) > _strip_trailing_zeros(stable_tuple)
 
     def ensure_v_prefix_if_missing(self, version: Optional[str]) -> Optional[str]:
         """

--- a/src/fetchtastic/download/version.py
+++ b/src/fetchtastic/download/version.py
@@ -203,6 +203,33 @@ class VersionManager:
             return -1
         return 0
 
+    def is_prerelease_base_newer_than_stable(
+        self, base_version: str, stable_version: str
+    ) -> bool:
+        """
+        Admit a prerelease base only when its parsed release is strictly newer than the stable release.
+
+        Both inputs are parsed to integer release tuples via :meth:`get_release_tuple`.
+        If either value cannot be parsed the result is conservative (``False``) so
+        unparseable bases are never admitted. This is the single semantic rule for
+        prerelease admission: every base strictly newer than stable is admitted;
+        bases equal to or older than stable are rejected.
+
+        Parameters:
+            base_version (str): Prerelease base version to admit or reject (e.g., "2.7.27").
+            stable_version (str): Latest stable release used as the admission floor
+                (e.g., "2.7.26" or "v2.7.26").
+
+        Returns:
+            bool: ``True`` only when ``base_version`` parses to a release tuple strictly
+            greater than ``stable_version``'s release tuple.
+        """
+        base_tuple = self.get_release_tuple(base_version)
+        stable_tuple = self.get_release_tuple(stable_version)
+        if base_tuple is None or stable_tuple is None:
+            return False
+        return base_tuple > stable_tuple
+
     def ensure_v_prefix_if_missing(self, version: Optional[str]) -> Optional[str]:
         """
         Ensure the version string starts with a leading "v".
@@ -1166,6 +1193,25 @@ def calculate_expected_prerelease_version(latest_version: str) -> Optional[str]:
         expected_base_version (Optional[str]): The computed base version for prereleases (for example "1.2.4"); returns None if an expected version cannot be determined.
     """
     return _version_manager.calculate_expected_prerelease_version(latest_version)
+
+
+def is_prerelease_base_newer_than_stable(
+    base_version: str, stable_version: str
+) -> bool:
+    """
+    Admit a prerelease base only when it is strictly newer than the stable release.
+
+    Parameters:
+        base_version (str): Prerelease base version to admit or reject.
+        stable_version (str): Latest stable release used as the admission floor.
+
+    Returns:
+        bool: ``True`` only when ``base_version`` is strictly newer than ``stable_version``;
+        ``False`` when either value cannot be parsed.
+    """
+    return _version_manager.is_prerelease_base_newer_than_stable(
+        base_version, stable_version
+    )
 
 
 def is_prerelease_directory(dir_name: str) -> bool:

--- a/src/fetchtastic/download/version.py
+++ b/src/fetchtastic/download/version.py
@@ -226,7 +226,7 @@ class VersionManager:
         and normalized by stripping trailing zero components so that semantically
         equal releases compare equal regardless of component count (``2.7`` ==
         ``2.7.0``). If either value cannot be parsed the result is conservative
-        (``False``) so unparseable bases are never admitted. This is the single
+        (``False``) so unparsable bases are never admitted. This is the single
         semantic rule for prerelease admission: every base strictly newer than
         stable is admitted; bases equal to or older than stable are rejected.
 

--- a/src/fetchtastic/notifications.py
+++ b/src/fetchtastic/notifications.py
@@ -74,6 +74,7 @@ def send_download_completion_notification(
     downloaded_desktop: Optional[List[str]] = None,
     downloaded_desktop_prereleases: Optional[List[str]] = None,
     downloaded_app_snapshots: Optional[List[str]] = None,
+    downloaded_firmware_nightlies: Optional[List[str]] = None,
 ) -> None:
     """
     Send notification when downloads are completed successfully.
@@ -87,6 +88,7 @@ def send_download_completion_notification(
         downloaded_desktop (Optional[List[str]]): Legacy list of client app desktop versions that were downloaded.
         downloaded_desktop_prereleases (Optional[List[str]]): Legacy list of client app desktop prerelease versions that were downloaded.
         downloaded_app_snapshots (Optional[List[str]]): List of snapshot debug build versionCodes that were downloaded.
+        downloaded_firmware_nightlies (Optional[List[str]]): List of firmware nightly build identifiers that were downloaded.
 
     Side effects:
         - Sends notification to configured NTFY server/topic if downloads occurred.
@@ -99,6 +101,7 @@ def send_download_completion_notification(
     downloaded_desktop = downloaded_desktop or []
     downloaded_desktop_prereleases = downloaded_desktop_prereleases or []
     downloaded_app_snapshots = downloaded_app_snapshots or []
+    downloaded_firmware_nightlies = downloaded_firmware_nightlies or []
     downloaded_client_apps = _dedupe_preserving_order(
         [*downloaded_apks, *downloaded_desktop]
     )
@@ -114,6 +117,7 @@ def send_download_completion_notification(
         and not downloaded_desktop
         and not downloaded_desktop_prereleases
         and not downloaded_app_snapshots
+        and not downloaded_firmware_nightlies
     ):
         return  # No downloads, no notification needed
 
@@ -145,6 +149,13 @@ def send_download_completion_notification(
         message = (
             "Downloaded Android snapshot debug builds: "
             f"{', '.join(downloaded_app_snapshots)}"
+        )
+        notification_messages.append(message)
+
+    if downloaded_firmware_nightlies:
+        message = (
+            "Downloaded firmware nightly builds: "
+            f"{', '.join(downloaded_firmware_nightlies)}"
         )
         notification_messages.append(message)
 

--- a/src/fetchtastic/setup_config.py
+++ b/src/fetchtastic/setup_config.py
@@ -26,6 +26,7 @@ from fetchtastic.constants import (
     DEFAULT_APP_VERSIONS_TO_KEEP,
     DEFAULT_CHECK_APP_PRERELEASES,
     DEFAULT_CHECK_APP_SNAPSHOTS,
+    DEFAULT_CHECK_FIRMWARE_NIGHTLIES,
     DEFAULT_CREATE_LATEST_SYMLINKS,
 )
 from fetchtastic.constants import (
@@ -33,6 +34,7 @@ from fetchtastic.constants import (
 )
 from fetchtastic.constants import (
     DEFAULT_EXTRACTION_PATTERNS,
+    DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP,
     DEFAULT_KEEP_LAST_BETA,
     MESHTASTIC_DIR_NAME,
     NTFY_REQUEST_TIMEOUT,
@@ -834,7 +836,7 @@ def _setup_downloads(
     """
     Configure which asset types (client app assets and firmware) should be downloaded and update the provided configuration accordingly.
 
-    Updates the config in place with keys such as ``SAVE_CLIENT_APPS``, ``SAVE_FIRMWARE``, and, when asset selection menus run, ``SELECTED_APP_ASSETS``, ``SELECTED_FIRMWARE_ASSETS``, ``CHECK_PRERELEASES``, ``CHECK_APP_PRERELEASES``, ``CHECK_APP_SNAPSHOTS``, ``APP_VERSIONS_TO_KEEP``, ``APP_SNAPSHOT_VERSIONS_TO_KEEP``, and ``ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES``.  Legacy keys ``SAVE_APKS`` and ``SELECTED_APK_ASSETS`` are also set for backward compatibility. Prompts the user as needed (or reuses existing values during a partial run) and may disable downloads if no assets are selected.
+    Updates the config in place with keys such as ``SAVE_CLIENT_APPS``, ``SAVE_FIRMWARE``, and, when asset selection menus run, ``SELECTED_APP_ASSETS``, ``SELECTED_FIRMWARE_ASSETS``, ``CHECK_PRERELEASES``, ``CHECK_APP_PRERELEASES``, ``CHECK_APP_SNAPSHOTS``, ``CHECK_FIRMWARE_NIGHTLIES``, ``APP_VERSIONS_TO_KEEP``, ``APP_SNAPSHOT_VERSIONS_TO_KEEP``, ``FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP``, and ``ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES``.  Legacy keys ``SAVE_APKS`` and ``SELECTED_APK_ASSETS`` are also set for backward compatibility. Prompts the user as needed (or reuses existing values during a partial run) and may disable downloads if no assets are selected.
 
     Parameters:
         config (dict): Mutable configuration dictionary to update.
@@ -934,6 +936,7 @@ def _setup_downloads(
     if not save_firmware and (not is_partial_run or wants("firmware")):
         config["CHECK_PRERELEASES"] = False
         config["SELECTED_PRERELEASE_ASSETS"] = []
+        config["CHECK_FIRMWARE_NIGHTLIES"] = False
     if save_client_apps_was_enabled and not save_client_apps:
         _clear_client_app_flags(config)
         config["SAVE_DESKTOP_APP"] = False
@@ -976,6 +979,32 @@ def _setup_downloads(
             default=check_prereleases_default,
         )
         config["CHECK_PRERELEASES"] = _coerce_bool(check_prereleases_input)
+
+    # --- Firmware Nightly (Rolling Experimental) Configuration ---
+    if save_firmware and (not is_partial_run or wants("firmware")):
+        check_nightlies_current = _coerce_bool(
+            config.get("CHECK_FIRMWARE_NIGHTLIES", DEFAULT_CHECK_FIRMWARE_NIGHTLIES)
+        )
+        check_nightlies_default = "y" if check_nightlies_current else "n"
+        check_nightlies_input = _safe_input(
+            f"\nWould you like to check for and download rolling experimental firmware nightly builds? "
+            f"These are not production releases, are replaced on every push to firmware main, "
+            f"and are stored separately under firmware/nightlies/. [y/n] (default: {check_nightlies_default}): ",
+            default=check_nightlies_default,
+        )
+        config["CHECK_FIRMWARE_NIGHTLIES"] = _coerce_bool(
+            check_nightlies_input,
+            default=check_nightlies_current,
+        )
+        if config["CHECK_FIRMWARE_NIGHTLIES"]:
+            nightly_keep = config.get(
+                "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP",
+                DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP,
+            )
+            parsed_keep = _parse_non_negative_int(nightly_keep)
+            if parsed_keep is None or parsed_keep < 1:
+                parsed_keep = DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP
+            config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = parsed_keep
 
     app_section_requested = not is_partial_run or wants("app")
 

--- a/tests/test_cli_notifications.py
+++ b/tests/test_cli_notifications.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from fetchtastic.constants import FILE_TYPE_APP_SNAPSHOT
+from fetchtastic.constants import FILE_TYPE_APP_SNAPSHOT, FILE_TYPE_FIRMWARE_NIGHTLY
 from fetchtastic.download.cli_integration import DownloadCLIIntegration
 from fetchtastic.download.interfaces import DownloadResult
 
@@ -92,6 +92,7 @@ def test_summary_sends_completion_notification(integration):
             [],
             [],
             downloaded_app_snapshots=[],
+            downloaded_firmware_nightlies=[],
         )
         mock_up_to_date.assert_not_called()
 
@@ -464,3 +465,182 @@ def test_send_download_completion_notification_empty_snapshots_no_notification()
         )
 
     mock_ntfy.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# Firmware nightly build reporting (collect release_tag, gate by
+# NOTIFY_ON_FIRMWARE_NIGHTLIES)
+# ------------------------------------------------------------------
+
+
+def test_populated_firmware_nightly_notification_displays_build_id(integration):
+    """Populated firmware nightly results produce build-id in notification, deduplicated."""
+    integration.config["NOTIFY_ON_FIRMWARE_NIGHTLIES"] = True
+    integration.orchestrator.download_results = [
+        DownloadResult(
+            success=True,
+            release_tag="2.7.18.abc123",
+            file_path="/data/firmware-nightly/2.7.18.abc123/firmware.zip",
+            download_url="http://x",
+            file_size=1,
+            file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+            was_skipped=False,
+        ),
+        DownloadResult(
+            success=True,
+            release_tag="2.7.18.abc123",
+            file_path="/data/firmware-nightly/2.7.18.abc123/firmware-esp32.bin",
+            download_url="http://y",
+            file_size=1,
+            file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+            was_skipped=False,
+        ),
+        DownloadResult(
+            success=True,
+            release_tag="2.7.18.abc123",
+            file_path="/data/firmware-nightly/2.7.18.abc123/firmware-nrf52840.bin",
+            download_url="http://z",
+            file_size=1,
+            file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+            was_skipped=True,
+        ),
+    ]
+
+    with patch(
+        "fetchtastic.download.cli_integration.send_download_completion_notification"
+    ) as mock_notify:
+        integration.log_download_results_summary(
+            logger_override=Mock(),
+            elapsed_seconds=1.0,
+            downloaded_firmwares=[],
+            downloaded_apks=[],
+            failed_downloads=[],
+            latest_firmware_version="",
+            latest_apk_version="",
+        )
+
+    mock_notify.assert_called_once()
+    assert mock_notify.call_args.kwargs["downloaded_firmware_nightlies"] == [
+        "2.7.18.abc123"
+    ]
+
+
+def test_firmware_nightly_only_notifications_disabled_sends_nothing(integration):
+    """Firmware-nightly-only download with NOTIFY_ON_FIRMWARE_NIGHTLIES unset → no notification."""
+    integration.orchestrator.download_results = [
+        DownloadResult(
+            success=True,
+            release_tag="2.7.18.abc123",
+            file_path="/data/firmware-nightly/2.7.18.abc123/firmware.zip",
+            download_url="https://example.invalid/firmware.zip",
+            file_size=1,
+            file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+            was_skipped=False,
+        ),
+    ]
+
+    mock_log = Mock()
+    with (
+        patch(
+            "fetchtastic.download.cli_integration.send_download_completion_notification"
+        ) as mock_completion,
+        patch(
+            "fetchtastic.download.cli_integration.send_up_to_date_notification"
+        ) as mock_up_to_date,
+        patch(
+            "fetchtastic.download.cli_integration.send_new_releases_available_notification"
+        ) as mock_new_releases,
+    ):
+        integration.log_download_results_summary(
+            logger_override=mock_log,
+            elapsed_seconds=1.0,
+            downloaded_firmwares=[],
+            downloaded_apks=[],
+            failed_downloads=[],
+            latest_firmware_version="",
+            latest_apk_version="",
+        )
+
+    # No NTFY notifications at all
+    mock_completion.assert_not_called()
+    mock_up_to_date.assert_not_called()
+    mock_new_releases.assert_not_called()
+
+    # Local accounting still works: nonzero download count and nightly build logged
+    log_calls = [str(c) for c in mock_log.info.call_args_list]
+    assert any("Downloaded 1 new versions" in c for c in log_calls)
+    assert any("Downloaded firmware nightly builds:" in c for c in log_calls)
+    assert any("2.7.18.abc123" in c for c in log_calls)
+
+
+def test_failed_firmware_nightly_not_reported_as_downloaded(integration):
+    """Failed firmware nightly results must NOT appear in downloaded_firmware_nightlies."""
+    integration.orchestrator = Mock()
+    integration.orchestrator.wifi_skipped = False
+    integration.orchestrator.download_results = [
+        DownloadResult(
+            success=False,
+            release_tag="2.7.18.abc123",
+            file_path="/data/firmware-nightly/2.7.18.abc123/firmware.zip",
+            download_url="http://x",
+            file_size=1,
+            file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+            was_skipped=False,
+        ),
+    ]
+    integration.orchestrator.log_firmware_release_history_summary = Mock()
+    integration.orchestrator.get_latest_versions = Mock(return_value={})
+
+    with (
+        patch(
+            "fetchtastic.download.cli_integration.send_download_completion_notification"
+        ) as mock_notify,
+        patch("fetchtastic.download.cli_integration.send_up_to_date_notification"),
+    ):
+        integration.log_download_results_summary(
+            logger_override=Mock(),
+            elapsed_seconds=1.0,
+            downloaded_firmwares=[],
+            downloaded_apks=[],
+            failed_downloads=[],
+            latest_firmware_version="",
+            latest_apk_version="",
+        )
+    # No successful downloads → completion notification must not fire.
+    mock_notify.assert_not_called()
+
+
+def test_failed_firmware_nightly_plus_successful_firmware(integration):
+    """A failed nightly must not appear in the notification when firmware succeeded."""
+    integration.orchestrator = Mock()
+    integration.orchestrator.wifi_skipped = False
+    integration.orchestrator.download_results = [
+        DownloadResult(
+            success=False,
+            release_tag="2.7.18.abc123",
+            file_path="/data/firmware-nightly/2.7.18.abc123/firmware.zip",
+            download_url="http://x",
+            file_size=1,
+            file_type=FILE_TYPE_FIRMWARE_NIGHTLY,
+            was_skipped=False,
+        ),
+    ]
+    integration.orchestrator.log_firmware_release_history_summary = Mock()
+    integration.orchestrator.get_latest_versions = Mock(return_value={})
+
+    with patch(
+        "fetchtastic.download.cli_integration.send_download_completion_notification"
+    ) as mock_notify:
+        integration.log_download_results_summary(
+            logger_override=Mock(),
+            elapsed_seconds=1.0,
+            downloaded_firmwares=["v2.8.0"],
+            downloaded_apks=[],
+            failed_downloads=[],
+            latest_firmware_version="v2.8.0",
+            latest_apk_version="",
+        )
+
+    mock_notify.assert_called_once()
+    # The failed nightly must NOT be counted — nightly list stays empty.
+    assert mock_notify.call_args.kwargs["downloaded_firmware_nightlies"] == []

--- a/tests/test_cli_notifications.py
+++ b/tests/test_cli_notifications.py
@@ -3,7 +3,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from fetchtastic.constants import FILE_TYPE_APP_SNAPSHOT, FILE_TYPE_FIRMWARE_NIGHTLY
+from fetchtastic.constants import (
+    FILE_TYPE_APP_SNAPSHOT,
+    FILE_TYPE_FIRMWARE_NIGHTLY,
+    NightlyRunState,
+)
 from fetchtastic.download.cli_integration import DownloadCLIIntegration
 from fetchtastic.download.interfaces import DownloadResult
 
@@ -476,6 +480,10 @@ def test_send_download_completion_notification_empty_snapshots_no_notification()
 def test_populated_firmware_nightly_notification_displays_build_id(integration):
     """Populated firmware nightly results produce build-id in notification, deduplicated."""
     integration.config["NOTIFY_ON_FIRMWARE_NIGHTLIES"] = True
+    # Nightly reporting now keys off the finalized transaction state, not
+    # per-asset results. The orchestrator reports one finalized build-id.
+    integration.orchestrator.nightly_run_state = NightlyRunState.FINALIZED
+    integration.orchestrator.latest_firmware_nightly_build_id = "2.7.18.abc123"
     integration.orchestrator.download_results = [
         DownloadResult(
             success=True,
@@ -527,6 +535,9 @@ def test_populated_firmware_nightly_notification_displays_build_id(integration):
 
 def test_firmware_nightly_only_notifications_disabled_sends_nothing(integration):
     """Firmware-nightly-only download with NOTIFY_ON_FIRMWARE_NIGHTLIES unset → no notification."""
+    # Nightly transaction finalized so it counts locally, but NTFY gate is off.
+    integration.orchestrator.nightly_run_state = NightlyRunState.FINALIZED
+    integration.orchestrator.latest_firmware_nightly_build_id = "2.7.18.abc123"
     integration.orchestrator.download_results = [
         DownloadResult(
             success=True,

--- a/tests/test_cli_notifications.py
+++ b/tests/test_cli_notifications.py
@@ -482,7 +482,7 @@ def test_populated_firmware_nightly_notification_displays_build_id(integration):
     integration.config["NOTIFY_ON_FIRMWARE_NIGHTLIES"] = True
     # Nightly reporting now keys off the finalized transaction state, not
     # per-asset results. The orchestrator reports one finalized build-id.
-    integration.orchestrator.nightly_run_state = NightlyRunState.FINALIZED
+    integration.orchestrator.nightly_run_state = NightlyRunState.FINALIZED_WITH_DOWNLOAD
     integration.orchestrator.latest_firmware_nightly_build_id = "2.7.18.abc123"
     integration.orchestrator.download_results = [
         DownloadResult(
@@ -536,7 +536,7 @@ def test_populated_firmware_nightly_notification_displays_build_id(integration):
 def test_firmware_nightly_only_notifications_disabled_sends_nothing(integration):
     """Firmware-nightly-only download with NOTIFY_ON_FIRMWARE_NIGHTLIES unset → no notification."""
     # Nightly transaction finalized so it counts locally, but NTFY gate is off.
-    integration.orchestrator.nightly_run_state = NightlyRunState.FINALIZED
+    integration.orchestrator.nightly_run_state = NightlyRunState.FINALIZED_WITH_DOWNLOAD
     integration.orchestrator.latest_firmware_nightly_build_id = "2.7.18.abc123"
     integration.orchestrator.download_results = [
         DownloadResult(

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -2997,7 +2997,12 @@ class TestFirmwareUncoveredBranches:
     def test_download_repo_prerelease_firmware_fallback_downloads_all_existing_dirs(
         self, downloader, tmp_path
     ):
-        """Fallback repo scanning should download every matching available prerelease dir."""
+        """Fallback repo scanning should download every dir whose base is strictly newer than stable.
+
+        Under the new admission rule, stable v2.7.22 admits 2.7.23.* AND 2.7.24.*
+        (any base strictly newer than the stable floor).  Returned latest is the
+        sorted-newest across all admitted bases.
+        """
         downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
         downloader.download_dir = str(tmp_path)
 
@@ -3023,11 +3028,13 @@ class TestFirmwareUncoveredBranches:
         ):
             result = downloader.download_repo_prerelease_firmware("v2.7.22.96dd647")
 
-        # After deterministic sorting, the newest (by directory string tiebreaker) is returned
-        assert result[2] == "firmware-2.7.23.7be5426"
+        # Newest admitted dir across bases: 2.7.24.bad9999 > 2.7.23.* > 2.7.22.
+        assert result[2] == "firmware-2.7.24.bad9999"
+        # Deterministic sort: by release tuple then directory string.
         assert [call.args[0] for call in download_assets.call_args_list] == [
             "firmware-2.7.23.2a858be",
             "firmware-2.7.23.7be5426",
+            "firmware-2.7.24.bad9999",
         ]
 
     # Lines 1797-1835: Release notes logging
@@ -4955,3 +4962,120 @@ class TestPrereleaseAvailabilityVerification:
         )
         expected_identifier = expected_latest_dir.removeprefix(FIRMWARE_DIR_PREFIX)
         assert any(expected_identifier in call for call in latest_calls)
+
+
+@pytest.mark.unit
+@pytest.mark.core_downloads
+class TestPrereleaseCrossBaseAdmission:
+    """RED tests: firmware downloader admits prereleases across higher minor/major bases.
+
+    Stable 2.7.26 should admit 2.8.0.<sha> prereleases. The current gate uses
+    exact equality (expected_version == next_patch "2.7.27") in
+    scan_prerelease_directories, filtering out firmware-2.8.0.abcdef1.
+    """
+
+    STABLE_TAG = "v2.7.26"
+    EXPECTED_NEXT_PATCH = "2.7.27"
+    HIGHER_MINOR_DIR = "firmware-2.8.0.abcdef1"
+
+    def test_download_repo_prerelease_firmware_admits_higher_minor_base(
+        self, downloader, tmp_path
+    ):
+        """Stable 2.7.26 downloads firmware-2.8.0.abcdef1 when no 2.7.27 prerelease exists."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        with (
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(None, []),
+            ),
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[self.HIGHER_MINOR_DIR],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ) as download_assets,
+        ):
+            _results, _failed, latest, _summary = (
+                downloader.download_repo_prerelease_firmware(self.STABLE_TAG)
+            )
+
+        download_assets.assert_called_once()
+        assert download_assets.call_args.args[0] == self.HIGHER_MINOR_DIR
+        assert latest == self.HIGHER_MINOR_DIR
+
+    def test_download_repo_prerelease_firmware_ranks_shas_across_bases_by_chronology(
+        self, downloader, tmp_path
+    ):
+        """When 2.7.27 and 2.8.0 prereleases both exist, added_at chronology ranks them."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+
+        older_dir = "firmware-2.7.27.aaaaaa"
+        newer_dir = "firmware-2.8.0.bbbbbb"
+        history_entries = [
+            {
+                "directory": older_dir,
+                "identifier": "2.7.27.aaaaaa",
+                "status": "active",
+                "added_at": "2024-01-01T00:00:00Z",
+            },
+            {
+                "directory": newer_dir,
+                "identifier": "2.8.0.bbbbbb",
+                "status": "active",
+                "added_at": "2024-01-02T00:00:00Z",
+            },
+        ]
+
+        with (
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(older_dir, history_entries),
+            ),
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[older_dir, newer_dir],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ),
+        ):
+            _results, _failed, latest, _summary = (
+                downloader.download_repo_prerelease_firmware(self.STABLE_TAG)
+            )
+
+        assert latest == newer_dir
+
+    def test_download_repo_prerelease_firmware_disabled_leaves_install_untouched(
+        self, downloader, tmp_path
+    ):
+        """Prerelease-disabled installs never scan or download, even with 2.8.0 available."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = False
+        downloader.config["CHECK_PRERELEASES"] = False
+        downloader.download_dir = str(tmp_path)
+
+        with (
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                return_value=[self.HIGHER_MINOR_DIR],
+            ) as mock_get_dirs,
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+            ) as mock_download,
+        ):
+            result = downloader.download_repo_prerelease_firmware(self.STABLE_TAG)
+
+        assert result == ([], [], None, None)
+        mock_get_dirs.assert_not_called()
+        mock_download.assert_not_called()

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -4967,11 +4967,12 @@ class TestPrereleaseAvailabilityVerification:
 @pytest.mark.unit
 @pytest.mark.core_downloads
 class TestPrereleaseCrossBaseAdmission:
-    """RED tests: firmware downloader admits prereleases across higher minor/major bases.
+    """Firmware downloader admits prereleases across higher minor/major bases.
 
-    Stable 2.7.26 should admit 2.8.0.<sha> prereleases. The current gate uses
-    exact equality (expected_version == next_patch "2.7.27") in
-    scan_prerelease_directories, filtering out firmware-2.8.0.abcdef1.
+    The admission gate uses semantic release-tuple comparison
+    (``is_prerelease_base_newer_than_stable``), so a stable like 2.7.26 admits
+    any strictly-newer prerelease base including 2.8.0.<sha>, not just the
+    next patch (2.7.27).
     """
 
     STABLE_TAG = "v2.7.26"

--- a/tests/test_firmware_nightlies.py
+++ b/tests/test_firmware_nightlies.py
@@ -58,7 +58,7 @@ pytestmark = [pytest.mark.core_downloads, pytest.mark.unit]
 #   should_download_nightly(build_id) -> bool
 #   should_process_nightly(entries, build_id) -> bool
 #   update_nightly_tracking(build_id) -> bool
-#   get_selected_nightly_assets(entries) -> list[dict]
+#   get_selected_nightly_assets(entries, build_id) -> list[dict]
 #   is_nightly_complete(build_id) -> bool
 #   get_nightly_target_path(build_id, name, *, create=False) -> str
 #   download_nightly_asset(entry, build_id) -> DownloadResult
@@ -386,7 +386,7 @@ def test_get_selected_nightly_assets_uses_selected_firmware_assets(
     downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
 
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(listing)
+    selected = select(listing, BUILD_2_8_0)
     # Must include the rak4631 zip but not other devices.
     names = [e["name"] for e in selected]
     assert any("rak4631" in n and n.endswith(".zip") for n in names)
@@ -402,7 +402,7 @@ def test_get_selected_nightly_assets_ignores_dead_keys(downloader):
     downloader.config["SELECTED_ASSETS"] = ["heltec"]
 
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(listing)
+    selected = select(listing, BUILD_2_8_0)
     names = [e["name"] for e in selected]
     assert any("rak4631" in n and n.endswith(".zip") for n in names)
     assert not any("tbeam" in n for n in names)
@@ -415,7 +415,7 @@ def test_get_selected_nightly_assets_includes_release_manifest(downloader):
     downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
 
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(listing)
+    selected = select(listing, BUILD_2_8_0)
     names = [e["name"] for e in selected]
     assert MANIFEST_2_8_0 in names
 
@@ -427,7 +427,7 @@ def test_get_selected_nightly_assets_respects_exclude_patterns(downloader):
     downloader.config["EXCLUDE_PATTERNS"] = ["*.zip"]
 
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(listing)
+    selected = select(listing, BUILD_2_8_0)
     names = [e["name"] for e in selected]
     # The manifest survives; the zip is excluded.
     assert MANIFEST_2_8_0 in names
@@ -440,7 +440,7 @@ def test_get_selected_nightly_assets_empty_when_no_match(downloader):
     downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["nonexistent-device"]
 
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(listing)
+    selected = select(listing, BUILD_2_8_0)
     # The release manifest is always included, so this is exactly the manifest.
     names = [e["name"] for e in selected]
     assert names == [MANIFEST_2_8_0]
@@ -461,7 +461,7 @@ def test_get_selected_nightly_assets_canonical_key_excludes_unrelated_devices(
     downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
 
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(listing)
+    selected = select(listing, BUILD_2_8_0)
     names = [e["name"] for e in selected]
 
     # The rak4631 zip and the release manifest are selected.
@@ -602,7 +602,7 @@ def test_should_process_nightly_same_identity_complete_skips(downloader, cache_m
     # Write all selected assets as fully valid (real zip/manifest + hash) so
     # _validate_nightly_asset passes on the skip path.
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(entries)
+    selected = select(entries, BUILD_2_8_0)
     for entry in selected:
         _write_valid_nightly_asset(downloader, BUILD_2_8_0, entry)
 
@@ -614,7 +614,7 @@ def test_is_nightly_complete_when_all_present(downloader):
     """is_nightly_complete returns True when all selected assets are present."""
     entries = _make_nightly_listing()
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(entries)
+    selected = select(entries, BUILD_2_8_0)
     get_path = _require_method(downloader, "get_nightly_target_path")
     for entry in selected:
         target = get_path(BUILD_2_8_0, entry["name"], create=True)
@@ -665,7 +665,7 @@ def test_should_process_nightly_partial_files_backfills(downloader, cache_manage
 
     entries = _make_nightly_listing()
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(entries)
+    selected = select(entries, BUILD_2_8_0)
     get_path = _require_method(downloader, "get_nightly_target_path")
     # Write only the first selected asset — leave the rest missing.
     if selected:
@@ -1225,7 +1225,7 @@ def test_production_2_8_nightly_selected_assets(downloader):
     downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
 
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(listing)
+    selected = select(listing, BUILD_2_8_0)
     names = [e["name"] for e in selected]
 
     # Must include the rak4631 zip and the release manifest.
@@ -1995,7 +1995,7 @@ def test_should_process_nightly_returns_true_when_hash_missing(
 
     entries = _make_nightly_listing()
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(entries)
+    selected = select(entries, BUILD_2_8_0)
     get_path = _require_method(downloader, "get_nightly_target_path")
     # Write files with correct size but NO hash -> integrity check fails.
     for entry in selected:
@@ -2020,7 +2020,7 @@ def test_should_process_nightly_returns_true_when_zip_corrupt(
 
     entries = _make_nightly_listing()
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(entries)
+    selected = select(entries, BUILD_2_8_0)
     get_path = _require_method(downloader, "get_nightly_target_path")
     for entry in selected:
         target = get_path(BUILD_2_8_0, entry["name"], create=True)
@@ -2045,7 +2045,7 @@ def test_should_process_nightly_returns_true_when_target_is_symlink(
 
     entries = _make_nightly_listing()
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(entries)
+    selected = select(entries, BUILD_2_8_0)
     get_path = _require_method(downloader, "get_nightly_target_path")
     # Point the first selected asset at a symlink.
     first = selected[0]
@@ -2075,7 +2075,7 @@ def test_should_process_nightly_same_identity_all_valid_skips(
 
     entries = _make_nightly_listing()
     select = _require_method(downloader, "get_selected_nightly_assets")
-    selected = select(entries)
+    selected = select(entries, BUILD_2_8_0)
     for entry in selected:
         _write_valid_nightly_asset(downloader, BUILD_2_8_0, entry)
 
@@ -2883,7 +2883,7 @@ def test_nightly_maintenance_runs_cleanup_pointer_chmod(tmp_path):
 
 def test_repair_nightly_executable_metadata_chmods_valid_sh(tmp_path):
     """A valid .sh asset without exec bit gets chmodded; no redownload."""
-    config = _make_config(tmp_path)
+    config = _make_config(tmp_path, SELECTED_FIRMWARE_ASSETS=[])
     dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
     target = dl.get_nightly_target_path(BUILD_2_8_0, "device-install.sh", create=True)
     Path(target).write_bytes(b"#!/bin/sh\necho hi\n")
@@ -2909,7 +2909,7 @@ def test_repair_nightly_executable_metadata_chmods_valid_sh(tmp_path):
 
 def test_repair_nightly_executable_metadata_skips_invalid(tmp_path):
     """An invalid .sh asset is not chmodded."""
-    config = _make_config(tmp_path)
+    config = _make_config(tmp_path, SELECTED_FIRMWARE_ASSETS=[])
     dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
     target = dl.get_nightly_target_path(BUILD_2_8_0, "bad.sh", create=True)
     Path(target).write_bytes(b"bad")
@@ -2920,7 +2920,7 @@ def test_repair_nightly_executable_metadata_skips_invalid(tmp_path):
 
 def test_repair_nightly_executable_metadata_skips_non_sh(tmp_path):
     """A valid .zip asset is never chmodded."""
-    config = _make_config(tmp_path)
+    config = _make_config(tmp_path, SELECTED_FIRMWARE_ASSETS=[])
     dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
     entry = _contents_entry("firmware.zip", size=100)
     repaired = dl.repair_nightly_executable_metadata(BUILD_2_8_0, [entry])
@@ -3162,3 +3162,570 @@ def test_is_nightly_complete_rejects_symlinked_build_dir(tmp_path):
         pytest.skip("Symlinks not supported")
 
     assert dl.is_nightly_complete(BUILD_2_8_0) is False
+
+
+# ==================================================================
+# PC P1-1: Coherent build-aware selection (no mixed generations)
+# ==================================================================
+
+
+_STALE_BUILD = "2.7.99.abc123"
+
+
+def _make_mixed_generation_listing() -> list[dict]:
+    """A listing with files from two build generations."""
+    return [
+        _contents_entry(f"firmware-{BUILD_2_8_0}.json", size=45_000),
+        _contents_entry(f"firmware-rak4631-{BUILD_2_8_0}.zip", size=1_200_000),
+        _contents_entry(f"firmware-rak4631-{BUILD_2_8_0}.mt.json", size=3_200),
+        _contents_entry("device-install.sh", size=12_000),
+        # Stale generation entries.
+        _contents_entry(f"firmware-{_STALE_BUILD}.json", size=44_000),
+        _contents_entry(f"firmware-rak4631-{_STALE_BUILD}.zip", size=1_100_000),
+        _contents_entry(f"firmware-rak4631-{_STALE_BUILD}.mt.json", size=3_100),
+    ]
+
+
+def test_get_selected_nightly_assets_rejects_mixed_generation(downloader):
+    """Only the current build's assets are selected; stale generation excluded."""
+    listing = _make_mixed_generation_listing()
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing, BUILD_2_8_0)
+    names = [e["name"] for e in selected]
+
+    # Current build manifest + rak4631 zip are selected.
+    assert f"firmware-{BUILD_2_8_0}.json" in names
+    assert any(BUILD_2_8_0 in n and n.endswith(".zip") for n in names)
+    # Stale generation entries are never selected.
+    assert not any(_STALE_BUILD in n for n in names)
+    # Per-device manifests are never selected.
+    assert not any(n.endswith(".mt.json") for n in names)
+
+
+def test_get_selected_nightly_assets_excludes_stale_zip_even_if_pattern_matches(
+    downloader,
+):
+    """A stale ZIP matching the pattern is excluded (different build token)."""
+    listing = [
+        _contents_entry(f"firmware-{BUILD_2_8_0}.json"),
+        _contents_entry(f"firmware-rak4631-{_STALE_BUILD}.zip"),
+    ]
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing, BUILD_2_8_0)
+    names = [e["name"] for e in selected]
+
+    assert names == [f"firmware-{BUILD_2_8_0}.json"]
+
+
+def test_get_selected_nightly_assets_excludes_per_device_manifest(downloader):
+    """Per-device manifests are excluded even if they match the pattern."""
+    listing = [
+        _contents_entry(f"firmware-{BUILD_2_8_0}.json"),
+        _contents_entry(f"firmware-rak4631-{BUILD_2_8_0}.mt.json"),
+    ]
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing, BUILD_2_8_0)
+    names = [e["name"] for e in selected]
+
+    assert f"firmware-{BUILD_2_8_0}.json" in names
+    assert not any(n.endswith(".mt.json") for n in names)
+
+
+def test_get_selected_nightly_assets_build_agnostic_helper_eligible(downloader):
+    """A build-agnostic helper (no build token) is eligible under patterns."""
+    listing = [
+        _contents_entry(f"firmware-{BUILD_2_8_0}.json"),
+        _contents_entry("device-install.sh"),
+    ]
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["device-install"]
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing, BUILD_2_8_0)
+    names = [e["name"] for e in selected]
+
+    assert "device-install.sh" in names
+    assert f"firmware-{BUILD_2_8_0}.json" in names
+
+
+def test_get_selected_nightly_assets_deterministic_order(downloader):
+    """Selection is sorted alphabetically and deduplicated by name."""
+    listing = [
+        _contents_entry(f"firmware-{BUILD_2_8_0}.json"),
+        _contents_entry("device-install.sh"),
+        _contents_entry(f"firmware-{BUILD_2_8_0}.json"),  # duplicate
+        _contents_entry("bleota.bin"),
+    ]
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = []
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing, BUILD_2_8_0)
+    names = [e["name"] for e in selected]
+
+    assert names == sorted(names)
+    assert len(names) == len(set(names))
+
+
+def test_get_selected_nightly_assets_rejects_invalid_build_id(downloader):
+    """An invalid build_id yields an empty selection."""
+    listing = _make_nightly_listing()
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    assert select(listing, "../../../etc") == []
+    assert select(listing, "") == []
+
+
+def test_should_process_nightly_uses_build_aware_set(downloader, cache_manager):
+    """should_process_nightly skips only when the build-aware set is complete."""
+    listing = _make_nightly_listing()
+    # Track the current build so should_process_nightly checks same-identity.
+    tracking_path = cache_manager.get_cache_file_path(
+        getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE")
+    )
+    Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing, BUILD_2_8_0)
+    for entry in selected:
+        _write_valid_nightly_asset(downloader, BUILD_2_8_0, entry)
+
+    should = _require_method(downloader, "should_process_nightly")
+    assert should(listing, BUILD_2_8_0) is False
+
+
+def test_orch_nightly_mixed_generation_selects_only_current(tmp_path):
+    """Orchestrator with stale-generation assets downloads only current build.
+
+    The listing has one manifest (BUILD_2_8_0) but also stale zips from a
+    previous generation (no manifest for the stale build). The build-aware
+    selector must exclude the stale zips even if they match the pattern.
+    """
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    listing = [
+        _contents_entry(f"firmware-{BUILD_2_8_0}.json", size=45_000),
+        _contents_entry(f"firmware-rak4631-{BUILD_2_8_0}.zip", size=1_200_000),
+        # Stale zip from a previous generation (no manifest for this build).
+        _contents_entry(f"firmware-rak4631-{_STALE_BUILD}.zip", size=1_100_000),
+    ]
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.should_process_nightly = Mock(return_value=True)
+
+    downloaded_names: list[str] = []
+
+    def _fake_download(entry, build_id):
+        downloaded_names.append(entry["name"])
+        target = fd.get_nightly_target_path(build_id, entry["name"], create=True)
+        Path(target).write_bytes(b"payload")
+        # Store hash so validation passes.
+        import hashlib
+
+        from fetchtastic.utils import get_hash_file_path
+
+        digest = hashlib.sha256(b"payload").hexdigest()
+        hash_path = get_hash_file_path(target)
+        Path(hash_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(hash_path).write_text(f"{digest}  {entry['name']}\n")
+        return DownloadResult(
+            success=True,
+            release_tag=build_id,
+            file_path=Path(target),
+            download_url=entry.get("download_url"),
+            file_size=len(b"payload"),
+            file_type=getattr(
+                constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"
+            ),
+        )
+
+    fd.download_nightly_asset = Mock(side_effect=_fake_download)
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+
+    orch._process_firmware_nightlies()
+
+    # Only current-build assets were downloaded; stale zip excluded.
+    assert all(_STALE_BUILD not in n for n in downloaded_names)
+    assert any(BUILD_2_8_0 in n for n in downloaded_names)
+    assert orch.nightly_run_state == NightlyRunState.FINALIZED_WITH_DOWNLOAD
+
+
+# ==================================================================
+# PC P1-2: Cleanup boundary — ancestor validation
+# ==================================================================
+
+
+def test_cleanup_nightly_rejects_symlinked_download_dir(downloader, tmp_path):
+    """A symlinked DOWNLOAD_DIR returns 0 without scanning or deleting."""
+    nightly_root = tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies"
+    nightly_root.mkdir(parents=True)
+    build_dir = nightly_root / BUILD_2_8_0
+    build_dir.mkdir()
+    (build_dir / "f.zip").write_bytes(b"x")
+
+    # Replace download_dir with a symlink.
+    real_downloads = tmp_path / "downloads"
+    link_downloads = tmp_path / "link_downloads"
+    try:
+        os.symlink(str(real_downloads), str(link_downloads))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+    downloader.config["DOWNLOAD_DIR"] = str(link_downloads)
+
+    removed = downloader.cleanup_superseded_nightlies(BUILD_2_8_0)
+    assert removed == 0
+    assert build_dir.exists()
+
+
+def test_cleanup_nightly_rejects_symlinked_firmware_parent(downloader, tmp_path):
+    """A symlinked firmware/ parent returns 0 without deleting."""
+    nightly_root = tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies"
+    nightly_root.mkdir(parents=True)
+    build_dir = nightly_root / BUILD_2_8_0
+    build_dir.mkdir()
+    (build_dir / "f.zip").write_bytes(b"x")
+
+    firmware_dir = tmp_path / "downloads" / FIRMWARE_DIR_NAME
+    link_firmware = tmp_path / "downloads" / "link_firmware"
+    try:
+        os.symlink(str(firmware_dir), str(link_firmware))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+    # Point DOWNLOAD_DIR at parent so firmware/ is the symlink.
+    downloader.config["DOWNLOAD_DIR"] = str(tmp_path / "downloads")
+    # Monkey-patch FIRMWARE_DIR_NAME lookup by replacing the dir structure.
+    # Actually simpler: just swap firmware/ itself for a symlink.
+    import shutil as _shutil
+
+    _shutil.rmtree(str(firmware_dir))
+    os.symlink(str(tmp_path / "real_firmware"), str(firmware_dir))
+    (tmp_path / "real_firmware").mkdir()
+
+    removed = downloader.cleanup_superseded_nightlies(BUILD_2_8_0)
+    assert removed == 0
+
+
+def test_cleanup_nightly_path_swap_parent_before_cleanup(downloader, tmp_path):
+    """Replacing the nightlies parent immediately before cleanup is safe.
+
+    A path-swap (replace the nightlies directory with a symlink to an
+    external dir right before cleanup) must not delete anything outside.
+    """
+    nightly_root = tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies"
+    nightly_root.mkdir(parents=True)
+    build_dir = nightly_root / BUILD_2_8_0
+    build_dir.mkdir()
+    (build_dir / "f.zip").write_bytes(b"x")
+
+    # External dir with sensitive content.
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "important.txt").write_bytes(b"do-not-delete")
+
+    # Swap: replace nightlies with a symlink to external.
+    import shutil as _shutil
+
+    _shutil.rmtree(str(nightly_root))
+    try:
+        os.symlink(str(external), str(nightly_root))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    removed = downloader.cleanup_superseded_nightlies(BUILD_2_8_0)
+    assert removed == 0
+    # External content is untouched.
+    assert (external / "important.txt").exists()
+    assert (external / "important.txt").read_bytes() == b"do-not-delete"
+
+
+# ==================================================================
+# PC P2-1: Source response — malformed entries fail closed
+# ==================================================================
+
+
+def test_fetch_firmware_nightlies_empty_is_valid(downloader, mock_cache_manager):
+    """None/[] from the source is a valid empty listing, not an error."""
+    mock_cache_manager.get_repo_contents.return_value = []
+    downloader.cache_manager = mock_cache_manager
+    assert downloader.fetch_firmware_nightlies() == []
+
+
+def test_fetch_firmware_nightlies_non_dict_entry_raises(downloader, mock_cache_manager):
+    """A non-dict entry in the listing raises ValueError (fail closed)."""
+    mock_cache_manager.get_repo_contents.return_value = [
+        {"name": "ok.bin"},
+        "not-a-dict",
+    ]
+    downloader.cache_manager = mock_cache_manager
+    with pytest.raises(ValueError, match="non-dict entry"):
+        downloader.fetch_firmware_nightlies()
+
+
+def test_fetch_firmware_nightlies_invalid_name_raises(downloader, mock_cache_manager):
+    """An entry with a non-string name raises ValueError (fail closed)."""
+    mock_cache_manager.get_repo_contents.return_value = [
+        {"name": 123},
+    ]
+    downloader.cache_manager = mock_cache_manager
+    with pytest.raises(ValueError, match="invalid name"):
+        downloader.fetch_firmware_nightlies()
+
+
+def test_fetch_firmware_nightlies_missing_name_raises(downloader, mock_cache_manager):
+    """An entry without a name key raises ValueError (fail closed)."""
+    mock_cache_manager.get_repo_contents.return_value = [
+        {"size": 100},
+    ]
+    downloader.cache_manager = mock_cache_manager
+    with pytest.raises(ValueError, match="invalid name"):
+        downloader.fetch_firmware_nightlies()
+
+
+def test_orch_nightly_malformed_source_sets_check_failed(tmp_path):
+    """A malformed source response sets CHECK_FAILED, not UNCHECKED."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(side_effect=ValueError("malformed"))
+    orch._handle_download_result = Mock()
+
+    orch._process_firmware_nightlies()
+
+    assert orch.nightly_run_state == NightlyRunState.CHECK_FAILED
+    assert orch.latest_firmware_nightly_build_id is None
+
+
+# ==================================================================
+# PC P2-2: Retry mutation order — outside paths untouched
+# ==================================================================
+
+
+def test_retry_nightly_outside_regular_path_untouched(tmp_path):
+    """An outside regular path is not touched; retry fails non-retryable."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    fd.download = Mock()
+    fd.verify = Mock()
+
+    # An outside regular file.
+    outside = tmp_path / "outside.bin"
+    outside.write_bytes(b"secret")
+    failed = DownloadResult(
+        success=False,
+        release_tag=BUILD_2_8_0,
+        file_path=Path(str(outside)),
+        download_url="http://x",
+        file_size=1,
+        file_type=getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"),
+        is_retryable=True,
+    )
+    result = orch._retry_single_failure(failed)
+
+    assert result.success is False
+    assert result.is_retryable is False
+    fd.download.assert_not_called()
+    # The outside file is untouched.
+    assert outside.exists()
+    assert outside.read_bytes() == b"secret"
+
+
+def test_retry_nightly_outside_symlink_untouched(tmp_path):
+    """An outside symlink path is not unlinked; retry fails non-retryable."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    fd.download = Mock()
+    fd.verify = Mock()
+
+    # Create an outside symlink (not in the managed nightly tree).
+    target = tmp_path / "target.bin"
+    target.write_bytes(b"data")
+    link = tmp_path / "rogue_link.bin"
+    try:
+        os.symlink(str(target), str(link))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    failed = DownloadResult(
+        success=False,
+        release_tag=BUILD_2_8_0,
+        file_path=Path(str(link)),
+        download_url="http://x",
+        file_size=1,
+        file_type=getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"),
+        is_retryable=True,
+    )
+    result = orch._retry_single_failure(failed)
+
+    assert result.success is False
+    assert result.is_retryable is False
+    fd.download.assert_not_called()
+    # The outside symlink is NOT removed — it was never proven canonical.
+    assert os.path.islink(str(link))
+    assert target.exists()
+
+
+def test_retry_nightly_coherent_set_reconciliation(tmp_path):
+    """Post-retry reconciliation finalizes when the coherent set is complete.
+
+    A nightly download with one retryable failure stashes the pending
+    transaction. After the failed asset is retried successfully (simulated
+    by adding its success to download_results and removing the failure),
+    _finalize_nightly_transaction_if_complete finalizes the build.
+    """
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    listing = _make_nightly_listing()
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=True)
+
+    selected = fd.get_selected_nightly_assets(listing, BUILD_2_8_0)
+    ftype = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    failed_entry = selected[-1]
+
+    # First pass: one asset fails (retryable), rest succeed.
+    def _first_pass(entry, _build_id):
+        target = fd.get_nightly_target_path(BUILD_2_8_0, entry["name"], create=True)
+        if entry is failed_entry:
+            return DownloadResult(
+                success=False,
+                release_tag=BUILD_2_8_0,
+                file_path=Path(target),
+                download_url=entry.get("download_url"),
+                file_size=entry.get("size"),
+                file_type=ftype,
+                is_retryable=True,
+                error_type=getattr(constants, "ERROR_TYPE_NETWORK", "network"),
+            )
+        Path(target).write_bytes(b"payload")
+        return DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=Path(target),
+            download_url=entry.get("download_url"),
+            file_size=entry.get("size"),
+            file_type=ftype,
+        )
+
+    fd.download_nightly_asset = Mock(side_effect=_first_pass)
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+
+    orch._process_firmware_nightlies()
+
+    # Transaction is pending (one failed asset).
+    assert orch.nightly_run_state == NightlyRunState.ATTEMPTED_INCOMPLETE
+    assert orch._pending_nightly_build_id == BUILD_2_8_0
+
+    # Simulate retry success: remove the nightly failure, add a success result.
+    orch.failed_downloads = [
+        r for r in orch.failed_downloads if not (r.file_type == ftype and not r.success)
+    ]
+    # Write the file for the previously failed asset.
+    target = fd.get_nightly_target_path(BUILD_2_8_0, failed_entry["name"], create=True)
+    Path(target).write_bytes(b"payload")
+    orch.download_results.append(
+        DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=Path(target),
+            download_url=failed_entry.get("download_url"),
+            file_size=failed_entry.get("size"),
+            file_type=ftype,
+        )
+    )
+
+    # Reconciliation finalizes.
+    orch._finalize_nightly_transaction_if_complete()
+
+    assert orch.nightly_run_state == NightlyRunState.FINALIZED_WITH_DOWNLOAD
+    fd.update_nightly_tracking.assert_called_once_with(BUILD_2_8_0)
+
+
+# ==================================================================
+# PC P2-3: is_nightly_complete — path/symlink safety
+# ==================================================================
+
+
+def test_is_nightly_complete_rejects_symlinked_ancestor(downloader, tmp_path):
+    """A symlink in the ancestor chain returns False."""
+    nightly_root = tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies"
+    nightly_root.mkdir(parents=True)
+    build_dir = nightly_root / BUILD_2_8_0
+    build_dir.mkdir()
+    (build_dir / "f.zip").write_bytes(b"x")
+
+    # Replace nightlies root with a symlink.
+    import shutil as _shutil
+
+    real_nightlies = tmp_path / "real_nightlies"
+    real_nightlies.mkdir()
+    _shutil.move(str(build_dir), str(real_nightlies / BUILD_2_8_0))
+    _shutil.rmtree(str(nightly_root))
+    try:
+        os.symlink(str(real_nightlies), str(nightly_root))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    assert downloader.is_nightly_complete(BUILD_2_8_0) is False
+
+
+def test_is_nightly_complete_rejects_file_symlink_inside_build(downloader, tmp_path):
+    """A symlink file inside the build dir is not counted as a real asset."""
+    build_dir = downloader.get_nightly_target_path(BUILD_2_8_0, "real.bin", create=True)
+    build_dir = os.path.dirname(build_dir)
+    real_file = os.path.join(build_dir, "real.bin")
+    Path(real_file).write_bytes(b"x")
+    link_file = os.path.join(build_dir, "link.bin")
+    try:
+        os.symlink(real_file, link_file)
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    # The symlink should not be counted; but real.bin should make it True.
+    assert downloader.is_nightly_complete(BUILD_2_8_0) is True
+
+    # Now remove the real file — only the symlink remains.
+    os.remove(real_file)
+    assert downloader.is_nightly_complete(BUILD_2_8_0) is False
+
+
+def test_is_nightly_complete_false_on_missing_root(downloader):
+    """Missing nightly root returns False."""
+    assert downloader.is_nightly_complete(BUILD_2_8_0) is False
+
+
+def test_is_nightly_complete_does_not_create_directories(downloader, tmp_path):
+    """is_nightly_complete never creates directories."""
+    nightly_root = tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies"
+    assert not nightly_root.exists()
+
+    downloader.is_nightly_complete(BUILD_2_8_0)
+
+    assert not nightly_root.exists()
+    assert not (nightly_root / BUILD_2_8_0).exists()

--- a/tests/test_firmware_nightlies.py
+++ b/tests/test_firmware_nightlies.py
@@ -588,7 +588,7 @@ def test_should_process_nightly_identity_changed(downloader, cache_manager):
 
 
 def test_should_process_nightly_same_identity_complete_skips(downloader, cache_manager):
-    """Same build-id tracked and all selected files present → must NOT process."""
+    """Same build-id tracked and all selected assets fully valid → must NOT process."""
     tracking_file = getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE", None)
     assert (
         tracking_file is not None
@@ -598,13 +598,12 @@ def test_should_process_nightly_same_identity_complete_skips(downloader, cache_m
     Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
 
     entries = _make_nightly_listing()
-    # Write all selected assets to disk so the build is "complete".
+    # Write all selected assets as fully valid (real zip/manifest + hash) so
+    # _validate_nightly_asset passes on the skip path.
     select = _require_method(downloader, "get_selected_nightly_assets")
     selected = select(entries)
-    get_path = _require_method(downloader, "get_nightly_target_path")
     for entry in selected:
-        target = get_path(BUILD_2_8_0, entry["name"], create=True)
-        Path(target).write_bytes(b"x" * entry.get("size", 1))
+        _write_valid_nightly_asset(downloader, BUILD_2_8_0, entry)
 
     should = _require_method(downloader, "should_process_nightly")
     assert should(entries, BUILD_2_8_0) is False
@@ -939,24 +938,25 @@ def test_cleanup_nightly_no_dir(downloader):
 
 
 def test_cleanup_nightly_preserves_latest_pointer(downloader, tmp_path):
-    """cleanup must not remove the 'latest' pointer inside nightlies/."""
+    """cleanup must not remove a valid relative 'latest' pointer inside nightlies/."""
     nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
     base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
     build_dir = base / "2.8.0.f52e2ea"
     build_dir.mkdir(parents=True)
     (build_dir / "firmware.zip").write_bytes(b"x")
-    # Create a latest symlink pointing to the build.
+    # Create a relative latest symlink (same-directory name) pointing to the build,
+    # matching how update_latest_pointer creates managed pointers.
     latest = base / LATEST_POINTER_NAME
     try:
-        os.symlink(str(build_dir), str(latest))
+        os.symlink("2.8.0.f52e2ea", str(latest))
     except OSError:
         pytest.skip("Symlinks not supported on this platform")
 
     downloader.config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = 1
     cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
     cleanup()
-    # The latest pointer must survive cleanup.
-    assert latest.is_symlink() or latest.exists()
+    # The valid retained latest pointer must survive cleanup.
+    assert latest.is_symlink()
 
 
 def test_cleanup_nightly_rejects_symlinked_root(downloader, tmp_path):
@@ -1448,7 +1448,8 @@ def test_retry_single_failure_dispatches_firmware_nightly(tmp_path):
     orch = DownloadOrchestrator(config)
     fd = orch.firmware_downloader
 
-    target = str(tmp_path / "night.bin")
+    # Canonical managed path so the retry revalidation accepts the target.
+    target = fd.get_nightly_target_path(BUILD_2_8_0, "night.bin", create=True)
     # Pre-place a valid file so download + validation succeed.
     Path(target).write_bytes(b"payload")
     save_file_hash(target, "2" * 64)
@@ -1480,7 +1481,8 @@ def test_retry_single_failure_nightly_bad_size_non_retryable(tmp_path):
     orch = DownloadOrchestrator(config)
     fd = orch.firmware_downloader
 
-    target = str(tmp_path / "night.bin")
+    # Canonical managed path so the retry revalidation accepts the target.
+    target = fd.get_nightly_target_path(BUILD_2_8_0, "night.bin", create=True)
     Path(target).write_bytes(b"short")
     save_file_hash(target, "3" * 64)
     # Validation reports a size mismatch.
@@ -1894,7 +1896,8 @@ def test_retry_nightly_wrong_size_removes_hash_and_legacy_sidecars(tmp_path):
     orch = DownloadOrchestrator(config)
     fd = orch.firmware_downloader
 
-    target = str(tmp_path / "night.bin")
+    # Canonical managed path so the retry revalidation accepts the target.
+    target = fd.get_nightly_target_path(BUILD_2_8_0, "night.bin", create=True)
     Path(target).write_bytes(b"wrong-size")
     # Pre-create BOTH hash sidecars so we can assert they are removed.
     current_hash = get_hash_file_path(target)
@@ -1940,7 +1943,8 @@ def test_retry_nightly_invalid_content_removes_hash_sidecars(tmp_path):
     orch = DownloadOrchestrator(config)
     fd = orch.firmware_downloader
 
-    target = str(tmp_path / "night.bin")
+    # Canonical managed path so the retry revalidation accepts the target.
+    target = fd.get_nightly_target_path(BUILD_2_8_0, "night.bin", create=True)
     Path(target).write_bytes(b"content")
     current_hash = get_hash_file_path(target)
     legacy_hash = get_legacy_hash_file_path(target)
@@ -1971,3 +1975,604 @@ def test_retry_nightly_invalid_content_removes_hash_sidecars(tmp_path):
     assert not os.path.exists(target)
     assert not os.path.exists(current_hash)
     assert not os.path.exists(legacy_hash)
+
+
+# ==================================================================
+# PC: Skip validation uses full _validate_nightly_asset
+# ==================================================================
+
+
+def test_should_process_nightly_returns_true_when_hash_missing(
+    downloader, cache_manager
+):
+    """Same identity but a selected asset has no stored hash -> must process (re-validate)."""
+    tracking_path = cache_manager.get_cache_file_path(
+        getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE")
+    )
+    Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
+
+    entries = _make_nightly_listing()
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(entries)
+    get_path = _require_method(downloader, "get_nightly_target_path")
+    # Write files with correct size but NO hash -> integrity check fails.
+    for entry in selected:
+        target = get_path(BUILD_2_8_0, entry["name"], create=True)
+        Path(target).write_bytes(b"x" * entry.get("size", 1))
+
+    should = _require_method(downloader, "should_process_nightly")
+    assert should(entries, BUILD_2_8_0) is True
+
+
+def test_should_process_nightly_returns_true_when_zip_corrupt(
+    downloader, cache_manager
+):
+    """Same identity but a selected zip fails ZIP integrity -> must process."""
+    from fetchtastic.utils import save_file_hash
+
+    tracking_path = cache_manager.get_cache_file_path(
+        getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE")
+    )
+    Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
+
+    entries = _make_nightly_listing()
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(entries)
+    get_path = _require_method(downloader, "get_nightly_target_path")
+    for entry in selected:
+        target = get_path(BUILD_2_8_0, entry["name"], create=True)
+        # Write corrupt bytes (not a valid zip) with correct size and a hash.
+        data = b"\x00" * entry.get("size", 1)
+        Path(target).write_bytes(data)
+        save_file_hash(target, "a" * 64)
+
+    should = _require_method(downloader, "should_process_nightly")
+    assert should(entries, BUILD_2_8_0) is True
+
+
+def test_should_process_nightly_returns_true_when_target_is_symlink(
+    downloader, cache_manager
+):
+    """Same identity but a selected asset is a symlink -> must process."""
+    tracking_path = cache_manager.get_cache_file_path(
+        getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE")
+    )
+    Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
+
+    entries = _make_nightly_listing()
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(entries)
+    get_path = _require_method(downloader, "get_nightly_target_path")
+    # Point the first selected asset at a symlink.
+    first = selected[0]
+    real = get_path(BUILD_2_8_0, "real.bin", create=True)
+    Path(real).write_bytes(b"x" * first.get("size", 1))
+    link = get_path(BUILD_2_8_0, first["name"], create=True)
+    if os.path.exists(link):
+        os.remove(link)
+    try:
+        os.symlink(real, link)
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    should = _require_method(downloader, "should_process_nightly")
+    assert should(entries, BUILD_2_8_0) is True
+
+
+def test_should_process_nightly_same_identity_all_valid_skips(
+    downloader, cache_manager
+):
+    """Same identity and every selected asset passes _validate_nightly_asset -> skip."""
+    tracking_path = cache_manager.get_cache_file_path(
+        getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE")
+    )
+    Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
+
+    entries = _make_nightly_listing()
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(entries)
+    for entry in selected:
+        _write_valid_nightly_asset(downloader, BUILD_2_8_0, entry)
+
+    should = _require_method(downloader, "should_process_nightly")
+    assert should(entries, BUILD_2_8_0) is False
+
+
+# ==================================================================
+# PC: Transaction reporting state machine
+# ==================================================================
+
+
+def test_nightly_run_state_unchecked_by_default(tmp_path):
+    """A fresh orchestrator reports UNCHECKED nightly state."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    assert orch.nightly_run_state == NightlyRunState.UNCHECKED
+
+
+def test_nightly_run_state_already_complete_when_should_process_false(tmp_path):
+    """should_process_nightly False sets ALREADY_COMPLETE."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=_make_nightly_listing())
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=False)
+    orch._handle_download_result = Mock()
+
+    orch._process_firmware_nightlies()
+
+    assert orch.nightly_run_state == NightlyRunState.ALREADY_COMPLETE
+    assert orch.latest_firmware_nightly_build_id is None
+
+
+def test_nightly_run_state_attempted_incomplete_on_partial_failure(tmp_path):
+    """Partial asset failure sets ATTEMPTED_INCOMPLETE (not FINALIZED)."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    listing = _make_nightly_listing()
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=True)
+    asset1, asset2 = listing[0], listing[4]
+    fd.get_selected_nightly_assets = Mock(return_value=[asset1, asset2])
+    ftype = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    fd.download_nightly_asset = Mock(
+        side_effect=[
+            DownloadResult(
+                success=True,
+                release_tag=BUILD_2_8_0,
+                file_path=str(tmp_path / "a"),
+                download_url="http://x",
+                file_size=1,
+                file_type=ftype,
+            ),
+            DownloadResult(
+                success=False,
+                release_tag=BUILD_2_8_0,
+                file_path=str(tmp_path / "b"),
+                download_url="http://y",
+                file_size=1,
+                file_type=ftype,
+            ),
+        ]
+    )
+    orch._handle_download_result = Mock()
+
+    orch._process_firmware_nightlies()
+
+    assert orch.nightly_run_state == NightlyRunState.ATTEMPTED_INCOMPLETE
+    assert orch.latest_firmware_nightly_build_id is None
+
+
+def test_nightly_run_state_finalized_on_full_success(tmp_path):
+    """All assets valid + tracking persists sets FINALIZED + run-scoped build-id."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    listing = _make_nightly_listing()
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=True)
+    selected = [listing[0], listing[4]]
+    fd.get_selected_nightly_assets = Mock(return_value=selected)
+    ftype = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    fd.download_nightly_asset = Mock(
+        return_value=DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=str(tmp_path / "x"),
+            download_url="http://x",
+            file_size=1,
+            file_type=ftype,
+        )
+    )
+    fd.get_nightly_target_path = Mock(return_value=str(tmp_path / "x"))
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+    orch._handle_download_result = Mock()
+
+    orch._process_firmware_nightlies()
+
+    assert orch.nightly_run_state == NightlyRunState.FINALIZED
+    assert orch.latest_firmware_nightly_build_id == BUILD_2_8_0
+
+
+def test_nightly_run_state_finalization_failure_is_attempted_incomplete(tmp_path):
+    """Tracking failure during finalization sets ATTEMPTED_INCOMPLETE, not FINALIZED."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    listing = _make_nightly_listing()
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=True)
+    selected = [listing[0]]
+    fd.get_selected_nightly_assets = Mock(return_value=selected)
+    ftype = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    fd.download_nightly_asset = Mock(
+        return_value=DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=str(tmp_path / "x"),
+            download_url="http://x",
+            file_size=1,
+            file_type=ftype,
+        )
+    )
+    fd.get_nightly_target_path = Mock(return_value=str(tmp_path / "x"))
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
+    fd.update_nightly_tracking = Mock(return_value=False)
+    orch._handle_download_result = Mock()
+
+    orch._process_firmware_nightlies()
+
+    assert orch.nightly_run_state == NightlyRunState.ATTEMPTED_INCOMPLETE
+    assert orch.latest_firmware_nightly_build_id is None
+
+
+def test_post_retry_finalization_sets_finalized(tmp_path):
+    """Post-retry reconciliation that finalizes sets FINALIZED."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    listing = _make_nightly_listing()
+    asset1 = listing[0]
+    ftype = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    orch.download_results = [
+        DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=str(tmp_path / "a"),
+            download_url=asset1["download_url"],
+            file_size=1,
+            file_type=ftype,
+        )
+    ]
+    orch._pending_nightly_build_id = BUILD_2_8_0
+    orch._pending_nightly_entries = [asset1]
+    fd.get_nightly_target_path = Mock(return_value=str(tmp_path / "x"))
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+
+    orch._finalize_nightly_transaction_if_complete()
+
+    assert orch.nightly_run_state == NightlyRunState.FINALIZED
+
+
+# ==================================================================
+# PC: Retry path revalidation
+# ==================================================================
+
+
+def test_retry_nightly_rejects_invalid_build_id(tmp_path):
+    """A release_tag that is not a build-id is rejected non-retryable, no download."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    fd.download = Mock()
+    fd.verify = Mock()
+
+    failed = DownloadResult(
+        success=False,
+        release_tag="../../etc/passwd",
+        file_path=Path(str(tmp_path / "x")),
+        download_url="http://x",
+        file_size=1,
+        file_type=getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"),
+        is_retryable=True,
+    )
+    result = orch._retry_single_failure(failed)
+
+    assert result.success is False
+    assert result.is_retryable is False
+    fd.download.assert_not_called()
+
+
+def test_retry_nightly_rejects_non_canonical_target(tmp_path):
+    """A file_path that differs from the canonical managed target is rejected."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    fd.download = Mock()
+    fd.verify = Mock()
+
+    # A path outside the managed nightly tree.
+    rogue = str(tmp_path / "rogue.bin")
+    failed = DownloadResult(
+        success=False,
+        release_tag=BUILD_2_8_0,
+        file_path=Path(rogue),
+        download_url="http://x",
+        file_size=1,
+        file_type=getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"),
+        is_retryable=True,
+    )
+    result = orch._retry_single_failure(failed)
+
+    assert result.success is False
+    assert result.is_retryable is False
+    fd.download.assert_not_called()
+
+
+def test_retry_nightly_rejects_symlink_target_before_download(tmp_path):
+    """A symlinked canonical target is removed and rejected before download."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+
+    name = "firmware-rak4631-2.8.0.f52e2ea.zip"
+    real = fd.get_nightly_target_path(BUILD_2_8_0, "real.bin", create=True)
+    Path(real).write_bytes(b"real")
+    link = fd.get_nightly_target_path(BUILD_2_8_0, name, create=True)
+    if os.path.exists(link):
+        os.remove(link)
+    try:
+        os.symlink(real, link)
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    fd.download = Mock()
+    fd.verify = Mock()
+
+    failed = DownloadResult(
+        success=False,
+        release_tag=BUILD_2_8_0,
+        file_path=Path(link),
+        download_url="http://x",
+        file_size=5,
+        file_type=getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"),
+        is_retryable=True,
+    )
+    result = orch._retry_single_failure(failed)
+
+    assert result.success is False
+    assert result.is_retryable is False
+    fd.download.assert_not_called()
+    assert not os.path.islink(link)
+
+
+def test_retry_nightly_chmods_sh_after_validation(tmp_path):
+    """A retried .sh nightly asset regains executable mode only after validation."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+
+    name = "device-install.sh"
+    target = fd.get_nightly_target_path(BUILD_2_8_0, name, create=True)
+
+    def _fake_download(url, path):
+        Path(path).write_bytes(b"payload")
+        return True
+
+    fd.download = Mock(side_effect=_fake_download)
+    fd.verify = Mock(return_value=True)
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
+
+    failed = DownloadResult(
+        success=False,
+        release_tag=BUILD_2_8_0,
+        file_path=Path(target),
+        download_url="http://x",
+        file_size=7,
+        file_type=getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"),
+        is_retryable=True,
+    )
+    result = orch._retry_single_failure(failed)
+
+    assert result.success is True
+    import stat as _stat
+
+    mode = _stat.S_IMODE(os.stat(target).st_mode)
+    assert mode & 0o111, "executable bit should be set for *.sh after retry validation"
+
+
+def test_retry_nightly_validation_failure_removes_target_and_hash(tmp_path):
+    """A retried nightly asset that fails validation is removed with its hash metadata."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+    from fetchtastic.utils import get_hash_file_path, get_legacy_hash_file_path
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+
+    name = "firmware-rak4631-2.8.0.f52e2ea.zip"
+    target = fd.get_nightly_target_path(BUILD_2_8_0, name, create=True)
+    Path(target).write_bytes(b"bad")
+    current_hash = get_hash_file_path(target)
+    legacy_hash = get_legacy_hash_file_path(target)
+    Path(current_hash).parent.mkdir(parents=True, exist_ok=True)
+    Path(current_hash).write_text("aaaa  x\n")
+    Path(legacy_hash).write_text("bbbb  x\n")
+
+    fd.download = Mock(return_value=True)
+    fd.verify = Mock(return_value=True)
+    fd._validate_nightly_asset = Mock(return_value=(False, "size mismatch"))
+
+    failed = DownloadResult(
+        success=False,
+        release_tag=BUILD_2_8_0,
+        file_path=Path(target),
+        download_url="http://x",
+        file_size=100,
+        file_type=getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"),
+        is_retryable=True,
+    )
+    result = orch._retry_single_failure(failed)
+
+    assert result.success is False
+    assert result.is_retryable is False
+    assert not os.path.exists(target)
+    assert not os.path.exists(current_hash)
+    assert not os.path.exists(legacy_hash)
+
+
+# ==================================================================
+# PC: Pipeline independence
+# ==================================================================
+
+
+def test_stable_error_does_not_suppress_nightly(tmp_path):
+    """A stable-stage error must not prevent nightly from running."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    # Force stable discovery to raise.
+    orch._ensure_firmware_releases = Mock(
+        side_effect=__import__("requests").RequestException("stable boom")
+    )
+    nightly_called = Mock()
+    orch._process_firmware_nightlies = nightly_called
+
+    orch._process_firmware_downloads()
+
+    nightly_called.assert_called_once()
+
+
+def test_empty_stable_does_not_suppress_nightly(tmp_path):
+    """An empty stable release list must not prevent nightly from running."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    orch._ensure_firmware_releases = Mock(return_value=[])
+    nightly_called = Mock()
+    orch._process_firmware_nightlies = nightly_called
+
+    orch._process_firmware_downloads()
+
+    nightly_called.assert_called_once()
+
+
+def test_nightly_error_does_not_break_stable(tmp_path):
+    """A nightly-stage error must not break already-completed stable work."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    # Stable succeeds (no releases to download), nightly raises internally.
+    orch._ensure_firmware_releases = Mock(return_value=[])
+    fd.fetch_firmware_nightlies = Mock(
+        side_effect=__import__("requests").RequestException("nightly boom")
+    )
+
+    # Must not raise.
+    orch._process_firmware_downloads()
+
+
+# ==================================================================
+# PC: Latest pointer validated on every cleanup
+# ==================================================================
+
+
+def test_cleanup_validates_latest_pointer_with_zero_removals(tmp_path):
+    """A dangling latest pointer is removed even when no build dirs are removed."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    keep = base / "2.8.0.aaaaaaa"
+    keep.mkdir(parents=True)
+    (keep / "f.zip").write_bytes(b"x")
+    # latest points at a name that exists but is the only retained dir (zero removals).
+    latest = base / LATEST_POINTER_NAME
+    try:
+        os.symlink("2.8.0.aaaaaaa", str(latest))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    config = {
+        "DOWNLOAD_DIR": str(tmp_path / "downloads"),
+        "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 1,
+    }
+    from fetchtastic.download.cache import CacheManager
+
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    removed = dl.cleanup_superseded_nightlies(current_build_id="2.8.0.aaaaaaa")
+
+    # No build dirs removed, but the valid retained latest is preserved.
+    assert removed == 0
+    assert latest.is_symlink()
+
+
+def test_cleanup_removes_dangling_latest_with_no_candidates(tmp_path):
+    """A dangling latest is removed even when there are no build candidates at all."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    base.mkdir(parents=True)
+    latest = base / LATEST_POINTER_NAME
+    try:
+        os.symlink("2.8.0.deleted", str(latest))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    config = {
+        "DOWNLOAD_DIR": str(tmp_path / "downloads"),
+        "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 1,
+    }
+    from fetchtastic.download.cache import CacheManager
+
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    removed = dl.cleanup_superseded_nightlies()
+
+    assert removed == 0
+    assert not latest.is_symlink()
+
+
+def test_cleanup_preserves_non_symlink_latest(tmp_path):
+    """A non-symlink latest entry is never removed by cleanup."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    keep = base / "2.8.0.aaaaaaa"
+    keep.mkdir(parents=True)
+    (keep / "f.zip").write_bytes(b"x")
+    # A regular file named 'latest' (non-symlink).
+    latest = base / LATEST_POINTER_NAME
+    latest.write_text("not a symlink")
+
+    config = {
+        "DOWNLOAD_DIR": str(tmp_path / "downloads"),
+        "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 1,
+    }
+    from fetchtastic.download.cache import CacheManager
+
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    dl.cleanup_superseded_nightlies(current_build_id="2.8.0.aaaaaaa")
+
+    assert latest.exists()
+    assert latest.read_text() == "not a symlink"

--- a/tests/test_firmware_nightlies.py
+++ b/tests/test_firmware_nightlies.py
@@ -1,0 +1,1251 @@
+"""
+Regression-contract suite for opt-in rolling firmware-nightly downloads.
+
+Firmware nightlies are a rolling flat directory published at
+``meshtastic.github.io/firmware-nightly`` containing ~487 files and one
+release-level manifest (``firmware-<version>.<hash>.json``) that identifies
+an immutable build (e.g. ``2.8.0.f52e2ea``).
+
+This feature is **separate** from:
+  - the workflow named "nightly" (a CI schedule, not a firmware source);
+  - stable firmware releases (GitHub Releases API);
+  - prerelease firmware directories (``firmware-<version>.<hash>`` dirs).
+
+It is opt-in, snapshot-like in lifecycle, and reuses the firmware
+GitHub-contents transport and asset-selection patterns.
+
+These tests lock the implemented nightly contract: any failure indicates a
+regression (a required constant or method went missing, or documented
+behavior changed).  Each symbol is accessed via ``getattr``/``hasattr`` so
+the module collects cleanly even when an API is partially absent.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from fetchtastic import constants
+from fetchtastic.constants import (
+    FIRMWARE_DIR_NAME,
+    FIRMWARE_PRERELEASES_DIR_NAME,
+    LATEST_POINTER_NAME,
+)
+from fetchtastic.download.cache import CacheManager
+from fetchtastic.download.firmware import FirmwareReleaseDownloader
+from fetchtastic.download.interfaces import DownloadResult
+from fetchtastic.download.prerelease_history import PrereleaseHistoryManager
+
+pytestmark = [pytest.mark.core_downloads]
+
+# ------------------------------------------------------------------
+# Nightly API surface — constants (defined in fetchtastic.constants)
+# ------------------------------------------------------------------
+# DEFAULT_CHECK_FIRMWARE_NIGHTLIES = False
+# FIRMWARE_NIGHTLIES_DIR_NAME = "nightlies"
+# LATEST_FIRMWARE_NIGHTLY_JSON_FILE = "latest_firmware_nightly.json"
+# FILE_TYPE_FIRMWARE_NIGHTLY = "firmware_nightly"
+# FIRMWARE_NIGHTLY_SOURCE_DIR = "firmware-nightly"
+# DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP = 1
+
+# Nightly API surface — methods on FirmwareReleaseDownloader:
+#   fetch_firmware_nightlies() -> list[dict]
+#   parse_nightly_build_id(name) -> str | None      (static)
+#   get_nightly_build_id(entries) -> str | None
+#   should_download_nightly(build_id) -> bool
+#   should_process_nightly(entries, build_id) -> bool
+#   update_nightly_tracking(build_id) -> bool
+#   get_selected_nightly_assets(entries) -> list[dict]
+#   is_nightly_complete(build_id) -> bool
+#   get_nightly_target_path(build_id, name, *, create=False) -> str
+#   download_nightly_asset(entry, build_id) -> DownloadResult
+#   cleanup_superseded_nightlies(current_build_id=None) -> int
+#   _ensure_nightly_base_dir() -> str
+#   _resolve_nightly_dir(build_id) -> str
+
+
+_NOT_IMPL = "firmware-nightly regression: required API missing"
+
+
+def _require_method(obj: object, name: str) -> Any:
+    """Return ``obj.name`` or fail with a clear missing-API message."""
+    method = getattr(obj, name, None)
+    assert callable(method), f"{type(obj).__name__}.{name} missing — {_NOT_IMPL}"
+    return method
+
+
+def _require_constant(name: str, expected: Any) -> Any:
+    """Return ``constants.name`` or fail if absent / wrong value."""
+    value = getattr(constants, name, None)
+    assert value is not None, f"constants.{name} missing — {_NOT_IMPL}"
+    assert value == expected, f"constants.{name} expected {expected!r}, got {value!r}"
+    return value
+
+
+# ==================================================================
+# GitHub Contents entry helpers (model the live API shape accurately)
+# ==================================================================
+
+_RAW_BASE = (
+    "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io"
+    "/main/firmware-nightly"
+)
+
+
+def _contents_entry(name: str, size: int = 1000, entry_type: str = "file") -> dict:
+    """Build a GitHub Contents API entry for a file in firmware-nightly/."""
+    return {
+        "name": name,
+        "path": f"firmware-nightly/{name}",
+        "download_url": f"{_RAW_BASE}/{name}",
+        "size": size,
+        "type": entry_type,
+    }
+
+
+# The immutable build identity for the production 2.8 nightly fixture.
+BUILD_2_8_0 = "2.8.0.f52e2ea"
+MANIFEST_2_8_0 = f"firmware-{BUILD_2_8_0}.json"
+
+
+def _make_nightly_listing(build: str = BUILD_2_8_0) -> list[dict]:
+    """A realistic flat listing of the firmware-nightly directory.
+
+    Models the live shape: one release-level manifest, several per-device
+    manifests (``.mt.json``), firmware zips, helper scripts, BLE OTA blobs,
+    LittleFS images, and ESP32 OTA helpers.  The real directory has ~487
+    files; this subset covers every category the asset-selection logic
+    must distinguish.
+    """
+    return [
+        # Release-level manifest — the ONLY file that identifies the build.
+        _contents_entry(f"firmware-{build}.json", size=45_000),
+        # Per-device manifests (must be rejected by build-id parsing).
+        _contents_entry(f"firmware-rak4631-{build}.mt.json", size=3_200),
+        _contents_entry(f"firmware-tbeam-{build}.mt.json", size=3_100),
+        _contents_entry(f"firmware-heltec-v3-{build}.mt.json", size=3_150),
+        # Firmware zip archives.
+        _contents_entry(f"firmware-rak4631-{build}.zip", size=1_200_000),
+        _contents_entry(f"firmware-tbeam-{build}.zip", size=1_100_000),
+        _contents_entry(f"firmware-heltec-v3-{build}.zip", size=1_150_000),
+        _contents_entry(f"firmware-tlora-v2-1-1_6-{build}.zip", size=1_180_000),
+        _contents_entry(f"firmware-t1000-e-{build}.zip", size=1_220_000),
+        # Helper scripts.
+        _contents_entry("device-install.sh", size=12_000),
+        _contents_entry("device-update.sh", size=10_000),
+        # BLE OTA blobs.
+        _contents_entry("bleota.bin", size=500_000),
+        _contents_entry("bleota-c3.bin", size=480_000),
+        _contents_entry("bleota-s3.bin", size=490_000),
+        # ESP32 OTA helpers.
+        _contents_entry("mt-esp32.bin", size=400_000),
+        _contents_entry("mt-esp32s3.bin", size=410_000),
+        _contents_entry("mt-esp32c3.bin", size=395_000),
+        # LittleFS images.
+        _contents_entry("littlefs-esp32s3.bin", size=300_000),
+    ]
+
+
+# ==================================================================
+# Fixtures
+# ==================================================================
+
+
+@pytest.fixture
+def cache_manager(tmp_path):
+    """Real CacheManager backed by tmp_path for file I/O."""
+    return CacheManager(cache_dir=str(tmp_path / "cache"))
+
+
+@pytest.fixture
+def mock_cache_manager(tmp_path):
+    """Mock CacheManager for API-call verification (no real I/O)."""
+    mock = Mock(spec=CacheManager)
+    mock.cache_dir = str(tmp_path / "cache")
+    mock.get_cache_file_path.side_effect = lambda file_name: os.path.join(
+        mock.cache_dir, file_name
+    )
+    return mock
+
+
+def _make_config(tmp_path, **overrides) -> dict:
+    """Build a firmware config with nightlies enabled by default."""
+    config = {
+        "DOWNLOAD_DIR": str(tmp_path / "downloads"),
+        "SAVE_FIRMWARE": True,
+        "CHECK_FIRMWARE_NIGHTLIES": True,
+        "SELECTED_FIRMWARE_ASSETS": ["rak4631"],
+        "EXCLUDE_PATTERNS": [],
+        "FIRMWARE_VERSIONS_TO_KEEP": 2,
+        "ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES": False,
+        "FILTER_REVOKED_RELEASES": False,
+    }
+    config.update(overrides)
+    return config
+
+
+@pytest.fixture
+def downloader(tmp_path, cache_manager):
+    """FirmwareReleaseDownloader with nightlies enabled and real cache."""
+    config = _make_config(tmp_path)
+    return FirmwareReleaseDownloader(config, cache_manager)
+
+
+@pytest.fixture
+def downloader_disabled(tmp_path, cache_manager):
+    """FirmwareReleaseDownloader with nightlies explicitly disabled."""
+    config = _make_config(tmp_path, CHECK_FIRMWARE_NIGHTLIES=False)
+    return FirmwareReleaseDownloader(config, cache_manager)
+
+
+@pytest.fixture
+def downloader_absent(tmp_path, cache_manager):
+    """FirmwareReleaseDownloader with CHECK_FIRMWARE_NIGHTLIES absent from config."""
+    config = _make_config(tmp_path)
+    del config["CHECK_FIRMWARE_NIGHTLIES"]
+    return FirmwareReleaseDownloader(config, cache_manager)
+
+
+# ==================================================================
+# 1. Default-Disabled: no API calls, no files, no tracking
+# ==================================================================
+
+
+def test_default_check_firmware_nightlies_is_false():
+    """The default for CHECK_FIRMWARE_NIGHTLIES must be False (opt-in)."""
+    _require_constant("DEFAULT_CHECK_FIRMWARE_NIGHTLIES", False)
+
+
+def test_disabled_no_api_calls(downloader_disabled, mock_cache_manager):
+    """When disabled, fetch_firmware_nightlies must not hit the GitHub API."""
+    downloader_disabled.cache_manager = mock_cache_manager
+    fetch = _require_method(downloader_disabled, "fetch_firmware_nightlies")
+    result = fetch()
+    assert result == []
+    mock_cache_manager.get_repo_contents.assert_not_called()
+
+
+def test_absent_config_defaults_false_no_side_effects(downloader_absent, tmp_path):
+    """Absent CHECK_FIRMWARE_NIGHTLIES must default to False with no side effects."""
+    fetch = _require_method(downloader_absent, "fetch_firmware_nightlies")
+    result = fetch()
+    assert result == []
+    # No nightlies directory created.
+    nightly_dir = tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies"
+    assert not nightly_dir.exists()
+    # No tracking file written.
+    tracking = getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE", None)
+    if tracking is not None:
+        assert not (tmp_path / "cache" / tracking).exists()
+
+
+def test_disabled_does_not_download(downloader_disabled):
+    """should_download_nightly must return False when disabled."""
+    should = _require_method(downloader_disabled, "should_download_nightly")
+    assert should(BUILD_2_8_0) is False
+
+
+def test_disabled_does_not_process(downloader_disabled):
+    """should_process_nightly must return False when disabled."""
+    should = _require_method(downloader_disabled, "should_process_nightly")
+    entries = _make_nightly_listing()
+    assert should(entries, BUILD_2_8_0) is False
+
+
+# ==================================================================
+# 2. Live-Shaped Flat Listing with Release Manifest
+# ==================================================================
+
+
+def test_fetch_firmware_nightlies_returns_flat_listing(downloader, mock_cache_manager):
+    """fetch_firmware_nightlies returns the flat GitHub Contents listing."""
+    listing = _make_nightly_listing()
+    mock_cache_manager.get_repo_contents = Mock(return_value=listing)
+    downloader.cache_manager = mock_cache_manager
+
+    fetch = _require_method(downloader, "fetch_firmware_nightlies")
+    entries = fetch()
+    assert isinstance(entries, list)
+    assert len(entries) == len(listing)
+    # Every entry must be a dict with the expected GitHub Contents keys.
+    for entry in entries:
+        assert "name" in entry
+        assert "download_url" in entry
+        assert entry.get("type") == "file"
+
+
+def test_fetch_firmware_nightlies_queries_firmware_nightly_dir(
+    downloader, mock_cache_manager
+):
+    """fetch_firmware_nightlies must query the firmware-nightly repo path."""
+    source_dir = _require_constant("FIRMWARE_NIGHTLY_SOURCE_DIR", "firmware-nightly")
+    mock_cache_manager.get_repo_contents = Mock(return_value=[])
+    downloader.cache_manager = mock_cache_manager
+
+    fetch = _require_method(downloader, "fetch_firmware_nightlies")
+    fetch()
+    mock_cache_manager.get_repo_contents.assert_called_once()
+    call_args = mock_cache_manager.get_repo_contents.call_args
+    # The first positional arg must be the source directory name.
+    assert call_args.args[0] == source_dir
+
+
+def test_listing_contains_release_manifest(downloader, mock_cache_manager):
+    """The flat listing must include the release manifest firmware-2.8.0.f52e2ea.json."""
+    listing = _make_nightly_listing()
+    mock_cache_manager.get_repo_contents = Mock(return_value=listing)
+    downloader.cache_manager = mock_cache_manager
+
+    fetch = _require_method(downloader, "fetch_firmware_nightlies")
+    entries = fetch()
+    names = [e["name"] for e in entries]
+    assert MANIFEST_2_8_0 in names
+
+
+def test_get_nightly_build_id_extracts_from_manifest(downloader, mock_cache_manager):
+    """get_nightly_build_id finds the release manifest and returns its build-id."""
+    listing = _make_nightly_listing()
+    mock_cache_manager.get_repo_contents = Mock(return_value=listing)
+    downloader.cache_manager = mock_cache_manager
+
+    get_build = _require_method(downloader, "get_nightly_build_id")
+    build_id = get_build(listing)
+    assert build_id == BUILD_2_8_0
+
+
+def test_get_nightly_build_id_none_when_no_manifest(downloader):
+    """get_nightly_build_id returns None when no release manifest is present."""
+    listing = [
+        _contents_entry("firmware-rak4631-2.8.0.f52e2ea.zip"),
+        _contents_entry("device-install.sh"),
+    ]
+    get_build = _require_method(downloader, "get_nightly_build_id")
+    assert get_build(listing) is None
+
+
+# ==================================================================
+# 3. Build-ID Parsing and Rejection of Device Manifests
+# ==================================================================
+
+
+def test_parse_nightly_build_id_from_release_manifest(downloader):
+    """parse_nightly_build_id extracts 2.8.0.f52e2ea from firmware-2.8.0.f52e2ea.json."""
+    parse = _require_method(downloader, "parse_nightly_build_id")
+    assert parse(MANIFEST_2_8_0) == BUILD_2_8_0
+
+
+def test_parse_nightly_build_id_rejects_device_manifest(downloader):
+    """Per-device manifests (.mt.json) must be rejected by build-id parsing."""
+    parse = _require_method(downloader, "parse_nightly_build_id")
+    device_manifest = f"firmware-rak4631-{BUILD_2_8_0}.mt.json"
+    assert parse(device_manifest) is None
+
+
+def test_parse_nightly_build_id_rejects_zip(downloader):
+    """Firmware zip archives must not yield a build-id."""
+    parse = _require_method(downloader, "parse_nightly_build_id")
+    assert parse(f"firmware-rak4631-{BUILD_2_8_0}.zip") is None
+
+
+def test_parse_nightly_build_id_rejects_non_firmware(downloader):
+    """Non-firmware-prefixed files must not yield a build-id."""
+    parse = _require_method(downloader, "parse_nightly_build_id")
+    assert parse("device-install.sh") is None
+    assert parse("bleota.bin") is None
+    assert parse("config.json") is None
+
+
+def test_parse_nightly_build_id_case_insensitive(downloader):
+    """Build-id parsing must be case-insensitive on the filename."""
+    parse = _require_method(downloader, "parse_nightly_build_id")
+    assert parse("FIRMWARE-2.8.0.f52e2ea.json") == BUILD_2_8_0
+
+
+def test_parse_nightly_build_id_different_build():
+    """parse_nightly_build_id works for a different build identity."""
+    # Use the class directly — implemented as a static method.
+    parse = getattr(FirmwareReleaseDownloader, "parse_nightly_build_id", None)
+    assert callable(parse), f"parse_nightly_build_id missing — {_NOT_IMPL}"
+    assert parse("firmware-2.7.20.abcdef0.json") == "2.7.20.abcdef0"
+
+
+# ==================================================================
+# 4. Selected Assets Use Production SELECTED_FIRMWARE_ASSETS Key
+# ==================================================================
+
+
+def test_get_selected_nightly_assets_uses_selected_firmware_assets(
+    downloader, mock_cache_manager
+):
+    """Nightly selection reads SELECTED_FIRMWARE_ASSETS (the production key)."""
+    listing = _make_nightly_listing()
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing)
+    # Must include the rak4631 zip but not other devices.
+    names = [e["name"] for e in selected]
+    assert any("rak4631" in n and n.endswith(".zip") for n in names)
+    assert not any("tbeam" in n for n in names)
+
+
+def test_get_selected_nightly_assets_ignores_dead_keys(downloader):
+    """SELECTED_NIGHTLY_ASSETS / SELECTED_ASSETS are not consulted; only SELECTED_FIRMWARE_ASSETS."""
+    listing = _make_nightly_listing()
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
+    # Dead keys set to a different device — must be ignored.
+    downloader.config["SELECTED_NIGHTLY_ASSETS"] = ["tbeam"]
+    downloader.config["SELECTED_ASSETS"] = ["heltec"]
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing)
+    names = [e["name"] for e in selected]
+    assert any("rak4631" in n and n.endswith(".zip") for n in names)
+    assert not any("tbeam" in n for n in names)
+    assert not any("heltec" in n for n in names)
+
+
+def test_get_selected_nightly_assets_includes_release_manifest(downloader):
+    """The release manifest must always be selected regardless of patterns."""
+    listing = _make_nightly_listing()
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing)
+    names = [e["name"] for e in selected]
+    assert MANIFEST_2_8_0 in names
+
+
+def test_get_selected_nightly_assets_respects_exclude_patterns(downloader):
+    """EXCLUDE_PATTERNS must remove matching entries from the selection."""
+    listing = _make_nightly_listing()
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
+    downloader.config["EXCLUDE_PATTERNS"] = ["*.zip"]
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing)
+    names = [e["name"] for e in selected]
+    # The manifest survives; the zip is excluded.
+    assert MANIFEST_2_8_0 in names
+    assert not any(n.endswith(".zip") for n in names)
+
+
+def test_get_selected_nightly_assets_empty_when_no_match(downloader):
+    """When no assets match the selection, return an empty list."""
+    listing = _make_nightly_listing()
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["nonexistent-device"]
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing)
+    # The release manifest is always included, so this is just the manifest.
+    names = [e["name"] for e in selected]
+    assert all(n == MANIFEST_2_8_0 for n in names)
+
+
+def test_get_selected_nightly_assets_canonical_key_excludes_unrelated_devices(
+    downloader,
+):
+    """Realistic fixture: canonical key selects only the matched device from many.
+
+    The listing includes firmware zips for rak4631, tbeam, heltec-v3,
+    tlora-v2-1-1_6, and t1000-e (all under the same build).  With
+    SELECTED_FIRMWARE_ASSETS=['rak4631'] only the rak4631 zip and the
+    release manifest must be selected — no unrelated device zips, no
+    helper scripts, no BLE OTA blobs, no LittleFS images.
+    """
+    listing = _make_nightly_listing()
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing)
+    names = [e["name"] for e in selected]
+
+    # The rak4631 zip and the release manifest are selected.
+    assert any("rak4631" in n and n.endswith(".zip") for n in names)
+    assert MANIFEST_2_8_0 in names
+
+    # No unrelated device zips, scripts, blobs, or LittleFS images.
+    assert not any("tbeam" in n for n in names)
+    assert not any("heltec" in n for n in names)
+    assert not any("tlora" in n for n in names)
+    assert not any("t1000" in n for n in names)
+    assert not any(n.endswith(".sh") for n in names)
+    assert not any(n.startswith("bleota") for n in names)
+    assert not any(n.startswith("mt-esp32") for n in names)
+    assert not any(n.startswith("littlefs") for n in names)
+
+
+# ==================================================================
+# 5. Dedicated firmware/nightlies/<build>/ Storage
+# ==================================================================
+
+
+def test_nightly_base_dir_under_firmware(downloader, tmp_path):
+    """_ensure_nightly_base_dir creates firmware/nightlies/ and returns its path."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    ensure = _require_method(downloader, "_ensure_nightly_base_dir")
+    result = ensure()
+    expected = str(tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name)
+    assert result == expected
+    assert os.path.isdir(result)
+
+
+def test_resolve_nightly_dir_includes_build_id(downloader, tmp_path):
+    """_resolve_nightly_dir returns firmware/nightlies/<build>/."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    resolve = _require_method(downloader, "_resolve_nightly_dir")
+    result = resolve(BUILD_2_8_0)
+    expected = str(
+        tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name / BUILD_2_8_0
+    )
+    assert result == expected
+    assert os.path.isdir(result)
+
+
+def test_get_nightly_target_path(downloader, tmp_path):
+    """get_nightly_target_path places files under firmware/nightlies/<build>/."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    get_path = _require_method(downloader, "get_nightly_target_path")
+    result = get_path(BUILD_2_8_0, "firmware-rak4631-2.8.0.f52e2ea.zip")
+    expected = str(
+        tmp_path
+        / "downloads"
+        / FIRMWARE_DIR_NAME
+        / nightly_dir_name
+        / BUILD_2_8_0
+        / "firmware-rak4631-2.8.0.f52e2ea.zip"
+    )
+    assert result == expected
+
+
+def test_get_nightly_target_path_create_flag(downloader, tmp_path):
+    """get_nightly_target_path with create=True makes the build directory."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    get_path = _require_method(downloader, "get_nightly_target_path")
+    get_path(BUILD_2_8_0, "test.bin", create=True)
+    build_dir = (
+        tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name / BUILD_2_8_0
+    )
+    assert build_dir.is_dir()
+
+
+def test_nightly_storage_separate_from_prerelease(downloader, tmp_path):
+    """Nightly storage must be under firmware/nightlies/, not firmware/prerelease/."""
+    resolve = _require_method(downloader, "_resolve_nightly_dir")
+    nightly_path = resolve(BUILD_2_8_0)
+    assert FIRMWARE_PRERELEASES_DIR_NAME not in nightly_path
+    assert "nightlies" in nightly_path
+
+
+# ==================================================================
+# 6. Identity-Changed Downloads
+# ==================================================================
+
+
+def test_should_download_nightly_new_build(downloader):
+    """A new build-id (not tracked) must trigger a download."""
+    should = _require_method(downloader, "should_download_nightly")
+    assert should(BUILD_2_8_0) is True
+
+
+def test_should_download_nightly_changed_build(downloader, cache_manager):
+    """When the tracked build-id differs, must download the new one."""
+    tracking_file = getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE", None)
+    assert (
+        tracking_file is not None
+    ), f"LATEST_FIRMWARE_NIGHTLY_JSON_FILE missing — {_NOT_IMPL}"
+    tracking_path = cache_manager.get_cache_file_path(tracking_file)
+    Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(tracking_path).write_text(json.dumps({"build_id": "2.7.20.abcdef0"}))
+
+    should = _require_method(downloader, "should_download_nightly")
+    # Use build-id inequality, not hash ordering.
+    assert should(BUILD_2_8_0) is True
+    assert should("2.7.20.abcdef0") is False
+
+
+def test_should_process_nightly_identity_changed(downloader, cache_manager):
+    """should_process_nightly returns True when build-id differs from tracked."""
+    tracking_file = getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE", None)
+    assert (
+        tracking_file is not None
+    ), f"LATEST_FIRMWARE_NIGHTLY_JSON_FILE missing — {_NOT_IMPL}"
+    tracking_path = cache_manager.get_cache_file_path(tracking_file)
+    Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(tracking_path).write_text(json.dumps({"build_id": "2.7.20.abcdef0"}))
+
+    entries = _make_nightly_listing()
+    should = _require_method(downloader, "should_process_nightly")
+    assert should(entries, BUILD_2_8_0) is True
+
+
+# ==================================================================
+# 7. Same Identity Complete — Skip
+# ==================================================================
+
+
+def test_should_process_nightly_same_identity_complete_skips(downloader, cache_manager):
+    """Same build-id tracked and all selected files present → must NOT process."""
+    tracking_file = getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE", None)
+    assert (
+        tracking_file is not None
+    ), f"LATEST_FIRMWARE_NIGHTLY_JSON_FILE missing — {_NOT_IMPL}"
+    tracking_path = cache_manager.get_cache_file_path(tracking_file)
+    Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
+
+    entries = _make_nightly_listing()
+    # Write all selected assets to disk so the build is "complete".
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(entries)
+    get_path = _require_method(downloader, "get_nightly_target_path")
+    for entry in selected:
+        target = get_path(BUILD_2_8_0, entry["name"], create=True)
+        Path(target).write_bytes(b"x" * entry.get("size", 1))
+
+    should = _require_method(downloader, "should_process_nightly")
+    assert should(entries, BUILD_2_8_0) is False
+
+
+def test_is_nightly_complete_when_all_present(downloader):
+    """is_nightly_complete returns True when all selected assets are present."""
+    entries = _make_nightly_listing()
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(entries)
+    get_path = _require_method(downloader, "get_nightly_target_path")
+    for entry in selected:
+        target = get_path(BUILD_2_8_0, entry["name"], create=True)
+        Path(target).write_bytes(b"x" * entry.get("size", 1))
+
+    is_complete = _require_method(downloader, "is_nightly_complete")
+    assert is_complete(BUILD_2_8_0) is True
+
+
+def test_is_nightly_complete_false_when_missing(downloader):
+    """is_nightly_complete returns False when selected assets are missing."""
+    is_complete = _require_method(downloader, "is_nightly_complete")
+    assert is_complete(BUILD_2_8_0) is False
+
+
+# ==================================================================
+# 8. Same Identity Incomplete — Backfill
+# ==================================================================
+
+
+def test_should_process_nightly_same_identity_incomplete_backfills(
+    downloader, cache_manager
+):
+    """Same build-id tracked but files missing → must process for backfill."""
+    tracking_file = getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE", None)
+    assert (
+        tracking_file is not None
+    ), f"LATEST_FIRMWARE_NIGHTLY_JSON_FILE missing — {_NOT_IMPL}"
+    tracking_path = cache_manager.get_cache_file_path(tracking_file)
+    Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
+
+    entries = _make_nightly_listing()
+    # Do NOT write any files — the build is incomplete.
+    should = _require_method(downloader, "should_process_nightly")
+    assert should(entries, BUILD_2_8_0) is True
+
+
+def test_should_process_nightly_partial_files_backfills(downloader, cache_manager):
+    """Same build-id, some files present but not all → must process for backfill."""
+    tracking_file = getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE", None)
+    assert (
+        tracking_file is not None
+    ), f"LATEST_FIRMWARE_NIGHTLY_JSON_FILE missing — {_NOT_IMPL}"
+    tracking_path = cache_manager.get_cache_file_path(tracking_file)
+    Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
+
+    entries = _make_nightly_listing()
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(entries)
+    get_path = _require_method(downloader, "get_nightly_target_path")
+    # Write only the first selected asset — leave the rest missing.
+    if selected:
+        target = get_path(BUILD_2_8_0, selected[0]["name"], create=True)
+        Path(target).write_bytes(b"x" * selected[0].get("size", 1))
+
+    should = _require_method(downloader, "should_process_nightly")
+    assert should(entries, BUILD_2_8_0) is True
+
+
+# ==================================================================
+# 9. Transactional Tracking / Latest Pointer (all assets must succeed)
+# ==================================================================
+
+
+def test_update_nightly_tracking_writes_json(downloader, cache_manager):
+    """update_nightly_tracking writes build_id to the tracking JSON file."""
+    tracking_file = getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE", None)
+    assert (
+        tracking_file is not None
+    ), f"LATEST_FIRMWARE_NIGHTLY_JSON_FILE missing — {_NOT_IMPL}"
+    tracking_path = cache_manager.get_cache_file_path(tracking_file)
+
+    update = _require_method(downloader, "update_nightly_tracking")
+    assert update(BUILD_2_8_0) is True
+
+    data = json.loads(Path(tracking_path).read_text())
+    assert data["build_id"] == BUILD_2_8_0
+    assert "last_updated" in data
+
+
+def test_orch_nightly_all_success_tracks_and_updates_latest(tmp_path, cache_manager):
+    """All selected assets succeed → tracking written once, latest pointer updated."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+
+    listing = _make_nightly_listing()
+    # Mock the nightly methods on the firmware downloader.
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=True)
+    selected = [listing[0], listing[4]]  # manifest + rak4631 zip
+    fd.get_selected_nightly_assets = Mock(return_value=selected)
+    file_type = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    fd.download_nightly_asset = Mock(
+        return_value=DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=str(tmp_path / "x.bin"),
+            download_url="http://x",
+            file_size=1,
+            file_type=file_type,
+        )
+    )
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+    orch._handle_download_result = Mock()
+
+    # The orchestrator must have a nightly seam.
+    assert hasattr(
+        orch, "_process_firmware_nightlies"
+    ), f"DownloadOrchestrator._process_firmware_nightlies missing — {_NOT_IMPL}"
+    orch._process_firmware_nightlies()
+
+    fd.update_nightly_tracking.assert_called_once_with(BUILD_2_8_0)
+    fd.cleanup_superseded_nightlies.assert_called_once_with(BUILD_2_8_0)
+    fd.update_latest_pointer_for_nightly.assert_called_once_with(BUILD_2_8_0)
+
+
+def test_orch_nightly_partial_failure_no_track_no_cleanup(tmp_path, cache_manager):
+    """Mixed success/failure → no tracking, no cleanup, no latest pointer."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+
+    listing = _make_nightly_listing()
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=True)
+    asset1, asset2 = listing[0], listing[4]
+    fd.get_selected_nightly_assets = Mock(return_value=[asset1, asset2])
+    file_type = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    fd.download_nightly_asset = Mock(
+        side_effect=[
+            DownloadResult(
+                success=True,
+                release_tag=BUILD_2_8_0,
+                file_path=str(tmp_path / "a.bin"),
+                download_url="http://x",
+                file_size=1,
+                file_type=file_type,
+            ),
+            DownloadResult(
+                success=False,
+                release_tag=BUILD_2_8_0,
+                file_path=str(tmp_path / "b.bin"),
+                download_url="http://y",
+                file_size=1,
+                file_type=file_type,
+            ),
+        ]
+    )
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+    orch._handle_download_result = Mock()
+
+    assert hasattr(
+        orch, "_process_firmware_nightlies"
+    ), f"DownloadOrchestrator._process_firmware_nightlies missing — {_NOT_IMPL}"
+    orch._process_firmware_nightlies()
+
+    fd.update_nightly_tracking.assert_not_called()
+    fd.cleanup_superseded_nightlies.assert_not_called()
+    fd.update_latest_pointer_for_nightly.assert_not_called()
+
+
+def test_orch_nightly_all_failure_no_track(tmp_path, cache_manager):
+    """All assets fail → no tracking, no cleanup."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+
+    listing = _make_nightly_listing()
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=True)
+    fd.get_selected_nightly_assets = Mock(return_value=[listing[0]])
+    file_type = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    fd.download_nightly_asset = Mock(
+        return_value=DownloadResult(
+            success=False,
+            release_tag=BUILD_2_8_0,
+            file_path=str(tmp_path / "x.bin"),
+            download_url="http://x",
+            file_size=1,
+            file_type=file_type,
+        )
+    )
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+    orch._handle_download_result = Mock()
+
+    assert hasattr(
+        orch, "_process_firmware_nightlies"
+    ), f"DownloadOrchestrator._process_firmware_nightlies missing — {_NOT_IMPL}"
+    orch._process_firmware_nightlies()
+
+    fd.update_nightly_tracking.assert_not_called()
+    fd.cleanup_superseded_nightlies.assert_not_called()
+
+
+def test_orch_nightly_empty_selected_no_track(tmp_path, cache_manager):
+    """Empty selected set → no downloads, no tracking, no cleanup."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+
+    listing = _make_nightly_listing()
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=True)
+    fd.get_selected_nightly_assets = Mock(return_value=[])
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+    orch._handle_download_result = Mock()
+
+    assert hasattr(
+        orch, "_process_firmware_nightlies"
+    ), f"DownloadOrchestrator._process_firmware_nightlies missing — {_NOT_IMPL}"
+    orch._process_firmware_nightlies()
+
+    fd.update_nightly_tracking.assert_not_called()
+    fd.cleanup_superseded_nightlies.assert_not_called()
+
+
+def test_orch_nightly_disabled_skips_entirely(tmp_path, cache_manager):
+    """CHECK_FIRMWARE_NIGHTLIES=False → fetch never called."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, CHECK_FIRMWARE_NIGHTLIES=False)
+    orch = DownloadOrchestrator(config)
+
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=[])
+
+    assert hasattr(
+        orch, "_process_firmware_nightlies"
+    ), f"DownloadOrchestrator._process_firmware_nightlies missing — {_NOT_IMPL}"
+    orch._process_firmware_nightlies()
+    fd.fetch_firmware_nightlies.assert_not_called()
+
+
+# ==================================================================
+# 10. Cleanup: Keep Count and Latest Preservation
+# ==================================================================
+
+
+def test_cleanup_superseded_nightlies_keep_count(downloader, tmp_path):
+    """cleanup_superseded_nightlies removes old builds, keeping the latest N."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    # Create three build directories with files.
+    for build in ("2.7.18.aaaaaaa", "2.7.19.bbbbbbb", "2.8.0.f52e2ea"):
+        d = base / build
+        d.mkdir(parents=True)
+        (d / "firmware-rak4631.zip").write_bytes(b"x")
+
+    downloader.config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = 1
+    cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
+    removed = cleanup()
+    assert removed == 2
+    # Latest build preserved.
+    assert (base / "2.8.0.f52e2ea").is_dir()
+    assert not (base / "2.7.19.bbbbbbb").is_dir()
+    assert not (base / "2.7.18.aaaaaaa").is_dir()
+
+
+def test_cleanup_superseded_nightlies_keep_two(downloader, tmp_path):
+    """Keep count of 2 preserves the two newest builds."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    for build in ("2.7.18.aaaaaaa", "2.7.19.bbbbbbb", "2.8.0.f52e2ea"):
+        (base / build).mkdir(parents=True)
+
+    downloader.config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = 2
+    cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
+    removed = cleanup()
+    assert removed == 1
+    assert (base / "2.8.0.f52e2ea").is_dir()
+    assert (base / "2.7.19.bbbbbbb").is_dir()
+    assert not (base / "2.7.18.aaaaaaa").is_dir()
+
+
+def test_cleanup_nightly_retention_floor_is_one(downloader, tmp_path):
+    """A keep count of zero must be clamped to 1 — never delete the current build."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    (base / "2.8.0.f52e2ea").mkdir(parents=True)
+
+    downloader.config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = 0
+    cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
+    removed = cleanup()
+    assert removed == 0
+    assert (base / "2.8.0.f52e2ea").is_dir()
+
+
+def test_cleanup_nightly_no_dir(downloader):
+    """cleanup_superseded_nightlies returns 0 when the nightlies dir does not exist."""
+    cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
+    assert cleanup() == 0
+
+
+def test_cleanup_nightly_preserves_latest_pointer(downloader, tmp_path):
+    """cleanup must not remove the 'latest' pointer inside nightlies/."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    build_dir = base / "2.8.0.f52e2ea"
+    build_dir.mkdir(parents=True)
+    (build_dir / "firmware.zip").write_bytes(b"x")
+    # Create a latest symlink pointing to the build.
+    latest = base / LATEST_POINTER_NAME
+    try:
+        os.symlink(str(build_dir), str(latest))
+    except OSError:
+        pytest.skip("Symlinks not supported on this platform")
+
+    downloader.config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = 1
+    cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
+    cleanup()
+    # The latest pointer must survive cleanup.
+    assert latest.is_symlink() or latest.exists()
+
+
+def test_cleanup_nightly_rejects_symlinked_root(downloader, tmp_path):
+    """A symlinked nightlies root must be rejected (do not follow symlinks)."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    firmware_base = tmp_path / "downloads" / FIRMWARE_DIR_NAME
+    firmware_base.mkdir(parents=True)
+    real_target = tmp_path / "real_nightlies"
+    real_target.mkdir()
+    try:
+        os.symlink(str(real_target), str(firmware_base / nightly_dir_name))
+    except OSError:
+        pytest.skip("Symlinks not supported on this platform")
+
+    cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
+    # Must not follow the symlink or delete anything inside real_target.
+    assert cleanup() == 0
+    assert real_target.is_dir()
+    # Nothing inside real_target should have been deleted.
+    assert list(real_target.iterdir()) == []
+
+
+def test_cleanup_nightly_preserves_non_build_dirs(downloader, tmp_path):
+    """Non-build-id directories inside nightlies/ must not be deleted."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    (base / "2.8.0.f52e2ea").mkdir(parents=True)
+    (base / "not_a_build").mkdir(parents=True)
+    (base / "2.8.0.f52e2ea" / "firmware.zip").write_bytes(b"x")
+
+    downloader.config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = 1
+    cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
+    cleanup()
+    assert (base / "not_a_build").is_dir()
+
+
+def test_cleanup_nightly_same_base_current_survives(downloader, tmp_path):
+    """current_build_id must survive even when same-base hashes sort it first.
+
+    Three builds share base 2.8.0 but differ in hash suffix:
+      - 2.8.0.aaaaaaa  (the just-downloaded current build)
+      - 2.8.0.bbbbbbb  (an older build)
+      - 2.8.0.f52e2ea  (the oldest build)
+
+    All have release_tuple (2, 8, 0), so sort falls through to the name
+    string.  'aaaaaaa' sorts first.  With keep_limit=1, the sort-only
+    keep window would be {f52e2ea} — deleting aaaaaaa (the current build)
+    and bbbbbbb.  The current_build_id pin must rescue aaaaaaa while
+    still allowing bbbbbbb to be removed.
+    """
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    current = "2.8.0.aaaaaaa"
+    middle = "2.8.0.bbbbbbb"
+    oldest = "2.8.0.f52e2ea"
+    for build in (current, middle, oldest):
+        d = base / build
+        d.mkdir(parents=True)
+        (d / "firmware.zip").write_bytes(b"x")
+
+    downloader.config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = 1
+    cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
+    removed = cleanup(current_build_id=current)
+
+    # Current build must survive even though it sorts first.
+    assert (base / current).is_dir()
+    # Oldest (in the keep window) also survives.
+    assert (base / oldest).is_dir()
+    # Middle build is removed.
+    assert not (base / middle).is_dir()
+    assert removed == 1
+
+
+def test_cleanup_nightly_same_base_current_survives_without_arg(downloader, tmp_path):
+    """Without current_build_id, the same-base sort order decides what lives.
+
+    This documents the pre-fix danger: with no current_build_id pin and
+    keep_limit=1, the alphabetically-first hash ('aaaaaaa') is deleted
+    even if it was the just-downloaded build.  The fix is for callers
+    to pass current_build_id; the primitive itself still respects sort
+    order when the pin is absent.
+    """
+    nightly_dir = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir
+    first = "2.8.0.aaaaaaa"
+    middle = "2.8.0.bbbbbbb"
+    last = "2.8.0.f52e2ea"
+    for build in (first, middle, last):
+        (base / build).mkdir(parents=True)
+        (base / build / "firmware.zip").write_bytes(b"x")
+
+    downloader.config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = 1
+    cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
+    removed = cleanup()
+
+    # Without the pin, sort order alone decides: only f52e2ea survives.
+    assert removed == 2
+    assert not (base / first).is_dir()
+    assert not (base / middle).is_dir()
+    assert (base / last).is_dir()
+
+
+# ==================================================================
+# 11. Stable Cleanup Preserves Nightlies
+# ==================================================================
+
+
+def test_stable_cleanup_preserves_nightlies_dir(downloader, tmp_path):
+    """cleanup_old_versions (stable) must not remove firmware/nightlies/."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    firmware_dir = tmp_path / "downloads" / FIRMWARE_DIR_NAME
+    nightly_dir = firmware_dir / nightly_dir_name
+    nightly_build = nightly_dir / BUILD_2_8_0
+    nightly_build.mkdir(parents=True)
+    (nightly_build / "firmware.zip").write_bytes(b"x")
+
+    # Also create a stable release dir so cleanup has something to scan.
+    stable_dir = firmware_dir / "v2.7.20"
+    stable_dir.mkdir(parents=True)
+    (stable_dir / "firmware.zip").write_bytes(b"x")
+
+    # Run stable cleanup with keep_limit=0 and no cached releases.
+    downloader.config["FILTER_REVOKED_RELEASES"] = False
+    downloader.cleanup_old_versions(keep_limit=0, cached_releases=[])
+
+    # The nightlies directory and its contents must survive.
+    assert nightly_dir.is_dir()
+    assert nightly_build.is_dir()
+    assert (nightly_build / "firmware.zip").exists()
+
+
+def test_stable_cleanup_preserves_nightlies_with_symlink(downloader, tmp_path):
+    """Stable cleanup must not follow or remove a nightlies symlink."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    firmware_dir = tmp_path / "downloads" / FIRMWARE_DIR_NAME
+    firmware_dir.mkdir(parents=True)
+    real_nightlies = tmp_path / "real_nightlies"
+    real_nightlies.mkdir()
+    (real_nightlies / BUILD_2_8_0).mkdir()
+    try:
+        os.symlink(str(real_nightlies), str(firmware_dir / nightly_dir_name))
+    except OSError:
+        pytest.skip("Symlinks not supported on this platform")
+
+    downloader.config["FILTER_REVOKED_RELEASES"] = False
+    downloader.cleanup_old_versions(keep_limit=0, cached_releases=[])
+
+    # Symlink must survive.
+    assert (firmware_dir / nightly_dir_name).is_symlink()
+    # Real target contents must survive.
+    assert (real_nightlies / BUILD_2_8_0).is_dir()
+
+
+# ==================================================================
+# 12. Generic Prerelease Scan Excludes firmware-nightly
+# ==================================================================
+
+
+def test_scan_prerelease_directories_excludes_firmware_nightly():
+    """scan_prerelease_directories must not return 'nightly' for any stable floor.
+
+    The history API admits prerelease bases strictly newer than the supplied
+    stable release, so callers pass the *preceding* stable (e.g. ``2.7.19`` when
+    a ``2.7.20.<sha>`` prerelease should be admitted).  ``firmware-nightly`` must
+    never appear in the result regardless.
+    """
+    manager = PrereleaseHistoryManager()
+    dirs = [
+        "firmware-nightly",
+        "firmware-2.7.20.abcdef0",
+        "firmware-2.8.0.f52e2ea",
+        "firmware-2.7.19.1234567",
+    ]
+    result = manager.scan_prerelease_directories(dirs, "2.7.19")
+    # "nightly" must never appear in the results.
+    assert "nightly" not in result
+    # 2.7.20 and 2.8.0 prerelease identifiers are admitted (> 2.7.19);
+    # 2.7.19.* is rejected (not strictly newer than the stable floor).
+    assert "2.7.20.abcdef0" in result
+    assert "2.8.0.f52e2ea" in result
+    assert "2.7.19.1234567" not in result
+
+
+def test_scan_prerelease_directories_excludes_firmware_nightly_for_2_8():
+    """The exclusion holds for any stable floor; 2.8.0 admits against 2.7.26."""
+    manager = PrereleaseHistoryManager()
+    dirs = [
+        "firmware-nightly",
+        f"firmware-{BUILD_2_8_0}",
+    ]
+    result = manager.scan_prerelease_directories(dirs, "2.7.26")
+    assert "nightly" not in result
+    assert BUILD_2_8_0 in result
+
+
+def test_firmware_nightly_not_treated_as_prerelease_dir(downloader, mock_cache_manager):
+    """download_repo_prerelease_firmware must not treat firmware-nightly as a prerelease."""
+    # When scanning repo dirs, firmware-nightly must not be selected as an active dir.
+    mock_cache_manager.get_repo_directories = Mock(
+        return_value=["firmware-nightly", "firmware-2.7.20.abcdef0"]
+    )
+    mock_cache_manager.get_repo_contents = Mock(return_value=[])
+    downloader.cache_manager = mock_cache_manager
+
+    with (
+        patch(
+            "fetchtastic.download.firmware.PrereleaseHistoryManager"
+            ".get_latest_active_prerelease_from_history",
+            return_value=(None, []),
+        ),
+    ):
+        successes, failures, active_dir, _ = (
+            downloader.download_repo_prerelease_firmware("v2.7.20")
+        )
+    # active_dir must not be "firmware-nightly".
+    assert active_dir != "firmware-nightly"
+
+
+# ==================================================================
+# 13. Production 2.8 Nightly Fixture
+# ==================================================================
+
+
+def test_production_2_8_nightly_fixture_listing_shape():
+    """The production 2.8 nightly fixture models the live flat directory shape."""
+    listing = _make_nightly_listing()
+    assert len(listing) >= 15  # representative subset of ~487 live files
+
+    # Every entry has the GitHub Contents API fields.
+    for entry in listing:
+        assert "name" in entry
+        assert "path" in entry
+        assert "download_url" in entry
+        assert "size" in entry
+        assert entry["type"] == "file"
+
+    # The release manifest is present and correctly named.
+    names = [e["name"] for e in listing]
+    assert MANIFEST_2_8_0 in names
+
+    # Download URLs point to the firmware-nightly raw path.
+    manifest_entry = next(e for e in listing if e["name"] == MANIFEST_2_8_0)
+    assert "firmware-nightly" in manifest_entry["download_url"]
+    assert manifest_entry["path"] == f"firmware-nightly/{MANIFEST_2_8_0}"
+
+
+def test_production_2_8_nightly_build_id_round_trip(downloader):
+    """The production 2.8 fixture build-id parses correctly end-to-end."""
+    listing = _make_nightly_listing()
+    get_build = _require_method(downloader, "get_nightly_build_id")
+    build_id = get_build(listing)
+    assert build_id == BUILD_2_8_0
+
+    parse = _require_method(downloader, "parse_nightly_build_id")
+    assert parse(MANIFEST_2_8_0) == BUILD_2_8_0
+
+
+def test_production_2_8_nightly_device_manifests_rejected(downloader):
+    """All per-device manifests in the 2.8 fixture must be rejected by build-id parsing."""
+    listing = _make_nightly_listing()
+    parse = _require_method(downloader, "parse_nightly_build_id")
+    device_manifests = [e["name"] for e in listing if e["name"].endswith(".mt.json")]
+    assert len(device_manifests) >= 3
+    for name in device_manifests:
+        assert parse(name) is None, f"Device manifest {name} must not yield a build-id"
+
+
+def test_production_2_8_nightly_selected_assets(downloader):
+    """The 2.8 fixture with SELECTED_FIRMWARE_ASSETS=['rak4631'] selects the right files."""
+    listing = _make_nightly_listing()
+    downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["rak4631"]
+
+    select = _require_method(downloader, "get_selected_nightly_assets")
+    selected = select(listing)
+    names = [e["name"] for e in selected]
+
+    # Must include the rak4631 zip and the release manifest.
+    assert any("rak4631" in n and n.endswith(".zip") for n in names)
+    assert MANIFEST_2_8_0 in names
+    # Must NOT include other devices.
+    assert not any("tbeam" in n for n in names)
+    assert not any("heltec" in n for n in names)
+
+
+def test_production_2_8_nightly_storage_path(downloader, tmp_path):
+    """The 2.8 fixture stores files under firmware/nightlies/2.8.0.f52e2ea/."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    get_path = _require_method(downloader, "get_nightly_target_path")
+    target = get_path(BUILD_2_8_0, "firmware-rak4631-2.8.0.f52e2ea.zip", create=True)
+    expected = str(
+        tmp_path
+        / "downloads"
+        / FIRMWARE_DIR_NAME
+        / nightly_dir_name
+        / BUILD_2_8_0
+        / "firmware-rak4631-2.8.0.f52e2ea.zip"
+    )
+    assert target == expected
+    assert os.path.isdir(os.path.dirname(target))

--- a/tests/test_firmware_nightlies.py
+++ b/tests/test_firmware_nightlies.py
@@ -39,7 +39,7 @@ from fetchtastic.download.firmware import FirmwareReleaseDownloader
 from fetchtastic.download.interfaces import DownloadResult
 from fetchtastic.download.prerelease_history import PrereleaseHistoryManager
 
-pytestmark = [pytest.mark.core_downloads]
+pytestmark = [pytest.mark.core_downloads, pytest.mark.unit]
 
 # ------------------------------------------------------------------
 # Nightly API surface — constants (defined in fetchtastic.constants)
@@ -434,15 +434,15 @@ def test_get_selected_nightly_assets_respects_exclude_patterns(downloader):
 
 
 def test_get_selected_nightly_assets_empty_when_no_match(downloader):
-    """When no assets match the selection, return an empty list."""
+    """When no assets match the selection, return only the release manifest."""
     listing = _make_nightly_listing()
     downloader.config["SELECTED_FIRMWARE_ASSETS"] = ["nonexistent-device"]
 
     select = _require_method(downloader, "get_selected_nightly_assets")
     selected = select(listing)
-    # The release manifest is always included, so this is just the manifest.
+    # The release manifest is always included, so this is exactly the manifest.
     names = [e["name"] for e in selected]
-    assert all(n == MANIFEST_2_8_0 for n in names)
+    assert names == [MANIFEST_2_8_0]
 
 
 def test_get_selected_nightly_assets_canonical_key_excludes_unrelated_devices(
@@ -723,6 +723,11 @@ def test_orch_nightly_all_success_tracks_and_updates_latest(tmp_path, cache_mana
             file_type=file_type,
         )
     )
+    # Finalization re-validates on disk before tracking. The validator is a
+    # firmware-level collaborator with its own tests; mock it here so this
+    # orchestrator-level contract test stays focused on finalization gating.
+    fd.get_nightly_target_path = Mock(return_value=str(tmp_path / "x.bin"))
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
     fd.update_nightly_tracking = Mock(return_value=True)
     fd.cleanup_superseded_nightlies = Mock(return_value=0)
     fd.update_latest_pointer_for_nightly = Mock(return_value=True)
@@ -737,6 +742,8 @@ def test_orch_nightly_all_success_tracks_and_updates_latest(tmp_path, cache_mana
     fd.update_nightly_tracking.assert_called_once_with(BUILD_2_8_0)
     fd.cleanup_superseded_nightlies.assert_called_once_with(BUILD_2_8_0)
     fd.update_latest_pointer_for_nightly.assert_called_once_with(BUILD_2_8_0)
+    # Run-scoped build-id must be set after a fully finalized transaction.
+    assert orch.latest_firmware_nightly_build_id == BUILD_2_8_0
 
 
 def test_orch_nightly_partial_failure_no_track_no_cleanup(tmp_path, cache_manager):
@@ -987,18 +994,17 @@ def test_cleanup_nightly_preserves_non_build_dirs(downloader, tmp_path):
 
 
 def test_cleanup_nightly_same_base_current_survives(downloader, tmp_path):
-    """current_build_id must survive even when same-base hashes sort it first.
+    """current_build_id occupies one slot under the exact-max retention limit.
 
     Three builds share base 2.8.0 but differ in hash suffix:
       - 2.8.0.aaaaaaa  (the just-downloaded current build)
       - 2.8.0.bbbbbbb  (an older build)
       - 2.8.0.f52e2ea  (the oldest build)
 
-    All have release_tuple (2, 8, 0), so sort falls through to the name
-    string.  'aaaaaaa' sorts first.  With keep_limit=1, the sort-only
-    keep window would be {f52e2ea} — deleting aaaaaaa (the current build)
-    and bbbbbbb.  The current_build_id pin must rescue aaaaaaa while
-    still allowing bbbbbbb to be removed.
+    With keep_limit=1 and current_build_id=2.8.0.aaaaaaa, the current build
+    consumes the only slot: both other builds are removed (exact maximum
+    including current). The deterministic mtime+name tiebreak — never hash
+    chronology — decides which other builds are removed when current is pinned.
     """
     nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
     base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
@@ -1014,23 +1020,19 @@ def test_cleanup_nightly_same_base_current_survives(downloader, tmp_path):
     cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
     removed = cleanup(current_build_id=current)
 
-    # Current build must survive even though it sorts first.
+    # Current build must survive; it occupies the single retention slot.
     assert (base / current).is_dir()
-    # Oldest (in the keep window) also survives.
-    assert (base / oldest).is_dir()
-    # Middle build is removed.
+    # Both non-current builds are removed under the exact-max rule.
     assert not (base / middle).is_dir()
-    assert removed == 1
+    assert not (base / oldest).is_dir()
+    assert removed == 2
 
 
 def test_cleanup_nightly_same_base_current_survives_without_arg(downloader, tmp_path):
-    """Without current_build_id, the same-base sort order decides what lives.
+    """Without current_build_id, mtime+name tiebreak alone decides what lives.
 
-    This documents the pre-fix danger: with no current_build_id pin and
-    keep_limit=1, the alphabetically-first hash ('aaaaaaa') is deleted
-    even if it was the just-downloaded build.  The fix is for callers
-    to pass current_build_id; the primitive itself still respects sort
-    order when the pin is absent.
+    With no current pin and keep_limit=1, the deterministic ordering
+    (mtime descending, name descending tiebreak) retains exactly one build.
     """
     nightly_dir = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
     base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir
@@ -1045,11 +1047,10 @@ def test_cleanup_nightly_same_base_current_survives_without_arg(downloader, tmp_
     cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
     removed = cleanup()
 
-    # Without the pin, sort order alone decides: only f52e2ea survives.
+    # Exactly one build survives (exact maximum, no current pin).
     assert removed == 2
-    assert not (base / first).is_dir()
-    assert not (base / middle).is_dir()
-    assert (base / last).is_dir()
+    survivors = [p.name for p in base.iterdir() if p.is_dir() and not p.is_symlink()]
+    assert len(survivors) == 1
 
 
 # ==================================================================
@@ -1249,3 +1250,724 @@ def test_production_2_8_nightly_storage_path(downloader, tmp_path):
     )
     assert target == expected
     assert os.path.isdir(os.path.dirname(target))
+
+
+# ==================================================================
+# 14. PC Final Correctness Pass — Regression Coverage
+# Each test locks one of the five P1 blockers or a review-comment fix.
+# ==================================================================
+
+
+import io  # noqa: E402  (local import keeps the header block above clean)
+import zipfile  # noqa: E402
+
+from fetchtastic.utils import save_file_hash  # noqa: E402
+
+
+def _write_valid_nightly_asset(downloader, build_id, entry):
+    """Write a real, valid nightly asset on disk so the validator accepts it.
+
+    Creates a real ZIP for ``*.zip`` entries, valid JSON for the release
+    manifest, and raw bytes otherwise. The entry's ``size`` is normalized to
+    the actual on-disk byte count so the validator's exact-size check passes,
+    and the correct SHA-256 is persisted so ``verify_file_integrity`` passes.
+    """
+    from fetchtastic.utils import calculate_sha256
+
+    name = entry["name"]
+    target = downloader.get_nightly_target_path(build_id, name, create=True)
+    lower = name.lower()
+    if lower.endswith(".zip"):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("payload.bin", b"x" * max(1, int(entry.get("size", 1))))
+        data = buf.getvalue()
+    elif downloader.parse_nightly_build_id(name) is not None:
+        data = json.dumps({"build_id": build_id, "notes": "x" * 32}).encode("utf-8")
+    else:
+        size = int(entry.get("size", 1))
+        data = (b"x" * size)[:size] if size > 0 else b""
+    Path(target).write_bytes(data)
+    entry["size"] = len(data)  # exact-match the validator's size check
+    save_file_hash(target, calculate_sha256(target) or "0" * 64)
+    return target
+
+
+# --- B1: Tracking failure must stop finalization -------------------
+
+
+def test_orch_nightly_tracking_failure_no_cleanup_no_pointer(tmp_path, cache_manager):
+    """Tracking failure → no cleanup, no pointer, no run-scoped id (B1)."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+
+    listing = _make_nightly_listing()
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=True)
+    selected = [listing[0], listing[4]]
+    fd.get_selected_nightly_assets = Mock(return_value=selected)
+    file_type = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    fd.download_nightly_asset = Mock(
+        return_value=DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=str(tmp_path / "ok.bin"),
+            download_url="http://x",
+            file_size=1,
+            file_type=file_type,
+        )
+    )
+    fd.get_nightly_target_path = Mock(return_value=str(tmp_path / "ok.bin"))
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
+    fd.update_nightly_tracking = Mock(return_value=False)  # tracking FAILS
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+    orch._handle_download_result = Mock()
+
+    orch._process_firmware_nightlies()
+
+    fd.update_nightly_tracking.assert_called_once_with(BUILD_2_8_0)
+    fd.cleanup_superseded_nightlies.assert_not_called()
+    fd.update_latest_pointer_for_nightly.assert_not_called()
+    assert orch.latest_firmware_nightly_build_id is None
+
+
+# --- B2: File validation — wrong size, bad zip, bad manifest -------
+
+
+def test_download_nightly_asset_wrong_size_fails_non_retryable(
+    downloader, mock_cache_manager
+):
+    """A downloaded file whose size does not match must fail non-retryably (B2)."""
+    entry = _contents_entry("firmware-rak4631-2.8.0.f52e2ea.zip", size=999_999)
+    target = downloader.get_nightly_target_path(BUILD_2_8_0, entry["name"], create=True)
+    # download_file_with_retry writes a valid zip but wrong size.
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("p", b"x")
+    Path(target).write_bytes(payload.getvalue())
+
+    with patch(
+        "fetchtastic.download.firmware.download_file_with_retry", return_value=True
+    ):
+        # Force the download path by removing any pre-existing file first.
+        if os.path.exists(target):
+            os.remove(target)
+        result = downloader.download_nightly_asset(entry, BUILD_2_8_0)
+
+    assert result.success is False
+    assert result.is_retryable is False
+    from fetchtastic.constants import ERROR_TYPE_VALIDATION
+
+    assert result.error_type == ERROR_TYPE_VALIDATION
+    # Bad file + hash sidecar must have been removed.
+    assert not os.path.exists(target)
+
+
+def test_validate_nightly_asset_rejects_corrupt_zip(downloader):
+    """A corrupt ZIP must fail validation and be removed (B2)."""
+    entry = _contents_entry("firmware-rak4631-2.8.0.f52e2ea.zip", size=10)
+    target = downloader.get_nightly_target_path(BUILD_2_8_0, entry["name"], create=True)
+    Path(target).write_bytes(b"not a zip" + b"\0" * 1)  # 10 bytes, not a zip
+
+    ok, reason = downloader._validate_nightly_asset(target, entry["name"], 10)
+    assert ok is False
+    assert "ZIP" in reason or "integrity" in reason.lower()
+
+
+def test_validate_nightly_asset_rejects_bad_manifest_json(downloader):
+    """An invalid release manifest JSON must fail validation (B2)."""
+    manifest_name = f"firmware-{BUILD_2_8_0}.json"
+    bad = b"not json!"  # 9 bytes; size matches so we reach the JSON check.
+    target = downloader.get_nightly_target_path(BUILD_2_8_0, manifest_name, create=True)
+    Path(target).write_bytes(bad)
+
+    ok, reason = downloader._validate_nightly_asset(target, manifest_name, len(bad))
+    assert ok is False
+    assert "manifest" in reason.lower() or "json" in reason.lower()
+
+
+def test_validate_nightly_asset_rejects_symlink_target(downloader):
+    """A symlink target must be rejected outright (B2/B5)."""
+    entry = _contents_entry("firmware-rak4631-2.8.0.f52e2ea.zip", size=5)
+    real = downloader.get_nightly_target_path(BUILD_2_8_0, "real.zip", create=True)
+    Path(real).write_bytes(b"real")
+    link = downloader.get_nightly_target_path(BUILD_2_8_0, entry["name"], create=True)
+    if os.path.exists(link):
+        os.remove(link)
+    try:
+        os.symlink(real, link)
+    except OSError:
+        pytest.skip("Symlinks not supported on this platform")
+
+    ok, reason = downloader._validate_nightly_asset(link, entry["name"], 5)
+    assert ok is False
+    assert "symlink" in reason.lower() or "regular" in reason.lower()
+
+
+def test_download_nightly_asset_executable_only_after_validation(
+    downloader, mock_cache_manager
+):
+    """The executable bit must be set only after successful validation (B2)."""
+    from fetchtastic.utils import calculate_sha256
+
+    entry = _contents_entry("device-install.sh", size=4)
+    target = downloader.get_nightly_target_path(BUILD_2_8_0, entry["name"], create=True)
+
+    def _fake_download(url, path):
+        Path(path).write_bytes(b"abcd")
+        save_file_hash(path, calculate_sha256(path) or "0" * 64)
+        return True
+
+    with patch(
+        "fetchtastic.download.firmware.download_file_with_retry",
+        side_effect=_fake_download,
+    ):
+        result = downloader.download_nightly_asset(entry, BUILD_2_8_0)
+
+    assert result.success is True
+    assert os.path.exists(target)
+    import stat as _stat
+
+    mode = _stat.S_IMODE(os.stat(target).st_mode)
+    assert mode & 0o111, "executable bit should be set for *.sh after validation"
+
+
+# --- B3: Retry dispatch + reconciliation ---------------------------
+
+
+def test_retry_single_failure_dispatches_firmware_nightly(tmp_path):
+    """_retry_single_failure must dispatch FILE_TYPE_FIRMWARE_NIGHTLY (B3)."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+
+    target = str(tmp_path / "night.bin")
+    # Pre-place a valid file so download + validation succeed.
+    Path(target).write_bytes(b"payload")
+    save_file_hash(target, "2" * 64)
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
+
+    failed = DownloadResult(
+        success=False,
+        release_tag=BUILD_2_8_0,
+        file_path=Path(target),
+        download_url="http://x",
+        file_size=7,
+        file_type=getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"),
+        is_retryable=True,
+    )
+    with patch.object(fd, "download", return_value=True) as mock_download, patch.object(
+        fd, "verify", return_value=True
+    ):
+        result = orch._retry_single_failure(failed)
+
+    assert result.success is True
+    mock_download.assert_called_once()
+
+
+def test_retry_single_failure_nightly_bad_size_non_retryable(tmp_path):
+    """A retried nightly asset that fails validation must be non-retryable (B3)."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+
+    target = str(tmp_path / "night.bin")
+    Path(target).write_bytes(b"short")
+    save_file_hash(target, "3" * 64)
+    # Validation reports a size mismatch.
+    fd._validate_nightly_asset = Mock(
+        return_value=(False, "size mismatch: expected 100, got 5")
+    )
+
+    failed = DownloadResult(
+        success=False,
+        release_tag=BUILD_2_8_0,
+        file_path=Path(target),
+        download_url="http://x",
+        file_size=100,
+        file_type=getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"),
+        is_retryable=True,
+    )
+    with patch.object(fd, "download", return_value=True), patch.object(
+        fd, "verify", return_value=True
+    ):
+        result = orch._retry_single_failure(failed)
+
+    assert result.success is False
+    assert result.is_retryable is False
+
+
+def test_finalize_nightly_transaction_partial_retry_finalizes_nothing(tmp_path):
+    """Post-retry reconciliation must not finalize when an asset is still failing (B3)."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+
+    listing = _make_nightly_listing()
+    asset1, asset2 = listing[0], listing[4]
+    file_type = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    # Only asset1 succeeded; asset2 still failing after retries.
+    orch.download_results = [
+        DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=str(tmp_path / "a"),
+            download_url=asset1["download_url"],
+            file_size=1,
+            file_type=file_type,
+        )
+    ]
+    orch._pending_nightly_build_id = BUILD_2_8_0
+    orch._pending_nightly_entries = [asset1, asset2]
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+
+    orch._finalize_nightly_transaction_if_complete()
+
+    fd.update_nightly_tracking.assert_not_called()
+    fd.cleanup_superseded_nightlies.assert_not_called()
+    fd.update_latest_pointer_for_nightly.assert_not_called()
+    assert orch.latest_firmware_nightly_build_id is None
+
+
+def test_finalize_nightly_transaction_all_success_finalizes_once(tmp_path):
+    """Post-retry reconciliation finalizes exactly once when all succeed (B3)."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+
+    listing = _make_nightly_listing()
+    asset1, asset2 = listing[0], listing[4]
+    file_type = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    orch.download_results = [
+        DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=str(tmp_path / "a"),
+            download_url=asset1["download_url"],
+            file_size=1,
+            file_type=file_type,
+        ),
+        DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=str(tmp_path / "b"),
+            download_url=asset2["download_url"],
+            file_size=1,
+            file_type=file_type,
+        ),
+    ]
+    orch._pending_nightly_build_id = BUILD_2_8_0
+    orch._pending_nightly_entries = [asset1, asset2]
+    fd.get_nightly_target_path = Mock(return_value=str(tmp_path / "x"))
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+
+    orch._finalize_nightly_transaction_if_complete()
+
+    fd.update_nightly_tracking.assert_called_once_with(BUILD_2_8_0)
+    fd.cleanup_superseded_nightlies.assert_called_once_with(BUILD_2_8_0)
+    fd.update_latest_pointer_for_nightly.assert_called_once_with(BUILD_2_8_0)
+    assert orch.latest_firmware_nightly_build_id == BUILD_2_8_0
+
+
+def test_finalize_nightly_transaction_tracking_failure_finalizes_nothing(tmp_path):
+    """Tracking failure during reconciliation must not finalize (B1 + B3)."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+
+    listing = _make_nightly_listing()
+    asset1 = listing[0]
+    file_type = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+    orch.download_results = [
+        DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=str(tmp_path / "a"),
+            download_url=asset1["download_url"],
+            file_size=1,
+            file_type=file_type,
+        )
+    ]
+    orch._pending_nightly_build_id = BUILD_2_8_0
+    orch._pending_nightly_entries = [asset1]
+    fd.get_nightly_target_path = Mock(return_value=str(tmp_path / "x"))
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
+    fd.update_nightly_tracking = Mock(return_value=False)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+
+    orch._finalize_nightly_transaction_if_complete()
+
+    fd.update_nightly_tracking.assert_called_once_with(BUILD_2_8_0)
+    fd.cleanup_superseded_nightlies.assert_not_called()
+    fd.update_latest_pointer_for_nightly.assert_not_called()
+    assert orch.latest_firmware_nightly_build_id is None
+
+
+# --- B4: Retention exact maximum including current -----------------
+
+
+def test_cleanup_nightly_current_occupies_one_slot(downloader, tmp_path):
+    """keep_limit=2 with current → current + exactly one other survive (B4)."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    current = "2.8.0.aaaaaaa"
+    other_a = "2.8.0.bbbbbbb"
+    other_b = "2.8.0.ccccccc"
+    for build in (current, other_a, other_b):
+        d = base / build
+        d.mkdir(parents=True)
+        (d / "firmware.zip").write_bytes(b"x")
+
+    downloader.config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = 2
+    cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
+    removed = cleanup(current_build_id=current)
+
+    # Exactly two survive: current + one other. The third is removed.
+    assert removed == 1
+    assert (base / current).is_dir()
+    survivors = [p.name for p in base.iterdir() if p.is_dir() and not p.is_symlink()]
+    assert len(survivors) == 2
+    assert current in survivors
+
+
+def test_cleanup_nightly_uses_safe_rmtree_not_raw(tmp_path, monkeypatch):
+    """Nightly cleanup must route removals through _safe_rmtree (B4/B5).
+
+    _safe_rmtree internally calls shutil.rmtree, so we cannot block raw
+    rmtree globally; instead we spy on _safe_rmtree and confirm it is the
+    only removal path used by the nightly cleanup.
+    """
+    import fetchtastic.download.firmware as firmware_mod
+
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    for build in ("2.7.18.aaaaaaa", "2.8.0.f52e2ea"):
+        d = base / build
+        d.mkdir(parents=True)
+        (d / "firmware.zip").write_bytes(b"x")
+
+    config = {
+        "DOWNLOAD_DIR": str(tmp_path / "downloads"),
+        "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 1,
+    }
+    from fetchtastic.download.cache import CacheManager
+    from fetchtastic.download.files import _safe_rmtree as real_safe_rmtree
+
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+
+    safe_calls: list[str] = []
+
+    def _spy_safe_rmtree(path, base_dir, name):
+        safe_calls.append(name)
+        return real_safe_rmtree(path, base_dir, name)
+
+    monkeypatch.setattr(firmware_mod, "_safe_rmtree", _spy_safe_rmtree)
+
+    removed = dl.cleanup_superseded_nightlies(current_build_id="2.8.0.f52e2ea")
+    assert removed == 1
+    assert len(safe_calls) == 1
+
+
+# --- B5: Path safety — build-id, symlinks, traversal ---------------
+
+
+def test_resolve_nightly_dir_rejects_bad_build_id(downloader):
+    """A build-id that fails the strict regex must be rejected (B5)."""
+    resolve = _require_method(downloader, "_resolve_nightly_dir")
+    with pytest.raises(ValueError):
+        resolve("../../../etc/passwd")
+    with pytest.raises(ValueError):
+        resolve("not-a-build-id")
+
+
+def test_resolve_nightly_dir_rejects_symlinked_root(downloader, tmp_path):
+    """A symlinked nightly root must be rejected (B5)."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    firmware_dir = tmp_path / "downloads" / FIRMWARE_DIR_NAME
+    firmware_dir.mkdir(parents=True)
+    real_target = tmp_path / "real_nightlies"
+    real_target.mkdir()
+    try:
+        os.symlink(str(real_target), str(firmware_dir / nightly_dir_name))
+    except OSError:
+        pytest.skip("Symlinks not supported on this platform")
+
+    resolve = _require_method(downloader, "_resolve_nightly_dir")
+    with pytest.raises(ValueError):
+        resolve(BUILD_2_8_0)
+    # The symlinked root must not be followed.
+    assert (firmware_dir / nightly_dir_name).is_symlink()
+
+
+def test_download_nightly_asset_rejects_symlink_target(downloader):
+    """A pre-existing symlink target must be refused and removed (B5)."""
+    entry = _contents_entry("firmware-rak4631-2.8.0.f52e2ea.zip", size=5)
+    real = downloader.get_nightly_target_path(BUILD_2_8_0, "real.zip", create=True)
+    Path(real).write_bytes(b"real")
+    link = downloader.get_nightly_target_path(BUILD_2_8_0, entry["name"], create=True)
+    if os.path.exists(link):
+        os.remove(link)
+    try:
+        os.symlink(real, link)
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    result = downloader.download_nightly_asset(entry, BUILD_2_8_0)
+    assert result.success is False
+    from fetchtastic.constants import ERROR_TYPE_VALIDATION
+
+    assert result.error_type == ERROR_TYPE_VALIDATION
+    # The symlink must have been removed.
+    assert not os.path.islink(link)
+
+
+def test_cleanup_nightly_removes_invalid_latest_pointer(downloader, tmp_path):
+    """An invalid latest symlink (target removed) is cleaned up (B4)."""
+    nightly_dir_name = _require_constant("FIRMWARE_NIGHTLIES_DIR_NAME", "nightlies")
+    base = tmp_path / "downloads" / FIRMWARE_DIR_NAME / nightly_dir_name
+    keep = base / "2.8.0.aaaaaaa"
+    gone = base / "2.8.0.bbbbbbb"
+    keep.mkdir(parents=True)
+    gone.mkdir(parents=True)
+    (keep / "f.zip").write_bytes(b"x")
+    (gone / "f.zip").write_bytes(b"x")
+    # latest points at the directory that will be removed.
+    latest = base / LATEST_POINTER_NAME
+    try:
+        os.symlink("2.8.0.bbbbbbb", str(latest))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    downloader.config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = 1
+    cleanup = _require_method(downloader, "cleanup_superseded_nightlies")
+    cleanup(current_build_id="2.8.0.aaaaaaa")
+
+    # The invalid latest pointer (target removed) is gone.
+    assert not latest.is_symlink()
+
+
+# --- Existing-skip path now uses the validator ---------------------
+
+
+def test_download_nightly_asset_skip_validates_full(downloader):
+    """An existing valid asset is skipped; validation runs on the skip path (B2)."""
+    entry = _make_nightly_listing()[4]  # rak4631 zip
+    _write_valid_nightly_asset(downloader, BUILD_2_8_0, entry)
+
+    result = downloader.download_nightly_asset(entry, BUILD_2_8_0)
+    assert result.success is True
+    assert getattr(result, "was_skipped", False) is True
+
+
+def test_download_nightly_asset_skip_reDownloads_when_existing_invalid(downloader):
+    """An existing invalid (wrong-size) asset is re-downloaded rather than silently accepted (B2)."""
+    from fetchtastic.utils import calculate_sha256
+
+    # Use a non-zip entry so exact-size content is trivial to produce.
+    entry = _contents_entry("device-install.sh", size=5)
+    target = downloader.get_nightly_target_path(BUILD_2_8_0, entry["name"], create=True)
+    # Existing file is wrong size (4 bytes vs expected 5) → validator rejects.
+    Path(target).write_bytes(b"\0\0\0\0")
+
+    def _fake_download(url, path):
+        Path(path).write_bytes(b"abcde")
+        save_file_hash(path, calculate_sha256(path) or "0" * 64)
+        return True
+
+    with patch(
+        "fetchtastic.download.firmware.download_file_with_retry",
+        side_effect=_fake_download,
+    ):
+        result = downloader.download_nightly_asset(entry, BUILD_2_8_0)
+
+    assert result.success is True
+    assert getattr(result, "was_skipped", False) is False
+
+
+# --- Network failure stays retryable -------------------------------
+
+
+def test_download_nightly_asset_network_failure_retryable(downloader):
+    """A network failure during download must remain retryable (B2)."""
+    import requests as _requests
+
+    entry = _make_nightly_listing()[4]
+    with patch(
+        "fetchtastic.download.firmware.download_file_with_retry",
+        side_effect=_requests.RequestException("boom"),
+    ):
+        result = downloader.download_nightly_asset(entry, BUILD_2_8_0)
+
+    assert result.success is False
+    assert result.is_retryable is True
+    from fetchtastic.constants import ERROR_TYPE_NETWORK
+
+    assert result.error_type == ERROR_TYPE_NETWORK
+
+
+# --- Symlink cleanup: dangling links unlinked, external targets safe ---
+
+
+def test_download_nightly_asset_dangling_symlink_unlinked(downloader):
+    """A dangling symlink at the target is unlinked, never followed (cleanup gap 1)."""
+    entry = _contents_entry("firmware-rak4631-2.8.0.f52e2ea.zip", size=5)
+    link = downloader.get_nightly_target_path(BUILD_2_8_0, entry["name"], create=True)
+    # Dangling symlink: target path does not exist anywhere.
+    outside = str(Path(link).parent / "does_not_exist.bin")
+    if os.path.exists(link):
+        os.remove(link)
+    try:
+        os.symlink(outside, link)
+    except OSError:
+        pytest.skip("Symlinks not supported on this platform")
+    assert os.path.islink(link) and not os.path.exists(link)  # dangling
+
+    result = downloader.download_nightly_asset(entry, BUILD_2_8_0)
+
+    # Rejected as validation failure; the dangling symlink is gone.
+    from fetchtastic.constants import ERROR_TYPE_VALIDATION
+
+    assert result.success is False
+    assert result.error_type == ERROR_TYPE_VALIDATION
+    assert not os.path.islink(link)
+    # No file was written at the (non-existent) external target.
+    assert not os.path.exists(outside)
+
+
+def test_download_nightly_asset_symlink_external_sentinel_untouched(
+    downloader, tmp_path
+):
+    """A symlink pointing outside the build tree is unlinked; the external file is untouched."""
+    entry = _contents_entry("firmware-rak4631-2.8.0.f52e2ea.zip", size=5)
+    # Sentinel lives OUTSIDE the build directory tree.
+    sentinel = tmp_path / "external_sentinel.bin"
+    sentinel.write_bytes(b"original-untouched")
+    link = downloader.get_nightly_target_path(BUILD_2_8_0, entry["name"], create=True)
+    if os.path.exists(link):
+        os.remove(link)
+    try:
+        os.symlink(str(sentinel), link)
+    except OSError:
+        pytest.skip("Symlinks not supported on this platform")
+
+    result = downloader.download_nightly_asset(entry, BUILD_2_8_0)
+
+    from fetchtastic.constants import ERROR_TYPE_VALIDATION
+
+    assert result.success is False
+    assert result.error_type == ERROR_TYPE_VALIDATION
+    # The symlink (link only) is gone; the external sentinel is untouched.
+    assert not os.path.islink(link)
+    assert sentinel.read_bytes() == b"original-untouched"
+
+
+# --- Retry validation failure removes hash metadata (cleanup gap 2) ---
+
+
+def test_retry_nightly_wrong_size_removes_hash_and_legacy_sidecars(tmp_path):
+    """Retry post-validation failure must remove target + current + legacy hash sidecars (gap 2)."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+    from fetchtastic.utils import get_hash_file_path, get_legacy_hash_file_path
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+
+    target = str(tmp_path / "night.bin")
+    Path(target).write_bytes(b"wrong-size")
+    # Pre-create BOTH hash sidecars so we can assert they are removed.
+    current_hash = get_hash_file_path(target)
+    legacy_hash = get_legacy_hash_file_path(target)
+    Path(current_hash).parent.mkdir(parents=True, exist_ok=True)
+    Path(current_hash).write_text("aaaa  night.bin\n")
+    Path(legacy_hash).write_text("bbbb  night.bin\n")
+    assert os.path.exists(current_hash) and os.path.exists(legacy_hash)
+
+    # Validation reports a size mismatch.
+    fd._validate_nightly_asset = Mock(
+        return_value=(False, "size mismatch: expected 100, got 10")
+    )
+
+    failed = DownloadResult(
+        success=False,
+        release_tag=BUILD_2_8_0,
+        file_path=Path(target),
+        download_url="http://x",
+        file_size=100,
+        file_type=getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"),
+        is_retryable=True,
+    )
+    with patch.object(fd, "download", return_value=True), patch.object(
+        fd, "verify", return_value=True
+    ):
+        result = orch._retry_single_failure(failed)
+
+    assert result.success is False
+    assert result.is_retryable is False
+    # Target, current hash sidecar, and legacy hash sidecar all removed.
+    assert not os.path.exists(target)
+    assert not os.path.exists(current_hash)
+    assert not os.path.exists(legacy_hash)
+
+
+def test_retry_nightly_invalid_content_removes_hash_sidecars(tmp_path):
+    """Retry validation failure for invalid content removes hash metadata (gap 2)."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+    from fetchtastic.utils import get_hash_file_path, get_legacy_hash_file_path
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+
+    target = str(tmp_path / "night.bin")
+    Path(target).write_bytes(b"content")
+    current_hash = get_hash_file_path(target)
+    legacy_hash = get_legacy_hash_file_path(target)
+    Path(current_hash).parent.mkdir(parents=True, exist_ok=True)
+    Path(current_hash).write_text("cccc  night.bin\n")
+    Path(legacy_hash).write_text("dddd  night.bin\n")
+
+    fd._validate_nightly_asset = Mock(
+        return_value=(False, "hash/integrity verification failed")
+    )
+
+    failed = DownloadResult(
+        success=False,
+        release_tag=BUILD_2_8_0,
+        file_path=Path(target),
+        download_url="http://x",
+        file_size=7,
+        file_type=getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly"),
+        is_retryable=True,
+    )
+    with patch.object(fd, "download", return_value=True), patch.object(
+        fd, "verify", return_value=True
+    ):
+        result = orch._retry_single_failure(failed)
+
+    assert result.success is False
+    assert result.is_retryable is False
+    assert not os.path.exists(target)
+    assert not os.path.exists(current_hash)
+    assert not os.path.exists(legacy_hash)

--- a/tests/test_firmware_nightlies.py
+++ b/tests/test_firmware_nightlies.py
@@ -317,13 +317,14 @@ def test_get_nightly_build_id_extracts_from_manifest(downloader, mock_cache_mana
 
 
 def test_get_nightly_build_id_none_when_no_manifest(downloader):
-    """get_nightly_build_id returns None when no release manifest is present."""
+    """get_nightly_build_id raises ValueError for a nonempty listing with no manifest."""
     listing = [
         _contents_entry("firmware-rak4631-2.8.0.f52e2ea.zip"),
         _contents_entry("device-install.sh"),
     ]
     get_build = _require_method(downloader, "get_nightly_build_id")
-    assert get_build(listing) is None
+    with pytest.raises(ValueError, match="no release-level manifest"):
+        get_build(listing)
 
 
 # ==================================================================
@@ -2098,7 +2099,7 @@ def test_nightly_run_state_unchecked_by_default(tmp_path):
 
 
 def test_nightly_run_state_already_complete_when_should_process_false(tmp_path):
-    """should_process_nightly False sets ALREADY_COMPLETE."""
+    """should_process_nightly False runs maintenance and sets MAINTENANCE_ONLY."""
     from fetchtastic.constants import NightlyRunState
     from fetchtastic.download.orchestrator import DownloadOrchestrator
 
@@ -2109,10 +2110,13 @@ def test_nightly_run_state_already_complete_when_should_process_false(tmp_path):
     fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
     fd.should_process_nightly = Mock(return_value=False)
     orch._handle_download_result = Mock()
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.recreate_latest_pointer_for_nightly = Mock(return_value=True)
+    fd.repair_nightly_executable_metadata = Mock(return_value=0)
 
     orch._process_firmware_nightlies()
 
-    assert orch.nightly_run_state == NightlyRunState.ALREADY_COMPLETE
+    assert orch.nightly_run_state == NightlyRunState.MAINTENANCE_ONLY
     assert orch.latest_firmware_nightly_build_id is None
 
 
@@ -2160,7 +2164,7 @@ def test_nightly_run_state_attempted_incomplete_on_partial_failure(tmp_path):
 
 
 def test_nightly_run_state_finalized_on_full_success(tmp_path):
-    """All assets valid + tracking persists sets FINALIZED + run-scoped build-id."""
+    """All assets valid + tracking persists sets FINALIZED_WITH_DOWNLOAD + run-scoped build-id."""
     from fetchtastic.constants import NightlyRunState
     from fetchtastic.download.orchestrator import DownloadOrchestrator
 
@@ -2174,26 +2178,28 @@ def test_nightly_run_state_finalized_on_full_success(tmp_path):
     selected = [listing[0], listing[4]]
     fd.get_selected_nightly_assets = Mock(return_value=selected)
     ftype = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
-    fd.download_nightly_asset = Mock(
-        return_value=DownloadResult(
+
+    def _make_result(entry, _build_id=None):
+        return DownloadResult(
             success=True,
             release_tag=BUILD_2_8_0,
-            file_path=str(tmp_path / "x"),
-            download_url="http://x",
+            file_path=str(tmp_path / entry["name"]),
+            download_url=entry.get("download_url") or entry.get("browser_download_url"),
             file_size=1,
             file_type=ftype,
+            was_skipped=False,
         )
-    )
+
+    fd.download_nightly_asset = Mock(side_effect=_make_result)
     fd.get_nightly_target_path = Mock(return_value=str(tmp_path / "x"))
     fd._validate_nightly_asset = Mock(return_value=(True, ""))
     fd.update_nightly_tracking = Mock(return_value=True)
     fd.cleanup_superseded_nightlies = Mock(return_value=0)
     fd.update_latest_pointer_for_nightly = Mock(return_value=True)
-    orch._handle_download_result = Mock()
 
     orch._process_firmware_nightlies()
 
-    assert orch.nightly_run_state == NightlyRunState.FINALIZED
+    assert orch.nightly_run_state == NightlyRunState.FINALIZED_WITH_DOWNLOAD
     assert orch.latest_firmware_nightly_build_id == BUILD_2_8_0
 
 
@@ -2264,7 +2270,7 @@ def test_post_retry_finalization_sets_finalized(tmp_path):
 
     orch._finalize_nightly_transaction_if_complete()
 
-    assert orch.nightly_run_state == NightlyRunState.FINALIZED
+    assert orch.nightly_run_state == NightlyRunState.FINALIZED_WITH_DOWNLOAD
 
 
 # ==================================================================
@@ -2576,3 +2582,583 @@ def test_cleanup_preserves_non_symlink_latest(tmp_path):
 
     assert latest.exists()
     assert latest.read_text() == "not a symlink"
+
+
+# ==================================================================
+# PC: Unified managed-path resolver — non-write mode safety
+# ==================================================================
+
+
+def test_get_nightly_target_path_non_write_rejects_symlinked_download_dir(tmp_path):
+    """Non-write mode must reject a symlinked DOWNLOAD_DIR (not silently trust it)."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+
+    real_downloads = tmp_path / "real_downloads"
+    real_downloads.mkdir()
+    link_downloads = tmp_path / "downloads"
+    try:
+        os.symlink(str(real_downloads), str(link_downloads))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    dl.download_dir = str(link_downloads)
+    with pytest.raises(ValueError, match="symlink ancestor"):
+        dl.get_nightly_target_path(BUILD_2_8_0, "firmware.zip", create=False)
+
+
+def test_get_nightly_target_path_non_write_rejects_symlinked_firmware_parent(
+    tmp_path,
+):
+    """Non-write mode must reject a symlinked firmware/ parent."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+
+    firmware_real = tmp_path / "downloads" / "real_firmware"
+    firmware_real.mkdir(parents=True)
+    firmware_link = tmp_path / "downloads" / FIRMWARE_DIR_NAME
+    try:
+        os.symlink(str(firmware_real), str(firmware_link))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    with pytest.raises(ValueError, match="symlink ancestor"):
+        dl.get_nightly_target_path(BUILD_2_8_0, "firmware.zip", create=False)
+
+
+def test_get_nightly_target_path_non_write_rejects_multi_component_name(tmp_path):
+    """Non-write mode must reject a multi-component asset name (path traversal)."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    with pytest.raises(ValueError):
+        dl.get_nightly_target_path(BUILD_2_8_0, "../../etc/passwd", create=False)
+
+
+def test_get_nightly_target_path_non_write_rejects_symlinked_target(tmp_path):
+    """Non-write mode must reject a symlinked target."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+
+    build_dir = tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies" / BUILD_2_8_0
+    build_dir.mkdir(parents=True)
+    real_file = build_dir / "real.bin"
+    real_file.write_bytes(b"x")
+    link = build_dir / "firmware.zip"
+    try:
+        os.symlink(str(real_file), str(link))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    with pytest.raises(ValueError, match="symlink"):
+        dl.get_nightly_target_path(BUILD_2_8_0, "firmware.zip", create=False)
+
+
+def test_get_nightly_target_path_non_write_allows_missing_root(tmp_path):
+    """Non-write mode must return the path (not raise) when the root is simply missing."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    path = dl.get_nightly_target_path(BUILD_2_8_0, "firmware.zip", create=False)
+    assert path.endswith(os.path.join("nightlies", BUILD_2_8_0, "firmware.zip"))
+    # Nothing was created.
+    nightly_root = tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies"
+    assert not nightly_root.exists()
+
+
+# ==================================================================
+# PC: Source failures — fetch_firmware_nightlies propagates errors
+# ==================================================================
+
+
+def test_fetch_firmware_nightlies_propagates_request_exception(tmp_path):
+    """Source RequestException must propagate, not collapse to empty list."""
+    import requests as _requests
+
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    dl.cache_manager.get_repo_contents = Mock(
+        side_effect=_requests.RequestException("boom")
+    )
+    with pytest.raises(_requests.RequestException):
+        dl.fetch_firmware_nightlies()
+
+
+def test_fetch_firmware_nightlies_propagates_oserror(tmp_path):
+    """Source OSError must propagate, not collapse to empty list."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    dl.cache_manager.get_repo_contents = Mock(side_effect=OSError("boom"))
+    with pytest.raises(OSError):
+        dl.fetch_firmware_nightlies()
+
+
+def test_fetch_firmware_nightlies_disabled_returns_empty(tmp_path):
+    """Disabled makes no call and returns empty list."""
+    config = _make_config(tmp_path, CHECK_FIRMWARE_NIGHTLIES=False)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    dl.cache_manager.get_repo_contents = Mock()
+    result = dl.fetch_firmware_nightlies()
+    assert result == []
+    dl.cache_manager.get_repo_contents.assert_not_called()
+
+
+def test_fetch_firmware_nightlies_empty_success_returns_empty(tmp_path):
+    """An empty-but-valid listing returns empty list (distinct from error)."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    dl.cache_manager.get_repo_contents = Mock(return_value=[])
+    result = dl.fetch_firmware_nightlies()
+    assert result == []
+
+
+# ==================================================================
+# PC: Coherent generation — get_nightly_build_id strict validation
+# ==================================================================
+
+
+def test_get_nightly_build_id_dedupes_exact_duplicates(downloader):
+    """Exact duplicate manifest entries are deduplicated, not rejected."""
+    listing = _make_nightly_listing()
+    # Duplicate the manifest entry.
+    listing.append(_contents_entry(MANIFEST_2_8_0, size=45_000))
+    build_id = downloader.get_nightly_build_id(listing)
+    assert build_id == BUILD_2_8_0
+
+
+def test_get_nightly_build_id_rejects_multiple_unique(downloader):
+    """Multiple unique build-ids raise ValueError (ambiguous generation)."""
+    listing = _make_nightly_listing(BUILD_2_8_0)
+    other_build = "2.8.1.abcdef0"
+    listing.append(_contents_entry(f"firmware-{other_build}.json", size=45_000))
+    with pytest.raises(ValueError, match="multiple unique build-ids"):
+        downloader.get_nightly_build_id(listing)
+
+
+def test_get_nightly_build_id_nonempty_no_manifest_raises(downloader):
+    """A nonempty listing with no manifest raises ValueError (malformed generation)."""
+    listing = [
+        _contents_entry("firmware-rak4631-2.8.0.f52e2ea.zip", size=1_200_000),
+        _contents_entry("device-install.sh", size=12_000),
+    ]
+    with pytest.raises(ValueError, match="no release-level manifest"):
+        downloader.get_nightly_build_id(listing)
+
+
+def test_get_nightly_build_id_empty_listing_returns_none(downloader):
+    """An empty listing returns None (no candidate published yet, not an error)."""
+    assert downloader.get_nightly_build_id([]) is None
+
+
+# ==================================================================
+# PC: Reporting state — CHECK_FAILED, MAINTENANCE_ONLY, FINALIZED_WITH_DOWNLOAD
+# ==================================================================
+
+
+def test_nightly_run_state_check_failed_on_source_error(tmp_path):
+    """A source fetch error sets CHECK_FAILED, not ATTEMPTED_INCOMPLETE."""
+    import requests as _requests
+
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(
+        side_effect=_requests.RequestException("source boom")
+    )
+    orch._handle_download_result = Mock()
+
+    orch._process_firmware_nightlies()
+
+    assert orch.nightly_run_state == NightlyRunState.CHECK_FAILED
+    assert orch.latest_firmware_nightly_build_id is None
+
+
+def test_nightly_run_state_check_failed_on_malformed_listing(tmp_path):
+    """A nonempty listing with no manifest sets CHECK_FAILED."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(
+        return_value=[_contents_entry("firmware-rak4631-2.8.0.f52e2ea.zip")]
+    )
+    fd.get_nightly_build_id = Mock(return_value=None)
+    orch._handle_download_result = Mock()
+
+    orch._process_firmware_nightlies()
+
+    assert orch.nightly_run_state == NightlyRunState.CHECK_FAILED
+
+
+def test_nightly_run_state_check_failed_on_ambiguous_generation(tmp_path):
+    """Multiple unique build-ids set CHECK_FAILED."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=_make_nightly_listing())
+    fd.get_nightly_build_id = Mock(side_effect=ValueError("ambiguous"))
+    orch._handle_download_result = Mock()
+
+    orch._process_firmware_nightlies()
+
+    assert orch.nightly_run_state == NightlyRunState.CHECK_FAILED
+
+
+def test_nightly_run_state_maintenance_only_on_all_skipped(tmp_path):
+    """All assets valid + tracking persisted + all was_skipped → MAINTENANCE_ONLY."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    listing = _make_nightly_listing()
+    fd = orch.firmware_downloader
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=True)
+    selected = [listing[0], listing[4]]
+    fd.get_selected_nightly_assets = Mock(return_value=selected)
+    ftype = getattr(constants, "FILE_TYPE_FIRMWARE_NIGHTLY", "firmware_nightly")
+
+    def _make_skipped(entry, _build_id=None):
+        return DownloadResult(
+            success=True,
+            release_tag=BUILD_2_8_0,
+            file_path=str(tmp_path / entry["name"]),
+            download_url=entry.get("download_url") or entry.get("browser_download_url"),
+            file_size=1,
+            file_type=ftype,
+            was_skipped=True,
+        )
+
+    fd.download_nightly_asset = Mock(side_effect=_make_skipped)
+    fd.get_nightly_target_path = Mock(return_value=str(tmp_path / "x"))
+    fd._validate_nightly_asset = Mock(return_value=(True, ""))
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+
+    orch._process_firmware_nightlies()
+
+    assert orch.nightly_run_state == NightlyRunState.MAINTENANCE_ONLY
+    assert orch.latest_firmware_nightly_build_id == BUILD_2_8_0
+
+
+def test_nightly_maintenance_runs_cleanup_pointer_chmod(tmp_path):
+    """Already-complete build runs retention/pointer/chmod, not tracking rewrite."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    listing = _make_nightly_listing()
+    fd.fetch_firmware_nightlies = Mock(return_value=listing)
+    fd.get_nightly_build_id = Mock(return_value=BUILD_2_8_0)
+    fd.should_process_nightly = Mock(return_value=False)
+    orch._handle_download_result = Mock()
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.recreate_latest_pointer_for_nightly = Mock(return_value=True)
+    fd.repair_nightly_executable_metadata = Mock(return_value=0)
+    fd.update_nightly_tracking = Mock(return_value=True)
+
+    orch._process_firmware_nightlies()
+
+    fd.cleanup_superseded_nightlies.assert_called_once_with(BUILD_2_8_0)
+    fd.recreate_latest_pointer_for_nightly.assert_called_once_with(BUILD_2_8_0)
+    fd.repair_nightly_executable_metadata.assert_called_once()
+    # Tracking must NOT be rewritten during maintenance.
+    fd.update_nightly_tracking.assert_not_called()
+
+
+# ==================================================================
+# PC: repair_nightly_executable_metadata
+# ==================================================================
+
+
+def test_repair_nightly_executable_metadata_chmods_valid_sh(tmp_path):
+    """A valid .sh asset without exec bit gets chmodded; no redownload."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    target = dl.get_nightly_target_path(BUILD_2_8_0, "device-install.sh", create=True)
+    Path(target).write_bytes(b"#!/bin/sh\necho hi\n")
+    # Store a hash so verify_file_integrity passes.
+    from fetchtastic.utils import get_hash_file_path
+
+    hash_path = get_hash_file_path(target)
+    Path(hash_path).parent.mkdir(parents=True, exist_ok=True)
+    import hashlib
+
+    digest = hashlib.sha256(b"#!/bin/sh\necho hi\n").hexdigest()
+    Path(hash_path).write_text(f"{digest}  device-install.sh\n")
+
+    entry = _contents_entry("device-install.sh", size=len(b"#!/bin/sh\necho hi\n"))
+    repaired = dl.repair_nightly_executable_metadata(BUILD_2_8_0, [entry])
+
+    assert repaired == 1
+    import stat as _stat
+
+    mode = _stat.S_IMODE(os.stat(target).st_mode)
+    assert mode & 0o111
+
+
+def test_repair_nightly_executable_metadata_skips_invalid(tmp_path):
+    """An invalid .sh asset is not chmodded."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    target = dl.get_nightly_target_path(BUILD_2_8_0, "bad.sh", create=True)
+    Path(target).write_bytes(b"bad")
+    entry = _contents_entry("bad.sh", size=100)
+    repaired = dl.repair_nightly_executable_metadata(BUILD_2_8_0, [entry])
+    assert repaired == 0
+
+
+def test_repair_nightly_executable_metadata_skips_non_sh(tmp_path):
+    """A valid .zip asset is never chmodded."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    entry = _contents_entry("firmware.zip", size=100)
+    repaired = dl.repair_nightly_executable_metadata(BUILD_2_8_0, [entry])
+    assert repaired == 0
+
+
+# ==================================================================
+# PC: recreate_latest_pointer_for_nightly
+# ==================================================================
+
+
+def test_recreate_latest_pointer_creates_missing(tmp_path):
+    """A missing latest pointer is created for a valid build."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    build_dir = tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies" / BUILD_2_8_0
+    build_dir.mkdir(parents=True)
+    (build_dir / "firmware.zip").write_bytes(b"x")
+
+    result = dl.recreate_latest_pointer_for_nightly(BUILD_2_8_0)
+    assert result is True
+    link = (
+        tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies" / LATEST_POINTER_NAME
+    )
+    assert link.is_symlink()
+
+
+def test_recreate_latest_pointer_preserves_non_symlink(tmp_path):
+    """A non-symlink latest entry is preserved, not overwritten."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    nightly_root = tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies"
+    nightly_root.mkdir(parents=True)
+    latest = nightly_root / LATEST_POINTER_NAME
+    latest.write_text("not a symlink")
+
+    result = dl.recreate_latest_pointer_for_nightly(BUILD_2_8_0)
+    assert result is False
+    assert latest.read_text() == "not a symlink"
+
+
+# ==================================================================
+# PC: CLI summary — comment 1 (incomplete/failure local summary)
+# ==================================================================
+
+
+def test_cli_summary_nightly_check_failed_emits_message(tmp_path):
+    """Zero downloads + no asset failures + CHECK_FAILED emits a local summary."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.cli_integration import DownloadCLIIntegration
+
+    integration = DownloadCLIIntegration()
+    integration.config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    integration.orchestrator = Mock()
+    integration.orchestrator.nightly_run_state = NightlyRunState.CHECK_FAILED
+    integration.orchestrator.latest_firmware_nightly_build_id = None
+    integration.orchestrator.wifi_skipped = False
+    integration.orchestrator.download_results = []
+    integration.orchestrator.failed_downloads = []
+    integration.orchestrator.available_new_firmware_versions = []
+    integration.orchestrator.available_new_apk_versions = []
+    integration.orchestrator.get_latest_versions = Mock(return_value={})
+
+    mock_log = Mock()
+    with patch(
+        "fetchtastic.download.cli_integration.send_new_releases_available_notification"
+    ), patch(
+        "fetchtastic.download.cli_integration.send_up_to_date_notification"
+    ), patch(
+        "fetchtastic.download.cli_integration.get_api_request_summary",
+        return_value={},
+    ):
+        integration.log_download_results_summary(
+            logger_override=mock_log,
+            elapsed_seconds=1.0,
+            downloaded_firmwares=[],
+            downloaded_apks=[],
+            failed_downloads=[],
+            latest_firmware_version="",
+            latest_apk_version="",
+        )
+
+    logged = " ".join(str(c) for c in mock_log.info.call_args_list)
+    assert "nightly check failed" in logged.lower()
+
+
+def test_cli_summary_nightly_incomplete_emits_message(tmp_path):
+    """Zero downloads + no asset failures + ATTEMPTED_INCOMPLETE emits a local summary."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.cli_integration import DownloadCLIIntegration
+
+    integration = DownloadCLIIntegration()
+    integration.config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    integration.orchestrator = Mock()
+    integration.orchestrator.nightly_run_state = NightlyRunState.ATTEMPTED_INCOMPLETE
+    integration.orchestrator.latest_firmware_nightly_build_id = None
+    integration.orchestrator.wifi_skipped = False
+    integration.orchestrator.download_results = []
+    integration.orchestrator.failed_downloads = []
+    integration.orchestrator.available_new_firmware_versions = []
+    integration.orchestrator.available_new_apk_versions = []
+    integration.orchestrator.get_latest_versions = Mock(return_value={})
+
+    mock_log = Mock()
+    with patch(
+        "fetchtastic.download.cli_integration.send_new_releases_available_notification"
+    ), patch(
+        "fetchtastic.download.cli_integration.send_up_to_date_notification"
+    ), patch(
+        "fetchtastic.download.cli_integration.get_api_request_summary",
+        return_value={},
+    ):
+        integration.log_download_results_summary(
+            logger_override=mock_log,
+            elapsed_seconds=1.0,
+            downloaded_firmwares=[],
+            downloaded_apks=[],
+            failed_downloads=[],
+            latest_firmware_version="",
+            latest_apk_version="",
+        )
+
+    logged = " ".join(str(c) for c in mock_log.info.call_args_list)
+    assert "incomplete" in logged.lower()
+
+
+def test_cli_summary_maintenance_only_allows_up_to_date(tmp_path):
+    """MAINTENANCE_ONLY does NOT suppress the up-to-date message."""
+    from fetchtastic.constants import NightlyRunState
+    from fetchtastic.download.cli_integration import DownloadCLIIntegration
+
+    integration = DownloadCLIIntegration()
+    integration.config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    integration.orchestrator = Mock()
+    integration.orchestrator.nightly_run_state = NightlyRunState.MAINTENANCE_ONLY
+    integration.orchestrator.latest_firmware_nightly_build_id = BUILD_2_8_0
+    integration.orchestrator.wifi_skipped = False
+    integration.orchestrator.download_results = []
+    integration.orchestrator.failed_downloads = []
+    integration.orchestrator.available_new_firmware_versions = []
+    integration.orchestrator.available_new_apk_versions = []
+    integration.orchestrator.get_latest_versions = Mock(return_value={})
+
+    mock_log = Mock()
+    with patch(
+        "fetchtastic.download.cli_integration.send_up_to_date_notification"
+    ) as mock_uptodate, patch(
+        "fetchtastic.download.cli_integration.get_api_request_summary",
+        return_value={},
+    ):
+        integration.log_download_results_summary(
+            logger_override=mock_log,
+            elapsed_seconds=1.0,
+            downloaded_firmwares=[],
+            downloaded_apks=[],
+            failed_downloads=[],
+            latest_firmware_version="",
+            latest_apk_version="",
+        )
+
+    logged = " ".join(str(c) for c in mock_log.info.call_args_list)
+    assert "up to date" in logged.lower()
+    mock_uptodate.assert_called_once()
+
+
+# ==================================================================
+# PC: Helper extraction — _derive_firmware_prerelease_admission_floor
+# ==================================================================
+
+
+def test_derive_admission_floor_returns_none_for_missing_release(tmp_path):
+    """Missing latest firmware release returns (None, None)."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    orch.firmware_downloader.get_latest_release_tag = Mock(return_value=None)
+
+    clean, expected = orch._derive_firmware_prerelease_admission_floor(None)
+    assert clean is None
+    assert expected is None
+
+
+def test_derive_admission_floor_returns_values_for_valid_release(tmp_path):
+    """A valid release tag returns (clean_tag, expected_version)."""
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    orch.firmware_downloader.get_latest_release_tag = Mock(return_value="v2.7.18")
+
+    clean, expected = orch._derive_firmware_prerelease_admission_floor("v2.7.18")
+    assert clean is not None
+    assert expected is not None
+
+
+def test_derive_admission_floor_used_by_cleanup_deleted_prereleases(tmp_path):
+    """_cleanup_deleted_prereleases routes through the shared helper."""
+    from unittest.mock import patch as _patch
+
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    orch.firmware_downloader.get_latest_release_tag = Mock(return_value="v2.7.18")
+
+    with _patch.object(
+        orch, "_derive_firmware_prerelease_admission_floor", return_value=(None, None)
+    ) as mock_helper:
+        orch._cleanup_deleted_prereleases()
+        mock_helper.assert_called_once_with("v2.7.18")
+
+
+# ==================================================================
+# PC: is_nightly_complete — build_id validation
+# ==================================================================
+
+
+def test_is_nightly_complete_rejects_invalid_build_id(downloader):
+    """An invalid build_id returns False without touching the filesystem."""
+    assert downloader.is_nightly_complete("../../../etc") is False
+    assert downloader.is_nightly_complete("") is False
+    assert downloader.is_nightly_complete("not-a-build-id") is False
+
+
+def test_is_nightly_complete_rejects_symlinked_build_dir(tmp_path):
+    """A symlinked build directory returns False."""
+    config = _make_config(tmp_path)
+    dl = FirmwareReleaseDownloader(config, CacheManager(cache_dir=str(tmp_path / "c")))
+    nightly_root = tmp_path / "downloads" / FIRMWARE_DIR_NAME / "nightlies"
+    nightly_root.mkdir(parents=True)
+    real_build = nightly_root / "real_build"
+    real_build.mkdir()
+    (real_build / "f.zip").write_bytes(b"x")
+    link = nightly_root / BUILD_2_8_0
+    try:
+        os.symlink(str(real_build), str(link))
+    except OSError:
+        pytest.skip("Symlinks not supported")
+
+    assert dl.is_nightly_complete(BUILD_2_8_0) is False

--- a/tests/test_firmware_nightlies.py
+++ b/tests/test_firmware_nightlies.py
@@ -1988,7 +1988,7 @@ def test_should_process_nightly_returns_true_when_hash_missing(
 ):
     """Same identity but a selected asset has no stored hash -> must process (re-validate)."""
     tracking_path = cache_manager.get_cache_file_path(
-        getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE")
+        constants.LATEST_FIRMWARE_NIGHTLY_JSON_FILE
     )
     Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
     Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
@@ -2013,7 +2013,7 @@ def test_should_process_nightly_returns_true_when_zip_corrupt(
     from fetchtastic.utils import save_file_hash
 
     tracking_path = cache_manager.get_cache_file_path(
-        getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE")
+        constants.LATEST_FIRMWARE_NIGHTLY_JSON_FILE
     )
     Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
     Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
@@ -2038,7 +2038,7 @@ def test_should_process_nightly_returns_true_when_target_is_symlink(
 ):
     """Same identity but a selected asset is a symlink -> must process."""
     tracking_path = cache_manager.get_cache_file_path(
-        getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE")
+        constants.LATEST_FIRMWARE_NIGHTLY_JSON_FILE
     )
     Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
     Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
@@ -2068,7 +2068,7 @@ def test_should_process_nightly_same_identity_all_valid_skips(
 ):
     """Same identity and every selected asset passes _validate_nightly_asset -> skip."""
     tracking_path = cache_manager.get_cache_file_path(
-        getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE")
+        constants.LATEST_FIRMWARE_NIGHTLY_JSON_FILE
     )
     Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
     Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
@@ -3284,7 +3284,7 @@ def test_should_process_nightly_uses_build_aware_set(downloader, cache_manager):
     listing = _make_nightly_listing()
     # Track the current build so should_process_nightly checks same-identity.
     tracking_path = cache_manager.get_cache_file_path(
-        getattr(constants, "LATEST_FIRMWARE_NIGHTLY_JSON_FILE")
+        constants.LATEST_FIRMWARE_NIGHTLY_JSON_FILE
     )
     Path(tracking_path).parent.mkdir(parents=True, exist_ok=True)
     Path(tracking_path).write_text(json.dumps({"build_id": BUILD_2_8_0}))
@@ -3506,6 +3506,130 @@ def test_orch_nightly_malformed_source_sets_check_failed(tmp_path):
 
     assert orch.nightly_run_state == NightlyRunState.CHECK_FAILED
     assert orch.latest_firmware_nightly_build_id is None
+
+
+# ------------------------------------------------------------------
+# Falsy non-list source responses: None/[] are valid empty; every
+# other falsy value ("", {}, 0, False, (), set()) must fail closed.
+# ------------------------------------------------------------------
+
+
+def test_fetch_firmware_nightlies_none_returns_empty(downloader, mock_cache_manager):
+    """None from the source is a valid empty listing."""
+    mock_cache_manager.get_repo_contents.return_value = None
+    downloader.cache_manager = mock_cache_manager
+    assert downloader.fetch_firmware_nightlies() == []
+
+
+def test_fetch_firmware_nightlies_empty_list_returns_empty(
+    downloader, mock_cache_manager
+):
+    """[] from the source is a valid empty listing (distinct from malformed)."""
+    mock_cache_manager.get_repo_contents.return_value = []
+    downloader.cache_manager = mock_cache_manager
+    assert downloader.fetch_firmware_nightlies() == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", {}, 0, False, (), set()],
+    ids=["empty-str", "empty-dict", "zero", "false", "empty-tuple", "empty-set"],
+)
+def test_fetch_firmware_nightlies_falsy_non_list_raises(
+    downloader, mock_cache_manager, value
+):
+    """A falsy non-list source response raises ValueError (fail closed).
+
+    Only ``None`` and ``[]`` are valid empty results; every other falsy
+    value is a malformed source response that must not be collapsed into
+    a successful empty listing.
+    """
+    mock_cache_manager.get_repo_contents.return_value = value
+    downloader.cache_manager = mock_cache_manager
+    with pytest.raises(ValueError, match="not a list"):
+        downloader.fetch_firmware_nightlies()
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        ["bad"],
+        [None, 1],
+        [{"name": "ok.bin"}, "bad"],
+        [{"name": "ok.bin"}, {"name": 123}],
+    ],
+    ids=[
+        "string-entry",
+        "non-dict-entries",
+        "mixed-valid-and-string",
+        "mixed-valid-and-bad-name",
+    ],
+)
+def test_fetch_firmware_nightlies_malformed_entries_raise(
+    downloader, mock_cache_manager, entries
+):
+    """Malformed list entries (non-dict or invalid name) raise ValueError."""
+    mock_cache_manager.get_repo_contents.return_value = entries
+    downloader.cache_manager = mock_cache_manager
+    with pytest.raises(ValueError):
+        downloader.fetch_firmware_nightlies()
+
+
+def test_fetch_firmware_nightlies_valid_list_unchanged(downloader, mock_cache_manager):
+    """A valid nonempty list is returned with every entry intact."""
+    listing = _make_nightly_listing()
+    mock_cache_manager.get_repo_contents.return_value = listing
+    downloader.cache_manager = mock_cache_manager
+    assert downloader.fetch_firmware_nightlies() == listing
+
+
+@pytest.mark.parametrize(
+    "value",
+    [{}, "", False],
+    ids=["empty-dict", "empty-str", "false"],
+)
+def test_orch_nightly_falsy_non_list_sets_check_failed(tmp_path, value):
+    """A falsy non-list source response sets CHECK_FAILED end-to-end.
+
+    The real ``fetch_firmware_nightlies`` runs against a mocked source
+    returning the falsy value; it raises ``ValueError``; the orchestrator
+    catches it and marks the run ``CHECK_FAILED``. No fake asset failure
+    is added, no build-id is recorded, and tracking/retention/latest-pointer
+    finalization are never invoked. The ``CHECK_FAILED`` state is the
+    signal ``cli_integration`` uses to suppress the generic "All assets
+    are up to date" log and NTFY.
+    """
+    from fetchtastic.constants import (
+        FILE_TYPE_FIRMWARE_NIGHTLY,
+        NightlyRunState,
+    )
+    from fetchtastic.download.orchestrator import DownloadOrchestrator
+
+    config = _make_config(tmp_path, SAVE_FIRMWARE=True)
+    orch = DownloadOrchestrator(config)
+    fd = orch.firmware_downloader
+    fd.cache_manager.get_repo_contents = Mock(return_value=value)
+    fd.update_nightly_tracking = Mock(return_value=True)
+    fd.cleanup_superseded_nightlies = Mock(return_value=0)
+    fd.update_latest_pointer_for_nightly = Mock(return_value=True)
+    orch._handle_download_result = Mock()
+
+    orch._process_firmware_nightlies()
+
+    assert orch.nightly_run_state == NightlyRunState.CHECK_FAILED
+    # No fake asset DownloadResult (success or failure) was added.
+    assert not any(
+        r.file_type == FILE_TYPE_FIRMWARE_NIGHTLY for r in orch.download_results
+    )
+    assert not any(
+        r.file_type == FILE_TYPE_FIRMWARE_NIGHTLY for r in orch.failed_downloads
+    )
+    # build-id never recorded.
+    assert orch.latest_firmware_nightly_build_id is None
+    # Tracking, retention, latest-pointer finalization never invoked.
+    fd.update_nightly_tracking.assert_not_called()
+    fd.cleanup_superseded_nightlies.assert_not_called()
+    fd.update_latest_pointer_for_nightly.assert_not_called()
 
 
 # ==================================================================

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -483,3 +483,75 @@ class TestNotificationEdgeCases:
         call_args = mock_send.call_args
         assert "2.7.4-alpha+build.123" in call_args[0][2]
         assert "1.2.3-rc.1" in call_args[0][2]
+
+    @patch("fetchtastic.notifications.send_ntfy_notification")
+    @patch("fetchtastic.notifications.datetime")
+    def test_send_completion_notification_with_firmware_nightlies(
+        self, mock_datetime, mock_send
+    ):
+        """Firmware nightly build-ids appear in the notification message."""
+        mock_datetime.now.return_value.astimezone.return_value.isoformat.return_value = (
+            "2024-01-01T12:00:00"
+        )
+
+        config = {"NTFY_SERVER": "https://ntfy.sh", "NTFY_TOPIC": "test"}
+        notifications.send_download_completion_notification(
+            config,
+            ["2.7.4"],
+            ["1.2.3"],
+            downloaded_firmware_nightlies=["2.7.18.abc123", "2.7.18.def456"],
+        )
+
+        expected_message = (
+            "Downloaded Firmware versions: 2.7.4\n"
+            "Downloaded Meshtastic Client versions: 1.2.3\n"
+            "Downloaded firmware nightly builds: 2.7.18.abc123, 2.7.18.def456\n"
+            "2024-01-01T12:00:00"
+        )
+        mock_send.assert_called_once_with(
+            "https://ntfy.sh",
+            "test",
+            expected_message,
+            title="Fetchtastic Download Completed",
+        )
+
+    @patch("fetchtastic.notifications.send_ntfy_notification")
+    @patch("fetchtastic.notifications.datetime")
+    def test_send_completion_notification_only_firmware_nightlies(
+        self, mock_datetime, mock_send
+    ):
+        """Nightly-only downloads still send a notification when passed non-empty."""
+        mock_datetime.now.return_value.astimezone.return_value.isoformat.return_value = (
+            "2024-01-01T12:00:00"
+        )
+
+        config = {"NTFY_SERVER": "https://ntfy.sh", "NTFY_TOPIC": "test"}
+        notifications.send_download_completion_notification(
+            config,
+            [],
+            [],
+            downloaded_firmware_nightlies=["2.7.18.abc123"],
+        )
+
+        expected_message = (
+            "Downloaded firmware nightly builds: 2.7.18.abc123\n" "2024-01-01T12:00:00"
+        )
+        mock_send.assert_called_once_with(
+            "https://ntfy.sh",
+            "test",
+            expected_message,
+            title="Fetchtastic Download Completed",
+        )
+
+    @patch("fetchtastic.notifications.send_ntfy_notification")
+    def test_send_completion_notification_empty_firmware_nightlies_no_notification(
+        self, mock_send
+    ):
+        """Empty firmware nightlies (like all-empty lists) → no notification sent."""
+        config = {"NTFY_SERVER": "https://ntfy.sh", "NTFY_TOPIC": "test"}
+
+        notifications.send_download_completion_notification(
+            config, [], [], downloaded_firmware_nightlies=[]
+        )
+
+        mock_send.assert_not_called()

--- a/tests/test_prereleases_modular.py
+++ b/tests/test_prereleases_modular.py
@@ -261,9 +261,10 @@ def test_prerelease_history_build_simplified_history(prerelease_manager):
         },
     ]
 
-    # Test with expected version "2.7.14"
+    # Stable 2.7.13 admits prerelease bases strictly newer (2.7.14); the 2.7.13
+    # delete commit is rejected (not strictly newer than stable).
     result, seen_shas = prerelease_manager.build_simplified_prerelease_history(
-        "2.7.14", sample_commits
+        "2.7.13", sample_commits
     )
 
     # Should have 2 entries for version 2.7.14 (one added, one deleted)
@@ -469,7 +470,7 @@ def test_find_latest_remote_prerelease_dir_prefers_commit_history(
         ),
     ):
         result = prerelease_manager.find_latest_remote_prerelease_dir(
-            "2.7.17",
+            "2.7.16",
             cache_manager=cache_manager,
             github_token="token",
             allow_env_token=False,
@@ -502,3 +503,111 @@ def test_find_latest_remote_prerelease_dir_returns_none_when_no_match(
         )
 
     assert result is None
+
+
+class TestPrereleaseBaseAdmission:
+    """Prerelease admission across higher minor/major bases.
+
+    Policy: a prerelease base is admitted iff its parsed release is strictly
+    newer than the latest stable release. Stable 2.7.26 therefore admits
+    2.7.27.<sha>, 2.8.0.<sha>, and 3.0.0.<sha> while rejecting <= 2.7.26.
+    `calculate_expected_prerelease_version` (legacy next-patch normalization)
+    remains unchanged and is asserted for regression.
+    """
+
+    STABLE_TAG = "v2.7.26"
+    STABLE = "2.7.26"
+    EXPECTED_NEXT_PATCH = "2.7.27"
+
+    def test_scan_admits_next_patch_and_higher_minor_base(
+        self, prerelease_manager, version_manager
+    ):
+        """Stable 2.7.26 admits next-patch 2.7.27.<sha> and higher-minor 2.8.0.<sha>."""
+        # Legacy next-patch normalization is unchanged.
+        assert (
+            version_manager.calculate_expected_prerelease_version(self.STABLE_TAG)
+            == self.EXPECTED_NEXT_PATCH
+        )
+
+        dirs = [
+            "firmware-2.7.27.abc123",
+            "firmware-2.8.0.abcdef1",
+            "firmware-2.7.26.deadbee",
+            "firmware-2.7.25.oldhash",
+        ]
+        admitted = prerelease_manager.scan_prerelease_directories(dirs, self.STABLE)
+
+        assert "2.7.27.abc123" in admitted
+        assert "2.8.0.abcdef1" in admitted
+        assert "2.7.26.deadbee" not in admitted
+        assert "2.7.25.oldhash" not in admitted
+
+    def test_scan_admits_multiple_newer_bases(
+        self, prerelease_manager, version_manager
+    ):
+        """Admission scans across next-patch, higher minor, and higher major bases."""
+        dirs = [
+            "firmware-2.7.27.aaaaaa",
+            "firmware-2.8.0.bbbbbb",
+            "firmware-3.0.0.cccccc",
+        ]
+        admitted = prerelease_manager.scan_prerelease_directories(dirs, self.STABLE)
+
+        assert "2.7.27.aaaaaa" in admitted
+        assert "2.8.0.bbbbbb" in admitted
+        assert "3.0.0.cccccc" in admitted
+
+    def test_build_history_preserves_add_delete_across_bases(
+        self, prerelease_manager, version_manager
+    ):
+        """Add/delete history recorded for next-patch and higher-minor bases; <= stable dropped."""
+        # Commits in GitHub API order (newest first); reversed internally to oldest-first.
+        commits = [
+            {
+                "sha": "sha0005",
+                "commit": {
+                    "message": "Delete firmware-2.8.0.abcdef1 directory",
+                    "committer": {"date": "2025-01-05T00:00:00Z"},
+                },
+            },
+            {
+                "sha": "sha0004",
+                "commit": {
+                    "message": "2.7.26.deadbee meshtastic/firmware@deadbee",
+                    "committer": {"date": "2025-01-04T00:00:00Z"},
+                },
+            },
+            {
+                "sha": "sha0003",
+                "commit": {
+                    "message": "Delete firmware-2.7.27.aaa0001 directory",
+                    "committer": {"date": "2025-01-03T00:00:00Z"},
+                },
+            },
+            {
+                "sha": "sha0002",
+                "commit": {
+                    "message": "2.8.0.abcdef1 meshtastic/firmware@abcdef1",
+                    "committer": {"date": "2025-01-02T00:00:00Z"},
+                },
+            },
+            {
+                "sha": "sha0001",
+                "commit": {
+                    "message": "2.7.27.aaa0001 meshtastic/firmware@aaa0001",
+                    "committer": {"date": "2025-01-01T00:00:00Z"},
+                },
+            },
+        ]
+        entries, _seen = prerelease_manager.build_simplified_prerelease_history(
+            self.STABLE, commits
+        )
+
+        directories = {e["directory"] for e in entries}
+        assert "firmware-2.7.27.aaa0001" in directories
+        assert "firmware-2.8.0.abcdef1" in directories
+        assert "firmware-2.7.26.deadbee" not in directories
+
+        eight = [e for e in entries if e["directory"] == "firmware-2.8.0.abcdef1"]
+        assert len(eight) == 1
+        assert eight[0]["status"] == "deleted"

--- a/tests/test_prereleases_modular.py
+++ b/tests/test_prereleases_modular.py
@@ -20,6 +20,8 @@ from fetchtastic.download.firmware import FirmwareReleaseDownloader
 from fetchtastic.download.prerelease_history import PrereleaseHistoryManager
 from fetchtastic.download.version import VersionManager
 
+pytestmark = [pytest.mark.unit, pytest.mark.core_downloads]
+
 
 @pytest.fixture
 def test_config():
@@ -235,8 +237,14 @@ def test_cache_manager_commit_timestamp(cache_manager):
 
 
 def test_prerelease_history_build_simplified_history(prerelease_manager):
-    """Test building simplified prerelease history."""
-    # Sample commit data that mimics real GitHub API response
+    """Build simplified prerelease history including a real deletion event.
+
+    Stable 2.7.13 admits prerelease bases strictly newer than it (2.7.14).
+    Both the add commit for 2.7.14 and the delete commit for an admitted
+    2.7.14 base are recorded; deletion of a non-admitted base (2.7.13) is
+    rejected. ``seen_shas`` is asserted to contain every scanned SHA.
+    """
+    # Sample commit data that mimics real GitHub API response (newest first).
     sample_commits = [
         {
             "sha": "abc123def456",
@@ -248,7 +256,7 @@ def test_prerelease_history_build_simplified_history(prerelease_manager):
         {
             "sha": "def456ghi789",
             "commit": {
-                "message": "Delete firmware-2.7.13.ffb168b directory",
+                "message": "Delete firmware-2.7.14.1c0c6b2 directory",
                 "committer": {"date": "2025-01-03T10:00:00Z"},
             },
         },
@@ -261,14 +269,20 @@ def test_prerelease_history_build_simplified_history(prerelease_manager):
         },
     ]
 
-    # Stable 2.7.13 admits prerelease bases strictly newer (2.7.14); the 2.7.13
-    # delete commit is rejected (not strictly newer than stable).
+    # Stable 2.7.13 admits prerelease bases strictly newer (2.7.14); the
+    # 2.7.14 add and the 2.7.14 delete are both admitted and recorded.
     result, seen_shas = prerelease_manager.build_simplified_prerelease_history(
         "2.7.13", sample_commits
     )
 
-    # Should have 2 entries for version 2.7.14 (one added, one deleted)
+    # Every scanned SHA must be observable via seen_shas.
+    assert seen_shas == {"abc123def456", "def456ghi789", "ghi789jkl012"}
+
+    # Two distinct directories, one active and one deleted.
     assert len(result) == 2
+    statuses = {e["directory"]: e["status"] for e in result}
+    assert statuses.get("firmware-2.7.14.e959000") == "active"
+    assert statuses.get("firmware-2.7.14.1c0c6b2") == "deleted"
 
     # Check that entries have the expected structure
     for entry in result:
@@ -505,6 +519,8 @@ def test_find_latest_remote_prerelease_dir_returns_none_when_no_match(
     assert result is None
 
 
+@pytest.mark.unit
+@pytest.mark.core_downloads
 class TestPrereleaseBaseAdmission:
     """Prerelease admission across higher minor/major bases.
 
@@ -542,9 +558,7 @@ class TestPrereleaseBaseAdmission:
         assert "2.7.26.deadbee" not in admitted
         assert "2.7.25.oldhash" not in admitted
 
-    def test_scan_admits_multiple_newer_bases(
-        self, prerelease_manager, version_manager
-    ):
+    def test_scan_admits_multiple_newer_bases(self, prerelease_manager):
         """Admission scans across next-patch, higher minor, and higher major bases."""
         dirs = [
             "firmware-2.7.27.aaaaaa",
@@ -557,9 +571,7 @@ class TestPrereleaseBaseAdmission:
         assert "2.8.0.bbbbbb" in admitted
         assert "3.0.0.cccccc" in admitted
 
-    def test_build_history_preserves_add_delete_across_bases(
-        self, prerelease_manager, version_manager
-    ):
+    def test_build_history_preserves_add_delete_across_bases(self, prerelease_manager):
         """Add/delete history recorded for next-patch and higher-minor bases; <= stable dropped."""
         # Commits in GitHub API order (newest first); reversed internally to oldest-first.
         commits = [

--- a/tests/test_setup_config.py
+++ b/tests/test_setup_config.py
@@ -2,6 +2,7 @@ import copy
 import importlib
 import os
 import subprocess
+from collections.abc import Callable
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -498,7 +499,7 @@ def test_setup_downloads_full_run_prompts_channel_suffix(mocker):
 
     mocker.patch(
         "builtins.input",
-        side_effect=["", "2", "n", "n", "n", "n"],
+        side_effect=["", "2", "n", "n", "n", "n", "n"],
     )
     mocker.patch(
         "fetchtastic.menu_firmware.run_menu",
@@ -1604,6 +1605,7 @@ def test_run_setup_first_run_linux_simple(
         "",  # Use default base directory
         "b",  # Both APKs and firmware
         "n",  # Check for firmware prereleases
+        "n",  # Check for firmware nightlies
         "2",  # Keep 2 versions of client app (now in _setup_downloads)
         "y",  # Check for APK prereleases
         "n",  # Check for app snapshots
@@ -1692,6 +1694,7 @@ def test_run_setup_first_run_windows(
         "y",  # create menu
         "b",  # Both APKs and firmware
         "n",  # Check for firmware prereleases
+        "n",  # Check for firmware nightlies
         "2",  # Keep 2 versions of client app (now in _setup_downloads)
         "y",  # Check for APK prereleases
         "n",  # Check for app snapshots
@@ -1787,6 +1790,7 @@ def test_run_setup_first_run_termux(  # noqa: ARG001
         "",  # Use default base directory
         "b",  # Both APKs and firmware
         "n",  # Check for firmware prereleases
+        "n",  # Check for firmware nightlies
         "1",  # Keep 1 version of client app (now in _setup_downloads)
         "y",  # Check for APK prereleases
         "n",  # Check for app snapshots
@@ -1881,6 +1885,7 @@ def test_run_setup_existing_config(
         "/new/base/dir",  # New base directory
         "f",  # Only firmware
         "y",  # Check for pre-releases
+        "n",  # Check for firmware nightlies
         "n",  # Add channel suffixes
         "5",  # Keep 5 versions of firmware
         "y",  # Auto-extract
@@ -1998,6 +2003,7 @@ def test_run_setup_partial_firmware_section(
         "y",  # Download firmware releases
         "y",  # Re-run firmware menu
         "y",  # Check for firmware prereleases
+        "n",  # Check for firmware nightlies
         "n",  # Add channel suffixes
         "3",  # Keep 3 versions of firmware
         "y",  # Auto-extract
@@ -2979,3 +2985,218 @@ def test_should_recommend_setup_attribute_error(mock_load_config):
     assert "Could not determine setup status" == reason
     assert last_ver is None
     assert curr_ver is None
+
+
+# ---------------------------------------------------------------------------
+# Firmware nightly (rolling) opt-in setup tests
+#
+# These tests cover the CHECK_FIRMWARE_NIGHTLIES and
+# FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP config keys that gate opt-in firmware
+# nightly downloads.  The nightly question runs after the firmware
+# prerelease prompt.
+# Defaults: CHECK_FIRMWARE_NIGHTLIES=False,
+# FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP=1.
+# ---------------------------------------------------------------------------
+
+
+def _make_firmware_only_input_captor(
+    prerelease_answer: str = "n",
+    nightly_answer: str = "n",
+) -> tuple[list[str], Callable[..., str]]:
+    """Return (captured_prompts, fake_input) for a firmware-only _setup_downloads run.
+
+    fake_input inspects the prompt text so it is robust to the nightly
+    question wording.  When the nightly prompt is absent the
+    ``nightly_answer`` is simply never consumed.
+    """
+
+    captured: list[str] = []
+
+    def fake_input(prompt: str = "", **_kwargs: object) -> str:
+        captured.append(prompt)
+        lowered = prompt.lower()
+
+        # Download-type selection prompt
+        if "client app assets, firmware, both, or none" in lowered:
+            return "f"  # firmware only
+
+        # Firmware prerelease prompt
+        if "pre-release firmware" in lowered:
+            return prerelease_answer
+
+        # Firmware nightly prompt
+        if "nightly" in lowered:
+            return nightly_answer
+
+        # Channel suffix prompt
+        if "suffix" in lowered:
+            return "n"
+
+        # Versions-to-keep prompts
+        if "how many" in lowered and "version" in lowered:
+            return "2"
+
+        # Safe default for anything else
+        return "n"
+
+    return captured, fake_input
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_downloads_disables_firmware_nightlies_by_default(mocker):
+    """Default firmware setup must explicitly set CHECK_FIRMWARE_NIGHTLIES to False."""
+    from fetchtastic.setup_config import _setup_downloads
+
+    config: dict = {}
+    _captured, fake_input = _make_firmware_only_input_captor(
+        prerelease_answer="n", nightly_answer="n"
+    )
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch(
+        "fetchtastic.menu_firmware.run_menu",
+        return_value={"selected_assets": ["rak4631-"]},
+    )
+
+    result_config, _save_apks, save_firmware = _setup_downloads(
+        config, is_partial_run=False, wants=lambda _: True
+    )
+
+    assert save_firmware is True
+    assert "CHECK_FIRMWARE_NIGHTLIES" in result_config
+    assert result_config["CHECK_FIRMWARE_NIGHTLIES"] is False
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_downloads_nightly_prompt_shown_when_firmware_enabled(mocker):
+    """Fresh setup with firmware enabled must ask an experimental rolling-nightly question."""
+    from fetchtastic.setup_config import _setup_downloads
+
+    config: dict = {}
+    captured, fake_input = _make_firmware_only_input_captor(
+        prerelease_answer="n", nightly_answer="n"
+    )
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch(
+        "fetchtastic.menu_firmware.run_menu",
+        return_value={"selected_assets": ["rak4631-"]},
+    )
+
+    _setup_downloads(config, is_partial_run=False, wants=lambda _: True)
+
+    nightly_prompts = [p for p in captured if "nightly" in p.lower()]
+    # A nightly opt-in prompt must appear during firmware setup.
+    assert (
+        len(nightly_prompts) >= 1
+    ), f"Expected a firmware nightly prompt; captured prompts: {captured}"
+    # The prompt must signal experimental/rolling status clearly
+    assert any(
+        "experimental" in p.lower() or "rolling" in p.lower() for p in nightly_prompts
+    ), f"Nightly prompt must clearly label itself experimental; got: {nightly_prompts}"
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_downloads_nightly_yes_enables_flag_and_defaults_keep_count(mocker):
+    """Answering yes to the nightly prompt enables the flag and defaults keep-count to 1."""
+    from fetchtastic.setup_config import _setup_downloads
+
+    config: dict = {}
+    captured, fake_input = _make_firmware_only_input_captor(
+        prerelease_answer="n", nightly_answer="y"
+    )
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch(
+        "fetchtastic.menu_firmware.run_menu",
+        return_value={"selected_assets": ["rak4631-"]},
+    )
+
+    result_config, _save_apks, save_firmware = _setup_downloads(
+        config, is_partial_run=False, wants=lambda _: True
+    )
+
+    assert save_firmware is True
+    # Yes-answer must enable the nightly flag.
+    assert "CHECK_FIRMWARE_NIGHTLIES" in result_config
+    assert result_config["CHECK_FIRMWARE_NIGHTLIES"] is True
+
+    # Keep-count must default to 1 silently.
+    assert "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP" in result_config
+    assert result_config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 1
+
+    # Guard: no separate "how many nightly versions to keep" prompt
+    nightly_keep_prompts = [
+        p for p in captured if "nightly" in p.lower() and "how many" in p.lower()
+    ]
+    assert nightly_keep_prompts == [], (
+        "Nightly keep-count should default silently, not via a separate prompt; "
+        f"got: {nightly_keep_prompts}"
+    )
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_downloads_nightly_no_preserves_disabled(mocker):
+    """Answering no to the nightly prompt preserves CHECK_FIRMWARE_NIGHTLIES as False."""
+    from fetchtastic.setup_config import _setup_downloads
+
+    config: dict = {}
+    _captured, fake_input = _make_firmware_only_input_captor(
+        prerelease_answer="n", nightly_answer="n"
+    )
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch(
+        "fetchtastic.menu_firmware.run_menu",
+        return_value={"selected_assets": ["rak4631-"]},
+    )
+
+    result_config, _save_apks, save_firmware = _setup_downloads(
+        config, is_partial_run=False, wants=lambda _: True
+    )
+
+    assert save_firmware is True
+    # No-answer must leave nightlies disabled.
+    assert "CHECK_FIRMWARE_NIGHTLIES" in result_config
+    assert result_config["CHECK_FIRMWARE_NIGHTLIES"] is False
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_downloads_firmware_disabled_forces_nightlies_off(mocker):
+    """When firmware downloads are disabled, nightlies must be explicitly forced off."""
+    from fetchtastic.setup_config import _setup_downloads
+
+    config: dict = {}
+    captured: list[str] = []
+
+    def fake_input(prompt: str = "", **_kwargs: object) -> str:
+        captured.append(prompt)
+        lowered = prompt.lower()
+        # Select client-app-only to disable firmware
+        if "client app assets, firmware, both, or none" in lowered:
+            return "a"
+        if "how many" in lowered and "version" in lowered:
+            return "2"
+        return "n"
+
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch(
+        "fetchtastic.menu_app.run_menu",
+        return_value={"selected_assets": ["meshtastic.apk"]},
+    )
+
+    result_config, _save_apks, save_firmware = _setup_downloads(
+        config, is_partial_run=False, wants=lambda _: True
+    )
+
+    assert save_firmware is False
+    # Firmware disabled must force nightlies off.
+    assert "CHECK_FIRMWARE_NIGHTLIES" in result_config
+    assert result_config["CHECK_FIRMWARE_NIGHTLIES"] is False
+
+    # Guard: no nightly prompt should appear when firmware is disabled
+    nightly_prompts = [p for p in captured if "nightly" in p.lower()]
+    assert (
+        nightly_prompts == []
+    ), f"Nightly prompt must not appear when firmware is disabled; got: {nightly_prompts}"

--- a/tests/test_setup_config_extended.py
+++ b/tests/test_setup_config_extended.py
@@ -247,6 +247,7 @@ def test_setup_downloads_firmware_only(mocker, capsys):
         side_effect=[
             "f",  # Choose firmware only
             "n",  # Check firmware prereleases
+            "n",  # Check firmware nightlies
             "n",  # Add channel suffixes
         ],
     )
@@ -275,7 +276,8 @@ def test_setup_downloads_both_selected(mocker, capsys):
         "builtins.input",
         side_effect=[
             "b",
-            "n",
+            "n",  # Check firmware prereleases
+            "n",  # Check firmware nightlies
             "2",
             "y",
             "n",
@@ -560,6 +562,7 @@ def test_setup_downloads_partial_run_firmware_keep_existing_skips_menu(mocker):
             "y",  # Download firmware releases
             "n",  # Don't rerun menu
             "n",  # Disable firmware prereleases
+            "n",  # Disable firmware nightlies
             "n",  # Add channel suffixes
         ],
     )
@@ -594,6 +597,7 @@ def test_setup_downloads_partial_run_firmware_channel_suffix_config(mocker):
             "y",  # Download firmware releases
             "n",  # Don't rerun menu
             "n",  # Disable firmware prereleases
+            "n",  # Disable firmware nightlies
             "n",  # Disable channel suffixes
         ],
     )
@@ -1202,3 +1206,142 @@ def test_prompt_for_migration(mocker):
     result = setup_config.prompt_for_migration()
 
     assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Firmware nightly (rolling) opt-in — backward-compatibility guard tests
+#
+# These tests guard the CHECK_FIRMWARE_NIGHTLIES and
+# FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP keys in the setup flow.  They verify
+# that:
+#   - Partial runs not targeting firmware preserve an existing nightly value
+#   - Existing configs without nightly keys remain unaffected after load
+#   - The nightly keep-count is never prompted separately (defaults silently)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_partial_non_firmware_run_preserves_existing_nightly_value(mocker):
+    """A partial run for a non-firmware section must not change CHECK_FIRMWARE_NIGHTLIES."""
+    from fetchtastic.setup_config import _setup_downloads
+
+    config = {
+        "SAVE_APKS": True,
+        "SAVE_FIRMWARE": False,
+        "SELECTED_APK_ASSETS": ["meshtastic.apk"],
+        "CHECK_APK_PRERELEASES": False,
+        # Simulate a config where the user previously opted into nightlies
+        "CHECK_FIRMWARE_NIGHTLIES": True,
+        "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 3,
+    }
+
+    mocker.patch(
+        "builtins.input",
+        side_effect=[
+            "y",  # Keep downloading client app releases
+            "n",  # Skip re-running menu (existing selection kept)
+            "2",  # Versions to keep
+            "n",  # Disable prereleases
+            "n",  # No channel suffixes
+        ],
+    )
+
+    result_config, _save_apks, save_firmware = _setup_downloads(
+        config, is_partial_run=True, wants=lambda section: section == "app"
+    )
+
+    # Firmware section was not touched; nightly value must be preserved
+    assert save_firmware is False
+    assert result_config.get("CHECK_FIRMWARE_NIGHTLIES") is True
+    assert result_config.get("FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP") == 3
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_existing_config_without_nightly_keys_remains_unaffected(mocker, tmp_path):
+    """load_config must not silently enable nightlies for existing configs lacking the keys."""
+    config_path = tmp_path / "fetchtastic.yaml"
+    old_config_path = tmp_path / "old_fetchtastic.yaml"
+
+    existing_config_data = {
+        "BASE_DIR": str(tmp_path / "downloads"),
+        "SAVE_FIRMWARE": True,
+        "SAVE_APKS": True,
+        "FIRMWARE_VERSIONS_TO_KEEP": 2,
+        "CHECK_PRERELEASES": False,
+    }
+    with open(config_path, "w") as f:
+        yaml.safe_dump(existing_config_data, f)
+
+    mocker.patch.object(setup_config, "CONFIG_FILE", str(config_path))
+    mocker.patch.object(setup_config, "OLD_CONFIG_FILE", str(old_config_path))
+
+    config = setup_config.load_config()
+
+    assert config is not None
+    # Nightly keys must not be silently enabled (True) on upgrade.
+    # They may be absent (pre-feature) or explicitly False (post-feature),
+    # but must never be True for an existing config that never opted in.
+    nightly_value = config.get("CHECK_FIRMWARE_NIGHTLIES", False)
+    assert (
+        nightly_value is not True
+    ), f"Existing config must not silently enable nightlies; got: {nightly_value}"
+
+    nightly_keep = config.get("FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP", 1)
+    assert (
+        nightly_keep != 0
+    ), f"Nightly keep-count must floor at 1, not 0; got: {nightly_keep}"
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_nightly_keep_count_not_prompted_separately(mocker):
+    """Enabling nightlies must not trigger a separate 'how many nightly versions' prompt."""
+    from fetchtastic.setup_config import _setup_downloads
+
+    config: dict = {}
+    captured: list[str] = []
+
+    def fake_input(prompt: str = "", **_kwargs: object) -> str:
+        captured.append(prompt)
+        lowered = prompt.lower()
+
+        if "client app assets, firmware, both, or none" in lowered:
+            return "f"
+        if "pre-release firmware" in lowered:
+            return "n"
+        if "nightly" in lowered:
+            return "y"  # opt into nightlies
+        if "suffix" in lowered:
+            return "n"
+        if "how many" in lowered and "version" in lowered:
+            return "2"
+        return "n"
+
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch(
+        "fetchtastic.menu_firmware.run_menu",
+        return_value={"selected_assets": ["rak4631-"]},
+    )
+
+    result_config, _save_apks, save_firmware = _setup_downloads(
+        config, is_partial_run=False, wants=lambda _: True
+    )
+
+    assert save_firmware is True
+
+    # Keep-count must default silently to 1.
+    assert "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP" in result_config
+    assert result_config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 1
+
+    # Guard: no separate "how many nightly versions to keep" prompt.
+    # The keep-count must default silently (matching the snapshot precedent
+    # which does not prompt for APP_SNAPSHOT_VERSIONS_TO_KEEP).
+    nightly_keep_prompts = [
+        p for p in captured if "nightly" in p.lower() and "how many" in p.lower()
+    ]
+    assert nightly_keep_prompts == [], (
+        "Nightly keep-count should default silently, not via a separate prompt; "
+        f"got: {nightly_keep_prompts}"
+    )

--- a/tests/test_setup_config_uncovered.py
+++ b/tests/test_setup_config_uncovered.py
@@ -173,6 +173,7 @@ def test_setup_downloads_full_run_multiple_selection(mocker):
             "y",
             "y",
             "y",
+            "n",  # No firmware nightlies
             "n",
             "n",
             "n",
@@ -1254,6 +1255,7 @@ def test_run_setup_windows_cmd_environment(
                 "n",  # Don't create menu shortcuts
                 "b",  # Both client apps and firmware
                 "n",  # No firmware prereleases
+                "n",  # No firmware nightlies
                 "n",  # No client app prereleases
                 "n",  # No app snapshots
                 "n",  # No channel suffixes
@@ -1598,6 +1600,7 @@ def test_run_setup_version_package_not_found(
             "",  # Use default base directory
             "b",  # Both client apps and firmware
             "n",  # No firmware prereleases
+            "n",  # No firmware nightlies
             "n",  # No client app prereleases
             "n",  # No app snapshots
             "n",  # No channel suffixes
@@ -1683,6 +1686,7 @@ def test_run_setup_version_other_error(
             "",  # Use default base directory
             "b",  # Both client apps and firmware
             "n",  # No firmware prereleases
+            "n",  # No firmware nightlies
             "n",  # No client app prereleases
             "n",  # No app snapshots
             "n",  # No channel suffixes
@@ -1769,6 +1773,7 @@ def test_run_setup_config_dir_creation_error(
             "",  # Use default base directory
             "b",  # Both client apps and firmware
             "n",  # No firmware prereleases
+            "n",  # No firmware nightlies
             "n",  # No client app prereleases
             "n",  # No app snapshots
             "n",  # No channel suffixes

--- a/tests/test_version_management.py
+++ b/tests/test_version_management.py
@@ -288,12 +288,12 @@ class TestPrereleaseBaseAdmission:
         assert vm.is_prerelease_base_newer_than_stable("2.7.27", "v2.7.26") is True
 
     def test_rejects_unparseable_base(self):
-        """An unparseable base is conservatively rejected."""
+        """An unparsable base is conservatively rejected."""
         vm = VersionManager()
         assert vm.is_prerelease_base_newer_than_stable("garbage", "2.7.26") is False
 
     def test_rejects_unparseable_stable(self):
-        """An unparseable stable is conservatively rejected."""
+        """An unparsable stable is conservatively rejected."""
         vm = VersionManager()
         assert vm.is_prerelease_base_newer_than_stable("2.7.27", "garbage") is False
 
@@ -319,7 +319,7 @@ class TestPrereleaseBaseAdmission:
         assert vm.is_prerelease_base_newer_than_stable("2.8.0", "2.7.26") is True
 
     def test_tuple_normalization_rejects_unparseable(self):
-        """Unparseable inputs are still conservatively rejected after normalization."""
+        """Unparsable inputs are still conservatively rejected after normalization."""
         vm = VersionManager()
         assert vm.is_prerelease_base_newer_than_stable("2.7", "garbage") is False
         assert vm.is_prerelease_base_newer_than_stable("garbage", "2.7.0") is False

--- a/tests/test_version_management.py
+++ b/tests/test_version_management.py
@@ -302,6 +302,28 @@ class TestPrereleaseBaseAdmission:
         assert is_prerelease_base_newer_than_stable("2.7.27", "2.7.26") is True
         assert is_prerelease_base_newer_than_stable("2.7.26", "2.7.26") is False
 
+    def test_tuple_normalization_two_component_equals_three_component(self):
+        """2.7 == 2.7.0 semantically: neither is strictly newer (both directions)."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("2.7", "2.7.0") is False
+        assert vm.is_prerelease_base_newer_than_stable("2.7.0", "2.7") is False
+
+    def test_tuple_normalization_higher_patch_beats_shorter(self):
+        """2.7.1 is strictly newer than 2.7 even though 2.7 has fewer components."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("2.7.1", "2.7") is True
+
+    def test_tuple_normalization_higher_minor_beats_longer(self):
+        """2.8.0 is strictly newer than 2.7.26 (minor dominates patch count)."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("2.8.0", "2.7.26") is True
+
+    def test_tuple_normalization_rejects_unparseable(self):
+        """Unparseable inputs are still conservatively rejected after normalization."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("2.7", "garbage") is False
+        assert vm.is_prerelease_base_newer_than_stable("garbage", "2.7.0") is False
+
 
 class TestPrereleaseVersionParsing:
     """Test prerelease version parsing."""

--- a/tests/test_version_management.py
+++ b/tests/test_version_management.py
@@ -21,6 +21,7 @@ from fetchtastic.download.version import (
     _write_latest_release_tag,
     calculate_expected_prerelease_version,
     extract_version,
+    is_prerelease_base_newer_than_stable,
     is_prerelease_directory,
     normalize_commit_identifier,
 )
@@ -249,6 +250,55 @@ class TestExpectedPrereleaseVersion:
         vm = VersionManager()
         result = vm.calculate_expected_prerelease_version("")
         assert result is None
+
+
+class TestPrereleaseBaseAdmission:
+    """Test the single semantic admission rule: base strictly newer than stable."""
+
+    def test_admits_higher_patch(self):
+        """2.7.27 is strictly newer than stable 2.7.26."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("2.7.27", "2.7.26") is True
+
+    def test_admits_higher_minor(self):
+        """2.8.0 is strictly newer than stable 2.7.26."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("2.8.0", "2.7.26") is True
+
+    def test_admits_higher_major(self):
+        """3.0.0 is strictly newer than stable 2.7.26."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("3.0.0", "2.7.26") is True
+
+    def test_rejects_equal_stable(self):
+        """A base equal to stable is not strictly newer."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("2.7.26", "2.7.26") is False
+
+    def test_rejects_older_base(self):
+        """A base older than stable is rejected."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("2.7.25", "2.7.26") is False
+
+    def test_accepts_v_prefixed_stable(self):
+        """A leading 'v' on the stable value is tolerated."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("2.7.27", "v2.7.26") is True
+
+    def test_rejects_unparseable_base(self):
+        """An unparseable base is conservatively rejected."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("garbage", "2.7.26") is False
+
+    def test_rejects_unparseable_stable(self):
+        """An unparseable stable is conservatively rejected."""
+        vm = VersionManager()
+        assert vm.is_prerelease_base_newer_than_stable("2.7.27", "garbage") is False
+
+    def test_module_helper_matches_method(self):
+        """The module-level helper delegates to the singleton consistently."""
+        assert is_prerelease_base_newer_than_stable("2.7.27", "2.7.26") is True
+        assert is_prerelease_base_newer_than_stable("2.7.26", "2.7.26") is False
 
 
 class TestPrereleaseVersionParsing:

--- a/tests/test_version_management.py
+++ b/tests/test_version_management.py
@@ -252,6 +252,8 @@ class TestExpectedPrereleaseVersion:
         assert result is None
 
 
+@pytest.mark.unit
+@pytest.mark.core_downloads
 class TestPrereleaseBaseAdmission:
     """Test the single semantic admission rule: base strictly newer than stable."""
 


### PR DESCRIPTION
## Summary

This adds opt-in support for downloading Meshtastic rolling firmware nightly builds and updates firmware prerelease selection to support minor and major version transitions, such as moving from stable `2.7.x` releases to `2.8.x` prereleases.

Firmware nightlies remain disabled by default and are stored separately from stable and prerelease firmware.

## What changed

### Firmware nightly downloads

* Add the opt-in `CHECK_FIRMWARE_NIGHTLIES` setting.
* Discover rolling builds from the `firmware-nightly` GitHub contents source.
* Derive an immutable build ID from the release-level firmware manifest.
* Store selected assets under:

  * `firmware/nightlies/<build_id>/`
* Maintain a managed relative `firmware/nightlies/latest` pointer.
* Track the finalized nightly build separately in the user cache.
* Reuse `SELECTED_FIRMWARE_ASSETS` and `EXCLUDE_PATTERNS`.
* Always retain the release-level manifest required to identify the build.
* Exclude stale assets belonging to a different nightly generation.
* Support configurable retention through `FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP`.

### Transaction and validation safety

A nightly build is finalized only after every selected asset is complete and valid.

The nightly workflow now:

* Validates GitHub-reported file sizes.
* Validates stored hashes.
* Checks ZIP archive integrity.
* Parses and validates the release-level JSON manifest.
* Removes invalid files and associated hash metadata.
* Applies executable permissions to validated shell scripts.
* Retries failed assets through the existing retry pipeline.
* Advances tracking, retention cleanup, and the `latest` pointer only after the complete transaction succeeds.
* Leaves older known-good nightlies untouched when downloading or tracking fails.
* Distinguishes actual downloads from tracking, pointer, retention, and permission-only maintenance.

Managed paths are validated before reading, writing, retrying, or deleting. Symlinked download roots, firmware parents, nightly directories, build directories, and asset targets are rejected without following or mutating external paths.

Malformed source responses fail closed and suppress false “up to date” reporting.

### Firmware prerelease admission

Firmware prerelease bases are now admitted when they are strictly newer than the latest stable version.

For example, stable `2.7.26` admits:

* `2.7.27`
* `2.8.0`
* Higher major versions

Equal, older, and unparseable bases remain rejected.

Release tuples are normalized so semantically equivalent versions such as `2.7` and `2.7.0` compare equally.

### Reporting, notifications, and setup

* Include finalized nightly builds in CLI summaries and latest-version reporting.
* Add optional NTFY notifications for actual nightly downloads.
* Do not report tracking or maintenance-only reconciliation as a new download.
* Suppress up-to-date notifications when a nightly check fails or remains incomplete.
* Add setup and documentation for nightly enablement, retention, storage, and notifications.

## Compatibility

Firmware nightlies are disabled by default, so existing users retain their current download behavior unless they explicitly enable the feature.

No migration is required.

The prerelease admission rule is intentionally stricter: only prerelease bases newer than the latest stable release are eligible.

## Testing

* Added extensive nightly regression coverage for discovery, coherent asset selection, downloads, validation, retries, transactional finalization, reporting, notifications, retention, pointer maintenance, reconciliation, and path safety.
* Added prerelease admission coverage across patch, minor, and major version transitions.
* The full 2,812-test suite passes.
* GitHub Actions passes on Python 3.10 through 3.14.
