### PR TITLE
Fix firmware nightly setup wording and question order

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,14 +93,14 @@ Firmware `latest` points only to a complete release with at least one selected n
 
 ### Firmware Nightly Builds
 
-When `CHECK_FIRMWARE_NIGHTLIES` is enabled, Fetchtastic checks a rolling experimental firmware source at `meshtastic.github.io/firmware-nightly`. This is a flat directory that is replaced on every push to the firmware `main` branch; it is not a GitHub Release, not a tagged release, and not a production release. Existing configurations remain disabled unless you opt in.
+When `CHECK_FIRMWARE_NIGHTLIES` is enabled, Fetchtastic checks a rolling experimental firmware source at `meshtastic.github.io/firmware-nightly`. Upstream publishes these from the firmware develop branch through its scheduled nightly workflow and may also refresh them manually; each publish replaces the rolling upstream contents. It is not a GitHub Release, not a tagged release, and not a production release. Existing configurations remain disabled unless you opt in.
 
 Nightly builds are stored separately from stable and prerelease firmware under `firmware/nightlies/<build_id>/`, where `<build_id>` is the immutable build identity parsed from the single release-level manifest (`firmware-<version>.<hash>.json`, for example `firmware-2.8.0.f52e2ea.json` → `2.8.0.f52e2ea`). Two distinct artifacts track the newest nightly, and they must not be confused:
 
 - **Cache tracking file** `latest_firmware_nightly.json` lives in the fetchtastic cache directory and records the build-id that has been fully downloaded and tracked. It is written only after every selected asset downloads and validates successfully.
 - **Filesystem `latest` pointer** is an optional relative symlink `firmware/nightlies/latest` pointing at the retained build directory. It is created only when `CREATE_LATEST_SYMLINKS` is enabled, and only after the same successful transaction that writes the cache tracking file.
 
-`FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP` (default `1`, minimum `1` when nightlies are enabled) controls how many nightly build directories are retained when cleanup runs. Because each push replaces the rolling build, older build directories are pruned as new builds arrive.
+`FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP` (default `1`, minimum `1` when nightlies are enabled) controls how many nightly build directories are retained when cleanup runs. Because each nightly publish replaces the rolling upstream contents, older build directories are pruned as new builds arrive.
 
 `NOTIFY_ON_FIRMWARE_NIGHTLIES` (default `false`) controls whether nightly downloads trigger NTFY notifications. When disabled, nightly downloads are still logged locally and counted in download summaries, but no push notification is sent.
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -300,7 +300,7 @@ Enable prerelease downloads to get the latest development firmware from meshtast
 
 ### Firmware Nightly Builds
 
-Separate from prereleases, Fetchtastic can download rolling experimental firmware nightly builds from `meshtastic.github.io/firmware-nightly`. These are not production releases: the rolling directory is replaced on every push to firmware `main`. The feature is opt-in (`CHECK_FIRMWARE_NIGHTLIES`, default off) and stores builds under `firmware/nightlies/<build_id>/`. `FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP` (default `1`) controls how many builds are kept, and `NOTIFY_ON_FIRMWARE_NIGHTLIES` (default off) controls NTFY notifications. See the [Configuration Reference](configuration.md) for details.
+Separate from prereleases, Fetchtastic can download rolling experimental firmware nightly builds from `meshtastic.github.io/firmware-nightly`. Upstream publishes these from the firmware develop branch through its scheduled nightly workflow and may also refresh them manually; each publish replaces the rolling upstream contents. These are not production releases. The feature is opt-in (`CHECK_FIRMWARE_NIGHTLIES`, default off) and stores builds under `firmware/nightlies/<build_id>/`. `FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP` (default `1`) controls how many builds are kept, and `NOTIFY_ON_FIRMWARE_NIGHTLIES` (default off) controls NTFY notifications. See the [Configuration Reference](configuration.md) for details.
 
 ### Multiple Asset Types
 

--- a/src/fetchtastic/setup_config.py
+++ b/src/fetchtastic/setup_config.py
@@ -800,7 +800,7 @@ def _disable_asset_downloads(
     """
     Disable downloads for the given asset type and clear related configuration keys.
 
-    Mutates and returns the provided configuration mapping, clears selected-asset lists, and disables related prerelease checks. Prints the provided message or a sensible default.
+    Mutates and returns the provided configuration mapping, clears selected-asset lists, and disables related prerelease checks. For firmware, also disables nightly checks (``CHECK_FIRMWARE_NIGHTLIES``) while preserving the nightly-retention preference (``FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP``). Prints the provided message or a sensible default.
 
     Parameters:
         config (Dict[str, Any]): Configuration dictionary to update in place and return.
@@ -825,6 +825,7 @@ def _disable_asset_downloads(
     if asset_type == "firmware":
         config["CHECK_PRERELEASES"] = False
         config["SELECTED_PRERELEASE_ASSETS"] = []
+        config["CHECK_FIRMWARE_NIGHTLIES"] = False
     else:
         config["CHECK_APK_PRERELEASES"] = False
     return config, False
@@ -942,39 +943,9 @@ def _setup_downloads(
         config["SAVE_DESKTOP_APP"] = False
         save_desktop = False
 
-    if save_firmware and (not is_partial_run or wants("firmware")):
-        rerun_menu = True
-        if is_partial_run:
-            if config.get("SELECTED_FIRMWARE_ASSETS"):
-                rerun_menu_choice = _safe_input(
-                    "Re-run the firmware asset selection menu? [y/n] (default: yes): ",
-                    default="y",
-                )
-                if not _coerce_bool(rerun_menu_choice, default=True):
-                    rerun_menu = False
-        if rerun_menu:
-            firmware_selection = menu_firmware.run_menu()
-            selected_assets = (
-                firmware_selection.get("selected_assets")
-                if isinstance(firmware_selection, dict)
-                else None
-            )
-            if not selected_assets:
-                config, save_firmware = _disable_asset_downloads(config, "firmware")
-            else:
-                config["SELECTED_FIRMWARE_ASSETS"] = selected_assets
-        elif not config.get("SELECTED_FIRMWARE_ASSETS"):
-            config, save_firmware = _disable_asset_downloads(
-                config,
-                "firmware",
-                "No existing firmware selection found. Firmware will not be downloaded.",
-            )
-
-    # Firmware pre-release, nightly, and channel-suffix prompts now live in
-    # _setup_firmware so the firmware section is contiguous (see run_setup).
-    # This function only sets the download toggle and runs the asset menus;
-    # the firmware-disabled guard below still force-disables the related
-    # flags so stale values cannot survive a firmware-off choice.
+    # Firmware asset-selection menu is deferred to after the client-app
+    # section so the full setup flow keeps the firmware section contiguous
+    # (asset menu → _setup_firmware prompts with no app prompts between).
 
     app_section_requested = not is_partial_run or wants("app")
 
@@ -1114,6 +1085,37 @@ def _setup_downloads(
     normalize_client_app_config(config)
     save_apks = save_client_apps
     save_desktop = _coerce_bool(config.get("SAVE_DESKTOP_APP", False))
+
+    # Firmware asset-selection menu — runs after the client-app section so
+    # the full setup flow has a contiguous firmware section: once the firmware
+    # asset menu starts, no client-app prompt appears before _setup_firmware.
+    if save_firmware and (not is_partial_run or wants("firmware")):
+        rerun_menu = True
+        if is_partial_run:
+            if config.get("SELECTED_FIRMWARE_ASSETS"):
+                rerun_menu_choice = _safe_input(
+                    "Re-run the firmware asset selection menu? [y/n] (default: yes): ",
+                    default="y",
+                )
+                if not _coerce_bool(rerun_menu_choice, default=True):
+                    rerun_menu = False
+        if rerun_menu:
+            firmware_selection = menu_firmware.run_menu()
+            selected_assets = (
+                firmware_selection.get("selected_assets")
+                if isinstance(firmware_selection, dict)
+                else None
+            )
+            if not selected_assets:
+                config, save_firmware = _disable_asset_downloads(config, "firmware")
+            else:
+                config["SELECTED_FIRMWARE_ASSETS"] = selected_assets
+        elif not config.get("SELECTED_FIRMWARE_ASSETS"):
+            config, save_firmware = _disable_asset_downloads(
+                config,
+                "firmware",
+                "No existing firmware selection found. Firmware will not be downloaded.",
+            )
 
     # Channel-suffix prompt has moved to _setup_firmware (contiguous firmware section).
 
@@ -1504,7 +1506,7 @@ def _setup_firmware(
         elif not nightly_input:
             config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = parsed_current
         else:
-            print("Invalid value — keeping current value. " "Minimum is 1.")
+            print("Invalid value — keeping current value. Minimum is 1.")
             config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = parsed_current
 
     return config

--- a/src/fetchtastic/setup_config.py
+++ b/src/fetchtastic/setup_config.py
@@ -970,41 +970,11 @@ def _setup_downloads(
                 "No existing firmware selection found. Firmware will not be downloaded.",
             )
 
-    # --- Firmware Pre-release Configuration ---
-    if save_firmware and (not is_partial_run or wants("firmware")):
-        check_prereleases_current = _coerce_bool(config.get("CHECK_PRERELEASES", False))
-        check_prereleases_default = "y" if check_prereleases_current else "n"
-        check_prereleases_input = _safe_input(
-            f"\nWould you like to check for and download pre-release firmware from meshtastic.github.io? [y/n] (default: {check_prereleases_default}): ",
-            default=check_prereleases_default,
-        )
-        config["CHECK_PRERELEASES"] = _coerce_bool(check_prereleases_input)
-
-    # --- Firmware Nightly (Rolling Experimental) Configuration ---
-    if save_firmware and (not is_partial_run or wants("firmware")):
-        check_nightlies_current = _coerce_bool(
-            config.get("CHECK_FIRMWARE_NIGHTLIES", DEFAULT_CHECK_FIRMWARE_NIGHTLIES)
-        )
-        check_nightlies_default = "y" if check_nightlies_current else "n"
-        check_nightlies_input = _safe_input(
-            f"\nWould you like to check for and download rolling experimental firmware nightly builds? "
-            f"These are not production releases, are replaced on every push to firmware main, "
-            f"and are stored separately under firmware/nightlies/. [y/n] (default: {check_nightlies_default}): ",
-            default=check_nightlies_default,
-        )
-        config["CHECK_FIRMWARE_NIGHTLIES"] = _coerce_bool(
-            check_nightlies_input,
-            default=check_nightlies_current,
-        )
-        if config["CHECK_FIRMWARE_NIGHTLIES"]:
-            nightly_keep = config.get(
-                "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP",
-                DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP,
-            )
-            parsed_keep = _parse_non_negative_int(nightly_keep)
-            if parsed_keep is None or parsed_keep < 1:
-                parsed_keep = DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP
-            config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = parsed_keep
+    # Firmware pre-release, nightly, and channel-suffix prompts now live in
+    # _setup_firmware so the firmware section is contiguous (see run_setup).
+    # This function only sets the download toggle and runs the asset menus;
+    # the firmware-disabled guard below still force-disables the related
+    # flags so stale values cannot survive a firmware-off choice.
 
     app_section_requested = not is_partial_run or wants("app")
 
@@ -1145,22 +1115,7 @@ def _setup_downloads(
     save_apks = save_client_apps
     save_desktop = _coerce_bool(config.get("SAVE_DESKTOP_APP", False))
 
-    # --- Channel Suffix Configuration ---
-    if save_firmware:
-        if not is_partial_run or wants("firmware"):
-            add_channel_suffixes_current = _coerce_bool(
-                config.get("ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES", True)
-            )
-            add_channel_suffixes_default = (
-                "yes" if add_channel_suffixes_current else "no"
-            )
-            add_channel_suffixes_input = _safe_input(
-                f"\nWould you like to add -alpha/-beta/-rc suffixes to release directories (e.g., v1.0.0-alpha)? [y/n] (default: {add_channel_suffixes_default}): ",
-                default=add_channel_suffixes_default,
-            )
-            config["ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES"] = _coerce_bool(
-                add_channel_suffixes_input
-            )
+    # Channel-suffix prompt has moved to _setup_firmware (contiguous firmware section).
 
     # If client app and firmware downloads are both disabled, inform the user and exit setup.
     # During partial runs that only update non-download sections (e.g. automation),
@@ -1312,6 +1267,22 @@ def _setup_firmware(
             - SELECTED_PRERELEASE_ASSETS: list of asset patterns selected for pre-release downloads
     """
 
+    # --- Stable Firmware Releases ---
+    print("\n--- Stable Firmware Releases ---")
+
+    # Channel suffix configuration (e.g., -alpha/-beta/-rc directory suffixes).
+    add_channel_suffixes_current = _coerce_bool(
+        config.get("ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES", True)
+    )
+    add_channel_suffixes_default = "yes" if add_channel_suffixes_current else "no"
+    add_channel_suffixes_input = _safe_input(
+        f"\nWould you like to add -alpha/-beta/-rc suffixes to release directories (e.g., v1.0.0-alpha)? [y/n] (default: {add_channel_suffixes_default}): ",
+        default=add_channel_suffixes_default,
+    )
+    config["ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES"] = _coerce_bool(
+        add_channel_suffixes_input
+    )
+
     # Prompt for firmware versions to keep
     current_versions = config.get("FIRMWARE_VERSIONS_TO_KEEP", default_versions)
     if is_first_run:
@@ -1350,6 +1321,9 @@ def _setup_firmware(
         config["KEEP_LAST_BETA"] = _coerce_bool(
             keep_last_beta_input, default=keep_last_beta_default_bool
         )
+
+    # --- Firmware Extraction ---
+    print("\n--- Firmware Extraction ---")
 
     # Prompt for automatic extraction
     auto_extract_current = _coerce_bool(config.get("AUTO_EXTRACT", False))
@@ -1459,8 +1433,15 @@ def _setup_firmware(
         config["EXTRACT_PATTERNS"] = []
         config["EXCLUDE_PATTERNS"] = []
 
-    # --- Pre-release Configuration ---
-    config["CHECK_PRERELEASES"] = _coerce_bool(config.get("CHECK_PRERELEASES", False))
+    # --- Firmware Prereleases ---
+    print("\n--- Firmware Prereleases ---")
+    check_prereleases_current = _coerce_bool(config.get("CHECK_PRERELEASES", False))
+    check_prereleases_default = "y" if check_prereleases_current else "n"
+    check_prereleases_input = _safe_input(
+        f"\nWould you like to check for and download pre-release firmware from meshtastic.github.io? [y/n] (default: {check_prereleases_default}): ",
+        default=check_prereleases_default,
+    )
+    config["CHECK_PRERELEASES"] = _coerce_bool(check_prereleases_input)
     if config["CHECK_PRERELEASES"]:
         # Use a copy to avoid aliasing EXTRACT_PATTERNS
         prerelease_patterns = list(config.get("EXTRACT_PATTERNS", []))
@@ -1481,6 +1462,50 @@ def _setup_firmware(
     else:
         # Prereleases disabled, clear the setting
         config["SELECTED_PRERELEASE_ASSETS"] = []
+
+    # --- Firmware Nightlies ---
+    print("\n--- Firmware Nightlies ---")
+    check_nightlies_current = _coerce_bool(
+        config.get("CHECK_FIRMWARE_NIGHTLIES", DEFAULT_CHECK_FIRMWARE_NIGHTLIES)
+    )
+    check_nightlies_default = "y" if check_nightlies_current else "n"
+    check_nightlies_input = _safe_input(
+        f"\nWould you like to check for and download rolling experimental firmware "
+        f"nightly builds? Upstream publishes these from the firmware develop branch "
+        f"through its scheduled nightly workflow and may also refresh them manually. "
+        f"Each publish replaces the rolling upstream contents, and Fetchtastic stores "
+        f"downloaded builds separately under firmware/nightlies/. "
+        f"[y/n] (default: {check_nightlies_default}): ",
+        default=check_nightlies_default,
+    )
+    config["CHECK_FIRMWARE_NIGHTLIES"] = _coerce_bool(
+        check_nightlies_input,
+        default=check_nightlies_current,
+    )
+    if config["CHECK_FIRMWARE_NIGHTLIES"]:
+        # Explicit retention prompt. Minimum 1; Enter preserves the current
+        # valid value; invalid/zero/negative preserves it with a warning.
+        # Disabling nightlies skips this block, so a previously stored valid
+        # preference is retained for a future enable.
+        nightly_keep_raw = config.get(
+            "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP",
+            DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP,
+        )
+        parsed_current = _parse_non_negative_int(nightly_keep_raw)
+        if parsed_current is None or parsed_current < 1:
+            parsed_current = DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP
+        nightly_input = _safe_input(
+            f"\nHow many firmware nightly builds would you like to keep? (current: {parsed_current}): ",
+            default=str(parsed_current),
+        ).strip()
+        parsed_keep = _parse_non_negative_int(nightly_input)
+        if parsed_keep is not None and parsed_keep >= 1:
+            config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = parsed_keep
+        elif not nightly_input:
+            config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = parsed_current
+        else:
+            print("Invalid value — keeping current value. " "Minimum is 1.")
+            config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] = parsed_current
 
     return config
 

--- a/tests/test_setup_config.py
+++ b/tests/test_setup_config.py
@@ -3195,6 +3195,27 @@ def test_setup_firmware_nightly_retention_negative_keeps_current(mocker):
 
 @pytest.mark.configuration
 @pytest.mark.unit
+def test_setup_firmware_nightly_retention_non_numeric_keeps_current_and_warns(
+    mocker, capsys
+):
+    """A non-numeric nightly-retention input preserves the current value and warns."""
+    _, fake_input, config = _make_setup_firmware_input_captor(
+        nightly_answer="y",
+        nightly_keep_answer="abc",
+        base_config={"FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 3},
+    )
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch("sys.stdin.isatty", return_value=False)
+
+    result = setup_config._setup_firmware(config, is_first_run=True, default_versions=2)
+
+    assert result["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 3
+    captured = capsys.readouterr()
+    assert "Invalid value — keeping current value. Minimum is 1." in captured.out
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
 def test_setup_firmware_nightly_retention_invalid_falls_back_to_default(mocker):
     """When the stored nightly-retention value is invalid, the prompt falls back to default."""
     captured, fake_input, config = _make_setup_firmware_input_captor(
@@ -3373,3 +3394,117 @@ def test_setup_downloads_firmware_disabled_forces_nightlies_off(mocker):
     assert (
         nightly_prompts == []
     ), f"Nightly prompt must not appear when firmware is disabled; got: {nightly_prompts}"
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_downloads_full_flow_firmware_section_contiguous(mocker):
+    """Full setup selecting both: firmware asset menu must come AFTER all
+    client-app prompts, so the firmware section is contiguous when
+    _setup_firmware runs next in run_setup."""
+    from fetchtastic.setup_config import _setup_downloads
+
+    events: list[tuple[str, str]] = []
+
+    def fake_input(prompt: str = "", **_kwargs: object) -> str:
+        lowered = prompt.lower()
+        if "client app assets, firmware, both, or none" in lowered:
+            events.append(("event", "download-choice"))
+            return "b"
+        if "how many versions of the client app" in lowered:
+            events.append(("event", "app-retention"))
+            return "2"
+        if "pre-release client app" in lowered:
+            events.append(("event", "app-prerelease"))
+            return "n"
+        if "snapshot debug builds" in lowered:
+            events.append(("event", "app-snapshot"))
+            return "n"
+        return "n"
+
+    def mock_app_menu():
+        events.append(("event", "app-menu"))
+        return {"selected_assets": ["meshtastic.apk"]}
+
+    def mock_firmware_menu():
+        events.append(("event", "firmware-menu"))
+        return {"selected_assets": ["rak4631-"]}
+
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch("fetchtastic.menu_app.run_menu", side_effect=mock_app_menu)
+    mocker.patch("fetchtastic.menu_firmware.run_menu", side_effect=mock_firmware_menu)
+
+    _setup_downloads({}, is_partial_run=False, wants=lambda _: True)
+
+    # Extract event labels in order.
+    labels = [label for _, label in events]
+    app_menu_idx = labels.index("app-menu")
+    fw_menu_idx = labels.index("firmware-menu")
+
+    # App menu before firmware menu.
+    assert (
+        app_menu_idx < fw_menu_idx
+    ), f"app-menu must precede firmware-menu; got: {labels}"
+
+    # All app-specific prompts must occur before firmware-menu.
+    for app_event in ("app-retention", "app-prerelease", "app-snapshot"):
+        idx = labels.index(app_event)
+        assert (
+            idx < fw_menu_idx
+        ), f"{app_event} must precede firmware-menu; got: {labels}"
+
+    # No app-specific event after firmware-menu.
+    app_events_after_fw = [
+        label
+        for i, label in enumerate(labels)
+        if i > fw_menu_idx and label.startswith("app-")
+    ]
+    assert (
+        app_events_after_fw == []
+    ), f"No app events after firmware-menu; got: {app_events_after_fw}"
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_downloads_empty_firmware_selection_disables_nightlies(mocker):
+    """Empty firmware asset selection must disable CHECK_FIRMWARE_NIGHTLIES
+    while preserving the retention preference."""
+    from fetchtastic.setup_config import _setup_downloads
+
+    config = {
+        "SAVE_FIRMWARE": True,
+        "SELECTED_FIRMWARE_ASSETS": ["rak4631-"],
+        "CHECK_PRERELEASES": True,
+        "SELECTED_PRERELEASE_ASSETS": ["rak4631-"],
+        "CHECK_FIRMWARE_NIGHTLIES": True,
+        "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 3,
+    }
+
+    def fake_input(prompt: str = "", **_kwargs: object) -> str:
+        lowered = prompt.lower()
+        if "both, or none" in lowered:
+            return "b"
+        return "n"
+
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch(
+        "fetchtastic.menu_app.run_menu",
+        return_value={"selected_assets": ["meshtastic.apk"]},
+    )
+    mocker.patch(
+        "fetchtastic.menu_firmware.run_menu",
+        return_value={"selected_assets": []},  # empty selection
+    )
+
+    result_config, _save_apks, save_firmware = _setup_downloads(
+        config, is_partial_run=False, wants=lambda _: True
+    )
+
+    assert save_firmware is False
+    assert result_config["SAVE_FIRMWARE"] is False
+    assert result_config["SELECTED_FIRMWARE_ASSETS"] == []
+    assert result_config["CHECK_PRERELEASES"] is False
+    assert result_config["SELECTED_PRERELEASE_ASSETS"] == []
+    assert result_config["CHECK_FIRMWARE_NIGHTLIES"] is False
+    # Retention preference preserved for future re-enable.
+    assert result_config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 3

--- a/tests/test_setup_config.py
+++ b/tests/test_setup_config.py
@@ -479,43 +479,26 @@ def test_setup_downloads_partial_skips_all_prompts(mocker):
 
 @pytest.mark.configuration
 @pytest.mark.unit
-def test_setup_downloads_full_run_prompts_channel_suffix(mocker):
-    """Full runs should prompt for channel suffixes when downloads are enabled."""
-    from fetchtastic.setup_config import _setup_downloads
-
+def test_setup_firmware_prompts_channel_suffix(mocker):
+    """Channel suffix prompting lives in _setup_firmware (contiguous firmware section)."""
     config = {}
 
-    def wants(_section: str) -> bool:
-        """
-        Indicates that any setup section should be included.
-
-        Parameters:
-            _section (str): Name of the setup section (ignored).
-
-        Returns:
-            bool: `True` for all sections.
-        """
-        return True
-
+    mocker.patch("sys.stdin.isatty", return_value=False)
     mocker.patch(
         "builtins.input",
-        side_effect=["", "2", "n", "n", "n", "n", "n"],
-    )
-    mocker.patch(
-        "fetchtastic.menu_firmware.run_menu",
-        return_value={"selected_assets": ["rak4631"]},
-    )
-    mocker.patch(
-        "fetchtastic.menu_app.run_menu",
-        return_value={"selected_assets": ["meshtastic.apk"]},
+        side_effect=[
+            "n",
+            "2",
+            "n",
+            "n",
+            "n",
+        ],  # suffix, versions, auto-extract, prerelease, nightly
     )
 
-    updated, save_apks, save_firmware = _setup_downloads(
-        config, is_partial_run=False, wants=wants
+    updated = setup_config._setup_firmware(
+        config, is_first_run=True, default_versions=2
     )
 
-    assert save_apks is True
-    assert save_firmware is True
     assert updated["ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES"] is False
 
 
@@ -1604,14 +1587,17 @@ def test_run_setup_first_run_linux_simple(
     user_inputs = [
         "",  # Use default base directory
         "b",  # Both APKs and firmware
-        "n",  # Check for firmware prereleases
-        "n",  # Check for firmware nightlies
-        "2",  # Keep 2 versions of client app (now in _setup_downloads)
+        # _setup_downloads: firmware prerelease/nightly/channel-suffix moved to _setup_firmware
+        "2",  # Keep 2 versions of client app
         "y",  # Check for APK prereleases
         "n",  # Check for app snapshots
+        # _setup_firmware (contiguous firmware section):
         "n",  # Add channel suffixes
         "2",  # Keep 2 versions of firmware
         "n",  # No auto-extract
+        "n",  # No firmware prereleases
+        "n",  # No firmware nightlies
+        # Automation/notification/github:
         "n",  # No cron job
         "n",  # No reboot cron job
         "n",  # No NTFY notifications
@@ -1693,14 +1679,17 @@ def test_run_setup_first_run_windows(
         "",  # Use default base directory
         "y",  # create menu
         "b",  # Both APKs and firmware
-        "n",  # Check for firmware prereleases
-        "n",  # Check for firmware nightlies
-        "2",  # Keep 2 versions of client app (now in _setup_downloads)
+        # _setup_downloads: firmware prerelease/nightly/channel-suffix moved to _setup_firmware
+        "2",  # Keep 2 versions of client app
         "y",  # Check for APK prereleases
         "n",  # Check for app snapshots
+        # _setup_firmware (contiguous firmware section):
         "n",  # Add channel suffixes
         "2",  # Keep 2 versions of firmware
         "n",  # No auto-extract
+        "n",  # No firmware prereleases
+        "n",  # No firmware nightlies
+        # Automation/notification/github:
         "y",  # create startup shortcut
         "n",  # No NTFY notifications
         "n",  # Would you like to set up a GitHub token now?
@@ -1789,14 +1778,17 @@ def test_run_setup_first_run_termux(  # noqa: ARG001
         "n",  # don't migrate to pipx (so setup continues)
         "",  # Use default base directory
         "b",  # Both APKs and firmware
-        "n",  # Check for firmware prereleases
-        "n",  # Check for firmware nightlies
-        "1",  # Keep 1 version of client app (now in _setup_downloads)
+        # _setup_downloads: firmware prerelease/nightly/channel-suffix moved to _setup_firmware
+        "1",  # Keep 1 version of client app
         "y",  # Check for APK prereleases
         "n",  # Check for app snapshots
+        # _setup_firmware (contiguous firmware section):
         "n",  # Add channel suffixes
         "1",  # Keep 1 version of firmware
         "n",  # No auto-extract
+        "n",  # No firmware prereleases
+        "n",  # No firmware nightlies
+        # Automation/notification/github:
         "y",  # wifi only
         "h",  # hourly cron job
         "y",  # boot script
@@ -1884,13 +1876,15 @@ def test_run_setup_existing_config(
         "",  # choose full setup at the new prompt
         "/new/base/dir",  # New base directory
         "f",  # Only firmware
-        "y",  # Check for pre-releases
-        "n",  # Check for firmware nightlies
+        # _setup_firmware (contiguous firmware section):
         "n",  # Add channel suffixes
         "5",  # Keep 5 versions of firmware
         "y",  # Auto-extract
         "rak4631- tbeam",  # Extraction patterns
         "y",  # Confirm extraction/exclude summary
+        "y",  # Firmware prereleases
+        "n",  # No firmware nightlies
+        # Automation/notification/github:
         "y",  # reconfigure cron
         "n",  # no cron job
         "n",  # no reboot cron
@@ -2002,12 +1996,14 @@ def test_run_setup_partial_firmware_section(
     mock_input.side_effect = [
         "y",  # Download firmware releases
         "y",  # Re-run firmware menu
-        "y",  # Check for firmware prereleases
-        "n",  # Check for firmware nightlies
+        # _setup_firmware (contiguous firmware section):
         "n",  # Add channel suffixes
         "3",  # Keep 3 versions of firmware
         "y",  # Auto-extract
         "esp32- rak4631-",  # Extraction patterns
+        "y",  # Confirm extraction
+        "y",  # Firmware prereleases
+        "n",  # No firmware nightlies
     ]
 
     with patch("builtins.open", mock_open()):
@@ -2308,8 +2304,8 @@ def test_setup_firmware_selected_prerelease_assets_new_config(mock_input):
     """Test setup wizard prompts for SELECTED_PRERELEASE_ASSETS with new configuration."""
     config = {"CHECK_PRERELEASES": True}
 
-    # Simulate user inputs: 3 versions, yes to auto-extract, device patterns
-    mock_input.side_effect = ["3", "y", "rak4631- tbeam", "y"]
+    # Inputs: channel suffix, versions, auto-extract, patterns, confirm, prerelease, nightly
+    mock_input.side_effect = ["n", "3", "y", "rak4631- tbeam", "y", "y", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         result = setup_config._setup_firmware(
@@ -2330,7 +2326,8 @@ def test_setup_firmware_keep_last_beta_non_interactive(mock_input):
     """Non-interactive runs should keep the existing KEEP_LAST_BETA setting."""
     config = {"KEEP_LAST_BETA": True}
 
-    mock_input.side_effect = ["2", "n"]
+    # Inputs: channel suffix, versions, auto-extract, prerelease, nightly
+    mock_input.side_effect = ["n", "2", "n", "n", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         result = setup_config._setup_firmware(
@@ -2338,7 +2335,6 @@ def test_setup_firmware_keep_last_beta_non_interactive(mock_input):
         )
 
     assert result["KEEP_LAST_BETA"] is True
-    assert mock_input.call_count == 2
 
 
 @pytest.mark.configuration
@@ -2348,7 +2344,8 @@ def test_setup_firmware_keep_last_beta_interactive(mock_input):
     """Interactive runs should prompt for KEEP_LAST_BETA."""
     config = {"KEEP_LAST_BETA": False}
 
-    mock_input.side_effect = ["2", "y", "n"]
+    # Inputs: channel suffix, versions, keep-beta, auto-extract, prerelease, nightly
+    mock_input.side_effect = ["n", "2", "y", "n", "n", "n"]
 
     with (
         patch("sys.stdin.isatty", return_value=True),
@@ -2368,7 +2365,8 @@ def test_setup_firmware_extraction_tips_only_when_enabled(mock_input, capsys):
     """Extraction tips should only appear when auto-extract is enabled."""
     config = {"CHECK_PRERELEASES": False}
 
-    mock_input.side_effect = ["2", "n"]
+    # Inputs: channel suffix, versions, auto-extract(off), prerelease, nightly
+    mock_input.side_effect = ["n", "2", "n", "n", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         setup_config._setup_firmware(config, is_first_run=True, default_versions=2)
@@ -2385,7 +2383,8 @@ def test_setup_firmware_extraction_tips_when_enabled(mock_input, capsys):
     """Extraction tips should appear after auto-extract is enabled."""
     config = {"CHECK_PRERELEASES": False}
 
-    mock_input.side_effect = ["2", "y", "", "y"]
+    # Inputs: suffix, versions, auto-extract, empty-patterns(disables), prerelease, nightly
+    mock_input.side_effect = ["n", "2", "y", "", "n", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         setup_config._setup_firmware(config, is_first_run=True, default_versions=2)
@@ -2407,8 +2406,8 @@ def test_setup_firmware_selected_prerelease_assets_migration_accept(mock_input):
         "AUTO_EXTRACT": True,
     }
 
-    # Simulate user inputs: keep 2 versions, keep auto-extract, keep current extraction patterns
-    mock_input.side_effect = ["2", "y", "y", "y"]
+    # Inputs: suffix, versions, auto-extract, keep-patterns, confirm, prerelease, nightly
+    mock_input.side_effect = ["n", "2", "y", "y", "y", "y", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         result = setup_config._setup_firmware(
@@ -2437,8 +2436,8 @@ def test_setup_firmware_selected_prerelease_assets_migration_decline(mock_input)
         "AUTO_EXTRACT": True,
     }
 
-    # Simulate user inputs: keep 2 versions, keep auto-extract, change extraction patterns, new patterns
-    mock_input.side_effect = ["2", "y", "n", "esp32- rak4631-", "y"]
+    # Inputs: suffix, versions, auto-extract, decline-patterns, new-patterns, confirm, prerelease, nightly
+    mock_input.side_effect = ["n", "2", "y", "n", "esp32- rak4631-", "y", "y", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         result = setup_config._setup_firmware(
@@ -2463,8 +2462,8 @@ def test_setup_firmware_selected_prerelease_assets_existing_keep(mock_input):
         "AUTO_EXTRACT": False,
     }
 
-    # Simulate user inputs: keep 3 versions, no auto-extract
-    mock_input.side_effect = ["3", "n"]
+    # Inputs: suffix, versions, auto-extract(off), prerelease, nightly
+    mock_input.side_effect = ["n", "3", "n", "y", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         result = setup_config._setup_firmware(
@@ -2488,8 +2487,8 @@ def test_setup_firmware_selected_prerelease_assets_existing_change(mock_input):
         "EXTRACT_PATTERNS": ["old-pattern"],
     }
 
-    # Simulate user inputs: keep 3 versions, keep auto-extract, don't keep patterns, new patterns
-    mock_input.side_effect = ["3", "y", "n", "new-pattern device-", "y"]
+    # Inputs: suffix, versions, auto-extract, decline-patterns, new-patterns, confirm, prerelease, nightly
+    mock_input.side_effect = ["n", "3", "y", "n", "new-pattern device-", "y", "y", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         result = setup_config._setup_firmware(
@@ -2514,8 +2513,8 @@ def test_setup_firmware_selected_prerelease_assets_disabled_prereleases(mock_inp
         "AUTO_EXTRACT": False,
     }
 
-    # Simulate user inputs: keep 2 versions, no auto-extract
-    mock_input.side_effect = ["2", "n"]
+    # Inputs: suffix, versions, auto-extract(off), prerelease(off), nightly
+    mock_input.side_effect = ["n", "2", "n", "n", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         result = setup_config._setup_firmware(
@@ -2534,8 +2533,8 @@ def test_setup_firmware_selected_prerelease_assets_empty_patterns(mock_input):
     """Test handling of empty prerelease asset patterns."""
     config = {"CHECK_PRERELEASES": True}
 
-    # Simulate user inputs: 2 versions, yes to auto-extract, empty patterns
-    mock_input.side_effect = ["2", "y", "", "y"]
+    # Inputs: suffix, versions, auto-extract, empty-patterns(disables), prerelease, nightly
+    mock_input.side_effect = ["n", "2", "y", "", "y", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         result = setup_config._setup_firmware(
@@ -2559,8 +2558,8 @@ def test_setup_firmware_selected_prerelease_assets_migration_empty_input(mock_in
         "AUTO_EXTRACT": False,
     }
 
-    # Simulate user inputs: keep 2 versions, yes to auto-extract, decline to keep patterns, empty input
-    mock_input.side_effect = ["2", "y", "n", "", "y"]
+    # Inputs: suffix, versions, auto-extract, decline-patterns, empty-input(disables), prerelease, nightly
+    mock_input.side_effect = ["n", "2", "y", "n", "", "y", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         result = setup_config._setup_firmware(
@@ -2583,7 +2582,8 @@ def test_setup_firmware_extract_patterns_string_config(mock_input):
         "EXTRACT_PATTERNS": "tbeam rak4631-",
     }
 
-    mock_input.side_effect = ["2", "y", "y", "y"]
+    # Inputs: suffix, versions, auto-extract, keep-patterns, confirm, prerelease, nightly
+    mock_input.side_effect = ["n", "2", "y", "y", "y", "y", "n"]
 
     with patch("sys.stdin.isatty", return_value=False):
         result = setup_config._setup_firmware(
@@ -2990,93 +2990,339 @@ def test_should_recommend_setup_attribute_error(mock_load_config):
 # ---------------------------------------------------------------------------
 # Firmware nightly (rolling) opt-in setup tests
 #
-# These tests cover the CHECK_FIRMWARE_NIGHTLIES and
-# FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP config keys that gate opt-in firmware
-# nightly downloads.  The nightly question runs after the firmware
-# prerelease prompt.
-# Defaults: CHECK_FIRMWARE_NIGHTLIES=False,
-# FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP=1.
+# These tests cover CHECK_FIRMWARE_NIGHTLIES and FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP.
+# The nightly toggle and retention prompt now live in _setup_firmware (after the
+# firmware extraction and prerelease sections), so _setup_downloads only carries
+# the firmware-disabled guard that force-disables nightlies.
+# Defaults: CHECK_FIRMWARE_NIGHTLIES=False, FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP=1.
 # ---------------------------------------------------------------------------
 
 
-def _make_firmware_only_input_captor(
+def _make_setup_firmware_input_captor(
     prerelease_answer: str = "n",
     nightly_answer: str = "n",
-) -> tuple[list[str], Callable[..., str]]:
-    """Return (captured_prompts, fake_input) for a firmware-only _setup_downloads run.
+    nightly_keep_answer: str = "",
+    suffix_answer: str = "n",
+    versions_answer: str = "2",
+    auto_extract_answer: str = "n",
+    base_config: dict | None = None,
+) -> tuple[list[str], Callable[..., str], dict]:
+    """Return (captured_prompts, fake_input, config) for a _setup_firmware run.
 
-    fake_input inspects the prompt text so it is robust to the nightly
-    question wording.  When the nightly prompt is absent the
-    ``nightly_answer`` is simply never consumed.
+    fake_input routes answers by prompt text so it is robust to wording.
+    Preceding prompts (channel suffix, versions, auto-extract) get sensible
+    defaults so the test can focus on the nightly/prerelease sections.
     """
 
     captured: list[str] = []
+    config: dict = dict(base_config) if base_config else {}
 
     def fake_input(prompt: str = "", **_kwargs: object) -> str:
         captured.append(prompt)
         lowered = prompt.lower()
 
-        # Download-type selection prompt
-        if "client app assets, firmware, both, or none" in lowered:
-            return "f"  # firmware only
+        # Channel suffix prompt
+        if "suffix" in lowered:
+            return suffix_answer
 
-        # Firmware prerelease prompt
+        # Firmware versions to keep
+        if "how many versions of the firmware" in lowered:
+            return versions_answer
+
+        # Auto-extract
+        if "automatically extract" in lowered:
+            return auto_extract_answer
+
+        # Pre-release firmware toggle
         if "pre-release firmware" in lowered:
             return prerelease_answer
 
-        # Firmware nightly prompt
+        # Nightly retention (only reached when nightlies enabled)
+        if "how many firmware nightly" in lowered:
+            return nightly_keep_answer
+
+        # Nightly toggle
         if "nightly" in lowered:
             return nightly_answer
 
-        # Channel suffix prompt
-        if "suffix" in lowered:
+        # Keep-last-beta (interactive only; non-interactive skips)
+        if "beta" in lowered:
             return "n"
 
-        # Versions-to-keep prompts
-        if "how many" in lowered and "version" in lowered:
-            return "2"
-
-        # Safe default for anything else
         return "n"
 
-    return captured, fake_input
+    return captured, fake_input, config
 
 
 @pytest.mark.configuration
 @pytest.mark.unit
-def test_setup_downloads_disables_firmware_nightlies_by_default(mocker):
-    """Default firmware setup must explicitly set CHECK_FIRMWARE_NIGHTLIES to False."""
-    from fetchtastic.setup_config import _setup_downloads
+def test_setup_firmware_nightly_prompt_no_inaccurate_claims(mocker):
+    """Nightly prompt must not claim 'every push' or 'firmware main'."""
+    captured, fake_input, config = _make_setup_firmware_input_captor()
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch("sys.stdin.isatty", return_value=False)
 
-    config: dict = {}
-    _captured, fake_input = _make_firmware_only_input_captor(
-        prerelease_answer="n", nightly_answer="n"
+    setup_config._setup_firmware(config, is_first_run=True, default_versions=2)
+
+    nightly_prompts = [p for p in captured if "nightly" in p.lower()]
+    assert nightly_prompts, f"Expected a nightly prompt; got: {captured}"
+    for prompt in nightly_prompts:
+        assert (
+            "every push" not in prompt.lower()
+        ), f"Nightly prompt must not claim 'every push'; got: {prompt}"
+        assert (
+            "firmware main" not in prompt.lower()
+        ), f"Nightly prompt must not reference 'firmware main'; got: {prompt}"
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_firmware_nightly_prompt_mentions_develop_and_scheduled(mocker):
+    """Nightly prompt must mention develop branch, scheduled publication, separate storage."""
+    captured, fake_input, config = _make_setup_firmware_input_captor()
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch("sys.stdin.isatty", return_value=False)
+
+    setup_config._setup_firmware(config, is_first_run=True, default_versions=2)
+
+    nightly_prompts = [
+        p for p in captured if "nightly" in p.lower() and "how many" not in p.lower()
+    ]
+    assert nightly_prompts, f"Expected a nightly toggle prompt; got: {captured}"
+    prompt_text = nightly_prompts[0].lower()
+    assert (
+        "develop" in prompt_text
+    ), f"Nightly prompt must mention develop branch; got: {nightly_prompts[0]}"
+    assert (
+        "scheduled" in prompt_text or "nightly workflow" in prompt_text
+    ), f"Nightly prompt must mention scheduled publication; got: {nightly_prompts[0]}"
+    assert (
+        "firmware/nightlies" in prompt_text
+    ), f"Nightly prompt must mention separate storage; got: {nightly_prompts[0]}"
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_firmware_nightly_yes_prompts_retention(mocker):
+    """Enabling nightlies must prompt for FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP."""
+    captured, fake_input, config = _make_setup_firmware_input_captor(
+        nightly_answer="y", nightly_keep_answer="3"
     )
     mocker.patch("builtins.input", side_effect=fake_input)
-    mocker.patch(
-        "fetchtastic.menu_firmware.run_menu",
-        return_value={"selected_assets": ["rak4631-"]},
-    )
+    mocker.patch("sys.stdin.isatty", return_value=False)
 
-    result_config, _save_apks, save_firmware = _setup_downloads(
-        config, is_partial_run=False, wants=lambda _: True
-    )
+    result = setup_config._setup_firmware(config, is_first_run=True, default_versions=2)
 
-    assert save_firmware is True
-    assert "CHECK_FIRMWARE_NIGHTLIES" in result_config
-    assert result_config["CHECK_FIRMWARE_NIGHTLIES"] is False
+    nightly_keep_prompts = [
+        p for p in captured if "how many firmware nightly" in p.lower()
+    ]
+    assert (
+        nightly_keep_prompts
+    ), f"Enabling nightlies must prompt for retention; got: {captured}"
+    assert result["CHECK_FIRMWARE_NIGHTLIES"] is True
+    assert result["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 3
 
 
 @pytest.mark.configuration
 @pytest.mark.unit
-def test_setup_downloads_nightly_prompt_shown_when_firmware_enabled(mocker):
-    """Fresh setup with firmware enabled must ask an experimental rolling-nightly question."""
+def test_setup_firmware_nightly_no_skips_retention(mocker):
+    """Disabling nightlies must skip the retention prompt entirely."""
+    captured, fake_input, config = _make_setup_firmware_input_captor(nightly_answer="n")
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch("sys.stdin.isatty", return_value=False)
+
+    result = setup_config._setup_firmware(config, is_first_run=True, default_versions=2)
+
+    nightly_keep_prompts = [
+        p for p in captured if "how many firmware nightly" in p.lower()
+    ]
+    assert (
+        nightly_keep_prompts == []
+    ), f"Disabling nightlies must not prompt for retention; got: {captured}"
+    assert result["CHECK_FIRMWARE_NIGHTLIES"] is False
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_firmware_nightly_retention_enter_preserves_current(mocker):
+    """Pressing Enter preserves the current valid nightly-retention value."""
+    _, fake_input, config = _make_setup_firmware_input_captor(
+        nightly_answer="y",
+        nightly_keep_answer="",  # Enter
+        base_config={"FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 5},
+    )
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch("sys.stdin.isatty", return_value=False)
+
+    result = setup_config._setup_firmware(config, is_first_run=True, default_versions=2)
+
+    assert result["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 5
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_firmware_nightly_retention_zero_keeps_current(mocker):
+    """A zero nightly-retention input preserves the current valid value."""
+    _, fake_input, config = _make_setup_firmware_input_captor(
+        nightly_answer="y",
+        nightly_keep_answer="0",
+        base_config={"FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 4},
+    )
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch("sys.stdin.isatty", return_value=False)
+
+    result = setup_config._setup_firmware(config, is_first_run=True, default_versions=2)
+
+    assert result["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 4
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_firmware_nightly_retention_negative_keeps_current(mocker):
+    """A negative nightly-retention input preserves the current valid value."""
+    _, fake_input, config = _make_setup_firmware_input_captor(
+        nightly_answer="y",
+        nightly_keep_answer="-1",
+        base_config={"FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 2},
+    )
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch("sys.stdin.isatty", return_value=False)
+
+    result = setup_config._setup_firmware(config, is_first_run=True, default_versions=2)
+
+    assert result["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 2
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_firmware_nightly_retention_invalid_falls_back_to_default(mocker):
+    """When the stored nightly-retention value is invalid, the prompt falls back to default."""
+    captured, fake_input, config = _make_setup_firmware_input_captor(
+        nightly_answer="y",
+        nightly_keep_answer="",  # Enter — should use the default fallback
+        base_config={"FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 0},  # invalid
+    )
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch("sys.stdin.isatty", return_value=False)
+
+    result = setup_config._setup_firmware(config, is_first_run=True, default_versions=2)
+
+    # Invalid stored value (0) falls back to DEFAULT_FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP (1).
+    assert result["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 1
+    # The prompt must show the fallback default as the current value.
+    nightly_keep_prompts = [
+        p for p in captured if "how many firmware nightly" in p.lower()
+    ]
+    assert nightly_keep_prompts
+    assert "current: 1" in nightly_keep_prompts[0]
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_firmware_nightly_disabled_preserves_retention_value(mocker):
+    """Disabling nightlies must not erase a previously valid retention preference."""
+    captured, fake_input, config = _make_setup_firmware_input_captor(
+        nightly_answer="n",  # disable
+        base_config={
+            "CHECK_FIRMWARE_NIGHTLIES": True,
+            "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 7,
+        },
+    )
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch("sys.stdin.isatty", return_value=False)
+
+    result = setup_config._setup_firmware(
+        config, is_first_run=False, default_versions=2
+    )
+
+    assert result["CHECK_FIRMWARE_NIGHTLIES"] is False
+    # The retention preference survives disabling.
+    assert result["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 7
+    # No retention prompt when disabled.
+    assert not any("how many firmware nightly" in p.lower() for p in captured)
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_firmware_question_order(mocker, capsys):
+    """Firmware questions must appear in the contiguous section order:
+    suffix → retention → (beta) → extraction → prerelease → nightly."""
+    captured: list[str] = []
+
+    def fake_input(prompt: str = "", **_kwargs: object) -> str:
+        captured.append(prompt)
+        lowered = prompt.lower()
+        if "suffix" in lowered:
+            return "n"
+        if "how many versions of the firmware" in lowered:
+            return "2"
+        if "beta" in lowered:
+            return "n"
+        if "automatically extract" in lowered:
+            return "n"
+        if "pre-release firmware" in lowered:
+            return "n"
+        if "nightly" in lowered and "how many" not in lowered:
+            return "n"
+        return "n"
+
+    mocker.patch("builtins.input", side_effect=fake_input)
+    mocker.patch("sys.stdin.isatty", return_value=False)
+
+    out = capsys.readouterr()
+    setup_config._setup_firmware({}, is_first_run=True, default_versions=2)
+    out = capsys.readouterr()
+
+    # Section headings must appear in this order.
+    headings = [
+        "--- Stable Firmware Releases ---",
+        "--- Firmware Extraction ---",
+        "--- Firmware Prereleases ---",
+        "--- Firmware Nightlies ---",
+    ]
+    positions = {h: out.out.index(h) for h in headings}
+    assert (
+        positions[headings[0]]
+        < positions[headings[1]]
+        < positions[headings[2]]
+        < positions[headings[3]]
+    ), f"Section headings out of order; positions: {positions}"
+
+    # Channel suffix prompt must precede the retention prompt.
+    suffix_idx = next(i for i, p in enumerate(captured) if "suffix" in p.lower())
+    versions_idx = next(
+        i for i, p in enumerate(captured) if "how many versions" in p.lower()
+    )
+    prerelease_idx = next(
+        i for i, p in enumerate(captured) if "pre-release firmware" in p.lower()
+    )
+    nightly_idx = next(
+        i
+        for i, p in enumerate(captured)
+        if "nightly" in p.lower() and "how many" not in p.lower()
+    )
+    assert suffix_idx < versions_idx < prerelease_idx < nightly_idx, (
+        f"Prompts out of order: suffix={suffix_idx}, versions={versions_idx}, "
+        f"prerelease={prerelease_idx}, nightly={nightly_idx}"
+    )
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_downloads_no_longer_prompts_nightly(mocker):
+    """_setup_downloads must NOT prompt for nightlies (moved to _setup_firmware)."""
     from fetchtastic.setup_config import _setup_downloads
 
     config: dict = {}
-    captured, fake_input = _make_firmware_only_input_captor(
-        prerelease_answer="n", nightly_answer="n"
-    )
+    captured: list[str] = []
+
+    def fake_input(prompt: str = "", **_kwargs: object) -> str:
+        captured.append(prompt)
+        lowered = prompt.lower()
+        if "client app assets, firmware, both, or none" in lowered:
+            return "f"
+        return "n"
+
     mocker.patch("builtins.input", side_effect=fake_input)
     mocker.patch(
         "fetchtastic.menu_firmware.run_menu",
@@ -3086,79 +3332,9 @@ def test_setup_downloads_nightly_prompt_shown_when_firmware_enabled(mocker):
     _setup_downloads(config, is_partial_run=False, wants=lambda _: True)
 
     nightly_prompts = [p for p in captured if "nightly" in p.lower()]
-    # A nightly opt-in prompt must appear during firmware setup.
     assert (
-        len(nightly_prompts) >= 1
-    ), f"Expected a firmware nightly prompt; captured prompts: {captured}"
-    # The prompt must signal experimental/rolling status clearly
-    assert any(
-        "experimental" in p.lower() or "rolling" in p.lower() for p in nightly_prompts
-    ), f"Nightly prompt must clearly label itself experimental; got: {nightly_prompts}"
-
-
-@pytest.mark.configuration
-@pytest.mark.unit
-def test_setup_downloads_nightly_yes_enables_flag_and_defaults_keep_count(mocker):
-    """Answering yes to the nightly prompt enables the flag and defaults keep-count to 1."""
-    from fetchtastic.setup_config import _setup_downloads
-
-    config: dict = {}
-    captured, fake_input = _make_firmware_only_input_captor(
-        prerelease_answer="n", nightly_answer="y"
-    )
-    mocker.patch("builtins.input", side_effect=fake_input)
-    mocker.patch(
-        "fetchtastic.menu_firmware.run_menu",
-        return_value={"selected_assets": ["rak4631-"]},
-    )
-
-    result_config, _save_apks, save_firmware = _setup_downloads(
-        config, is_partial_run=False, wants=lambda _: True
-    )
-
-    assert save_firmware is True
-    # Yes-answer must enable the nightly flag.
-    assert "CHECK_FIRMWARE_NIGHTLIES" in result_config
-    assert result_config["CHECK_FIRMWARE_NIGHTLIES"] is True
-
-    # Keep-count must default to 1 silently.
-    assert "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP" in result_config
-    assert result_config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 1
-
-    # Guard: no separate "how many nightly versions to keep" prompt
-    nightly_keep_prompts = [
-        p for p in captured if "nightly" in p.lower() and "how many" in p.lower()
-    ]
-    assert nightly_keep_prompts == [], (
-        "Nightly keep-count should default silently, not via a separate prompt; "
-        f"got: {nightly_keep_prompts}"
-    )
-
-
-@pytest.mark.configuration
-@pytest.mark.unit
-def test_setup_downloads_nightly_no_preserves_disabled(mocker):
-    """Answering no to the nightly prompt preserves CHECK_FIRMWARE_NIGHTLIES as False."""
-    from fetchtastic.setup_config import _setup_downloads
-
-    config: dict = {}
-    _captured, fake_input = _make_firmware_only_input_captor(
-        prerelease_answer="n", nightly_answer="n"
-    )
-    mocker.patch("builtins.input", side_effect=fake_input)
-    mocker.patch(
-        "fetchtastic.menu_firmware.run_menu",
-        return_value={"selected_assets": ["rak4631-"]},
-    )
-
-    result_config, _save_apks, save_firmware = _setup_downloads(
-        config, is_partial_run=False, wants=lambda _: True
-    )
-
-    assert save_firmware is True
-    # No-answer must leave nightlies disabled.
-    assert "CHECK_FIRMWARE_NIGHTLIES" in result_config
-    assert result_config["CHECK_FIRMWARE_NIGHTLIES"] is False
+        nightly_prompts == []
+    ), f"_setup_downloads must not prompt for nightlies; got: {nightly_prompts}"
 
 
 @pytest.mark.configuration
@@ -3173,7 +3349,6 @@ def test_setup_downloads_firmware_disabled_forces_nightlies_off(mocker):
     def fake_input(prompt: str = "", **_kwargs: object) -> str:
         captured.append(prompt)
         lowered = prompt.lower()
-        # Select client-app-only to disable firmware
         if "client app assets, firmware, both, or none" in lowered:
             return "a"
         if "how many" in lowered and "version" in lowered:
@@ -3191,11 +3366,9 @@ def test_setup_downloads_firmware_disabled_forces_nightlies_off(mocker):
     )
 
     assert save_firmware is False
-    # Firmware disabled must force nightlies off.
     assert "CHECK_FIRMWARE_NIGHTLIES" in result_config
     assert result_config["CHECK_FIRMWARE_NIGHTLIES"] is False
 
-    # Guard: no nightly prompt should appear when firmware is disabled
     nightly_prompts = [p for p in captured if "nightly" in p.lower()]
     assert (
         nightly_prompts == []

--- a/tests/test_setup_config_extended.py
+++ b/tests/test_setup_config_extended.py
@@ -467,8 +467,8 @@ def test_setup_downloads_partial_run(mocker):
             "y",  # Keep downloading client app releases
             "n",  # Skip re-running menu (existing selection kept)
             "2",  # Versions to keep
-            "y",  # Enable prereleases
-            "n",  # No channel suffixes
+            "y",  # Enable app prereleases (NOT firmware — this prompt is app-only)
+            "n",  # Disable snapshots (NOT channel suffixes — those are firmware-gated)
         ],
     )
 
@@ -582,32 +582,28 @@ def test_setup_downloads_partial_run_firmware_keep_existing_skips_menu(mocker):
 
 @pytest.mark.configuration
 @pytest.mark.unit
-def test_setup_downloads_partial_run_firmware_channel_suffix_config(mocker):
-    """Partial firmware run should persist channel suffix selection."""
+def test_setup_firmware_channel_suffix_config(mocker):
+    """_setup_firmware should persist channel suffix selection (moved from _setup_downloads)."""
+    from fetchtastic.setup_config import _setup_firmware
+
     config = {
-        "SAVE_APKS": False,
-        "SAVE_FIRMWARE": True,
-        "SELECTED_FIRMWARE_ASSETS": ["existing-firmware"],
         "ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES": True,
     }
 
     mocker.patch(
         "builtins.input",
         side_effect=[
-            "y",  # Download firmware releases
-            "n",  # Don't rerun menu
-            "n",  # Disable firmware prereleases
-            "n",  # Disable firmware nightlies
-            "n",  # Disable channel suffixes
+            "n",  # channel suffix — disable
+            "2",  # versions
+            "n",  # auto-extract no
+            "n",  # prerelease
+            "n",  # nightly
         ],
     )
+    mocker.patch("sys.stdin.isatty", return_value=False)
 
-    result_config, save_apks, save_firmware = setup_config._setup_downloads(
-        config, is_partial_run=True, wants=lambda section: section == "firmware"
-    )
+    result_config = _setup_firmware(config, is_first_run=False, default_versions=2)
 
-    assert save_apks is False
-    assert save_firmware is True
     assert result_config["ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES"] is False
 
 
@@ -1296,9 +1292,9 @@ def test_existing_config_without_nightly_keys_remains_unaffected(mocker, tmp_pat
 
 @pytest.mark.configuration
 @pytest.mark.unit
-def test_nightly_keep_count_not_prompted_separately(mocker):
-    """Enabling nightlies must not trigger a separate 'how many nightly versions' prompt."""
-    from fetchtastic.setup_config import _setup_downloads
+def test_nightly_keep_count_prompted_when_enabled(mocker):
+    """Enabling nightlies in _setup_firmware now prompts for the keep count."""
+    from fetchtastic.setup_config import _setup_firmware
 
     config: dict = {}
     captured: list[str] = []
@@ -1306,42 +1302,30 @@ def test_nightly_keep_count_not_prompted_separately(mocker):
     def fake_input(prompt: str = "", **_kwargs: object) -> str:
         captured.append(prompt)
         lowered = prompt.lower()
-
-        if "client app assets, firmware, both, or none" in lowered:
-            return "f"
-        if "pre-release firmware" in lowered:
-            return "n"
-        if "nightly" in lowered:
-            return "y"  # opt into nightlies
         if "suffix" in lowered:
             return "n"
-        if "how many" in lowered and "version" in lowered:
+        if "how many versions of the firmware" in lowered:
             return "2"
+        if "automatically extract" in lowered:
+            return "n"
+        if "pre-release firmware" in lowered:
+            return "n"
+        if "how many firmware nightly" in lowered:
+            return "5"
+        if "nightly" in lowered:
+            return "y"  # opt into nightlies
         return "n"
 
     mocker.patch("builtins.input", side_effect=fake_input)
-    mocker.patch(
-        "fetchtastic.menu_firmware.run_menu",
-        return_value={"selected_assets": ["rak4631-"]},
-    )
+    mocker.patch("sys.stdin.isatty", return_value=False)
 
-    result_config, _save_apks, save_firmware = _setup_downloads(
-        config, is_partial_run=False, wants=lambda _: True
-    )
+    result_config = _setup_firmware(config, is_first_run=True, default_versions=2)
 
-    assert save_firmware is True
-
-    # Keep-count must default silently to 1.
-    assert "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP" in result_config
-    assert result_config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 1
-
-    # Guard: no separate "how many nightly versions to keep" prompt.
-    # The keep-count must default silently (matching the snapshot precedent
-    # which does not prompt for APP_SNAPSHOT_VERSIONS_TO_KEEP).
+    # Retention prompt must appear and the value must be stored.
     nightly_keep_prompts = [
-        p for p in captured if "nightly" in p.lower() and "how many" in p.lower()
+        p for p in captured if "how many firmware nightly" in p.lower()
     ]
-    assert nightly_keep_prompts == [], (
-        "Nightly keep-count should default silently, not via a separate prompt; "
-        f"got: {nightly_keep_prompts}"
-    )
+    assert (
+        nightly_keep_prompts
+    ), f"Enabling nightlies must prompt for retention; got: {captured}"
+    assert result_config["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 5

--- a/tests/test_setup_config_uncovered.py
+++ b/tests/test_setup_config_uncovered.py
@@ -565,9 +565,12 @@ def test_setup_firmware_invalid_number_current_value(mocker, capsys):
     mocker.patch(
         "builtins.input",
         side_effect=[
+            "n",  # channel suffix
             "also_invalid",
-            "n",
-        ],  # User enters invalid, then no to auto-extract
+            "n",  # auto-extract no
+            "n",  # prerelease
+            "n",  # nightly
+        ],
     )
 
     result = _setup_firmware(config, is_first_run=False, default_versions=3)
@@ -593,11 +596,13 @@ def test_setup_firmware_extract_patterns_unexpected_type(mocker, capsys):
     mocker.patch(
         "builtins.input",
         side_effect=[
+            "n",  # channel suffix
             "2",
             "y",
             "",
-            "y",
-        ],  # versions, auto-extract yes, empty patterns, confirm
+            "n",  # prerelease
+            "n",  # nightly
+        ],
     )
 
     result = _setup_firmware(config, is_first_run=True, default_versions=2)
@@ -621,11 +626,13 @@ def test_setup_firmware_no_patterns_disables_auto_extract(mocker, capsys):
     mocker.patch(
         "builtins.input",
         side_effect=[
+            "n",  # channel suffix
             "2",
             "y",
             "",
-            "y",
-        ],  # versions, auto-extract yes, empty patterns, confirm
+            "n",  # prerelease
+            "n",  # nightly
+        ],
     )
 
     result = _setup_firmware(config, is_first_run=True, default_versions=2)
@@ -651,11 +658,14 @@ def test_setup_firmware_reconfigure_patterns(mocker):
     mocker.patch(
         "builtins.input",
         side_effect=[
+            "n",  # channel suffix
             "2",  # versions
             "y",  # auto-extract yes
             "n",  # don't keep current patterns
             "new-pattern",  # new patterns
             "y",  # confirm correct
+            "n",  # prerelease
+            "n",  # nightly
         ],
     )
 
@@ -679,7 +689,13 @@ def test_setup_firmware_auto_extract_off_clears_patterns(mocker):
 
     mocker.patch(
         "builtins.input",
-        side_effect=["2", "n"],  # versions, auto-extract no
+        side_effect=[
+            "n",
+            "2",
+            "n",
+            "n",
+            "n",
+        ],  # suffix, versions, auto-extract no, prerelease, nightly
     )
 
     result = _setup_firmware(config, is_first_run=True, default_versions=2)
@@ -702,7 +718,13 @@ def test_setup_firmware_no_auto_extract_no_exclude_patterns(mocker):
 
     mocker.patch(
         "builtins.input",
-        side_effect=["2", "n"],  # versions, auto-extract no
+        side_effect=[
+            "n",
+            "2",
+            "n",
+            "n",
+            "n",
+        ],  # suffix, versions, auto-extract no, prerelease, nightly
     )
 
     result = _setup_firmware(config, is_first_run=True, default_versions=2)
@@ -1254,18 +1276,21 @@ def test_run_setup_windows_cmd_environment(
                 "",  # Use default base directory
                 "n",  # Don't create menu shortcuts
                 "b",  # Both client apps and firmware
-                "n",  # No firmware prereleases
-                "n",  # No firmware nightlies
+                # _setup_downloads: firmware prerelease/nightly/channel-suffix moved to _setup_firmware
+                "n",  # Client app versions (invalid → keeps current)
                 "n",  # No client app prereleases
                 "n",  # No app snapshots
+                # _setup_firmware (contiguous firmware section):
                 "n",  # No channel suffixes
-                "2",  # Keep 2 versions
-                "2",  # Keep 2 versions
+                "2",  # Keep 2 versions of firmware
                 "n",  # No auto-extract
+                "n",  # No firmware prereleases
+                "n",  # No firmware nightlies
+                # Automation/notification/github:
                 "n",  # No Startup shortcut
                 "n",  # No NTFY
                 "n",  # No GitHub token
-                "",  # Press Enter to close (simulating the pause at end)
+                "",  # Press Enter to close
             ]
             mock_input.side_effect = user_inputs
 
@@ -1599,14 +1624,17 @@ def test_run_setup_version_package_not_found(
         user_inputs = [
             "",  # Use default base directory
             "b",  # Both client apps and firmware
-            "n",  # No firmware prereleases
-            "n",  # No firmware nightlies
+            # _setup_downloads: firmware prerelease/nightly/channel-suffix moved to _setup_firmware
+            "n",  # Client app versions (invalid → keeps current)
             "n",  # No client app prereleases
             "n",  # No app snapshots
+            # _setup_firmware (contiguous firmware section):
             "n",  # No channel suffixes
-            "2",  # Keep 2 versions
-            "2",  # Keep 2 versions firmware
+            "2",  # Keep 2 versions of firmware
             "n",  # No auto-extract
+            "n",  # No firmware prereleases
+            "n",  # No firmware nightlies
+            # Automation/notification/github:
             "n",  # No cron
             "n",  # No reboot
             "n",  # No NTFY
@@ -1685,14 +1713,17 @@ def test_run_setup_version_other_error(
         user_inputs = [
             "",  # Use default base directory
             "b",  # Both client apps and firmware
-            "n",  # No firmware prereleases
-            "n",  # No firmware nightlies
+            # _setup_downloads: firmware prerelease/nightly/channel-suffix moved to _setup_firmware
+            "n",  # Client app versions (invalid → keeps current)
             "n",  # No client app prereleases
             "n",  # No app snapshots
+            # _setup_firmware (contiguous firmware section):
             "n",  # No channel suffixes
-            "2",  # Keep 2 versions
-            "2",  # Keep 2 versions firmware
+            "2",  # Keep 2 versions of firmware
             "n",  # No auto-extract
+            "n",  # No firmware prereleases
+            "n",  # No firmware nightlies
+            # Automation/notification/github:
             "n",  # No cron
             "n",  # No reboot
             "n",  # No NTFY
@@ -1772,14 +1803,17 @@ def test_run_setup_config_dir_creation_error(
         user_inputs = [
             "",  # Use default base directory
             "b",  # Both client apps and firmware
-            "n",  # No firmware prereleases
-            "n",  # No firmware nightlies
+            # _setup_downloads: firmware prerelease/nightly/channel-suffix moved to _setup_firmware
+            "n",  # Client app versions (invalid → keeps current)
             "n",  # No client app prereleases
             "n",  # No app snapshots
+            # _setup_firmware (contiguous firmware section):
             "n",  # No channel suffixes
-            "2",  # Keep 2 versions
-            "2",  # Keep 2 versions firmware
+            "2",  # Keep 2 versions of firmware
             "n",  # No auto-extract
+            "n",  # No firmware prereleases
+            "n",  # No firmware nightlies
+            # Automation/notification/github:
             "n",  # No cron
             "n",  # No reboot
             "n",  # No NTFY

--- a/tests/test_setup_config_uncovered.py
+++ b/tests/test_setup_config_uncovered.py
@@ -460,6 +460,8 @@ def test_disable_asset_downloads_firmware_with_message():
         "SAVE_FIRMWARE": True,
         "SELECTED_FIRMWARE_ASSETS": ["test"],
         "CHECK_PRERELEASES": True,
+        "CHECK_FIRMWARE_NIGHTLIES": True,
+        "FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP": 3,
     }
 
     updated, result = _disable_asset_downloads(
@@ -469,6 +471,9 @@ def test_disable_asset_downloads_firmware_with_message():
     assert updated["SAVE_FIRMWARE"] is False
     assert updated["SELECTED_FIRMWARE_ASSETS"] == []
     assert updated["CHECK_PRERELEASES"] is False
+    assert updated["CHECK_FIRMWARE_NIGHTLIES"] is False
+    # Retention preference is preserved for a future re-enable.
+    assert updated["FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP"] == 3
     assert result is False
 
 


### PR DESCRIPTION
## Summary

This corrects the firmware-nightly description in the setup wizard and documentation, reorganizes the setup questions into a clearer app-first and firmware-contiguous flow, and adds an explicit retention prompt for downloaded firmware nightly builds.

## What changed

### Correct firmware-nightly wording

The setup wizard and documentation now accurately explain that upstream firmware nightlies:

* Are built from the firmware `develop` branch.
* Are published by the scheduled nightly workflow.
* May also be refreshed manually.
* Replace the contents of the rolling upstream `firmware-nightly/` source when published.
* Are stored separately by Fetchtastic under `firmware/nightlies/`.

The previous wording incorrectly described them as being rebuilt on every push to firmware `main`.

### Reorganize the setup flow

During a full setup, all client-app configuration now finishes before firmware asset selection begins.

The firmware portion then runs as one contiguous section:

1. Firmware asset selection.
2. Stable-release directory suffixes.
3. Stable-release retention.
4. Latest-beta retention.
5. Extraction and exclusion patterns.
6. Firmware prereleases.
7. Firmware nightlies.
8. Nightly retention.

Firmware-only partial setup retains the same contiguous firmware flow without presenting unrelated client-app questions.

### Add nightly retention configuration

When firmware nightlies are enabled, setup now asks how many nightly builds to retain.

The prompt:

* Uses `FIRMWARE_NIGHTLY_VERSIONS_TO_KEEP`.
* Requires a value of at least one.
* Preserves a valid current value when Enter is pressed.
* Preserves the current value after invalid input.
* Falls back to the default when the stored value is invalid.
* Is skipped when nightlies are disabled.

Disabling nightlies preserves the retention preference so it can be reused if nightlies are enabled later.

### Keep disabled firmware state consistent

Selecting no firmware assets now also disables `CHECK_FIRMWARE_NIGHTLIES`, along with the existing firmware and prerelease flags.

The stored nightly-retention preference is retained.

## Compatibility

No configuration keys were renamed or removed.

This does not change firmware downloading, nightly transactions, prerelease admission, cleanup, retries, tracking, notifications, or Android snapshot behavior.

## Testing

* 304 setup and configuration tests pass.
* 175 firmware-nightly regression tests pass.
* The complete 2,821-test suite passes.
* Ruff and Pyright pass.
* Git diff validation passes.
