### PR TITLE
Fix firmware prerelease reconciliation and clean up pointers

### DIFF
--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -97,6 +97,18 @@ _NIGHTLY_BUILD_ID_RX = re.compile(r"^\d+\.\d+\.\d+\.[a-f0-9]{6,}$", re.IGNORECAS
 _NIGHTLY_BUILD_TOKEN_RX = re.compile(r"(\d+\.\d+\.\d+\.[a-f0-9]{6,})", re.IGNORECASE)
 
 
+def _normalize_repo_directory_listing(raw: Any, *, source: str) -> list[str]:
+    """Return string directory names from a repository listing response."""
+    if not isinstance(raw, list):
+        logger.debug(
+            "Expected list of repo directories from %s, got %s",
+            source,
+            type(raw).__name__,
+        )
+        return []
+    return [directory for directory in raw if isinstance(directory, str)]
+
+
 def _resolve_extract_patterns(raw: Any) -> Optional[List[str]]:
     """Resolve an extraction-patterns config value, distinguishing
     absent/unsupported/malformed from explicitly empty.
@@ -2024,16 +2036,10 @@ class FirmwareReleaseDownloader(BaseDownloader):
                     github_token=self.config.get("GITHUB_TOKEN"),
                     allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
                 )
-                if not isinstance(dirs, list):
-                    logger.debug(
-                        "Expected list of repo directories from cache manager, got %s",
-                        type(dirs).__name__,
-                    )
-                    dirs = []
-                else:
-                    fallback_repo_dirs = [d for d in dirs if isinstance(d, str)]
+                dirs = _normalize_repo_directory_listing(dirs, source="cache manager")
+                fallback_repo_dirs = dirs
                 matches = prerelease_manager.scan_prerelease_directories(
-                    [d for d in dirs if isinstance(d, str)], clean_latest_release
+                    dirs, clean_latest_release
                 )
                 if matches:
                     # Choose newest by tuple then string
@@ -2075,24 +2081,69 @@ class FirmwareReleaseDownloader(BaseDownloader):
                         exc,
                     )
                     repo_dirs = []
-            if not isinstance(repo_dirs, list):
-                logger.debug(
-                    "Expected list of repo directories from cache manager, got %s",
-                    type(repo_dirs).__name__,
-                )
-                repo_dirs = []
+            repo_dirs = _normalize_repo_directory_listing(
+                repo_dirs, source="cache manager"
+            )
+            if repo_dirs:
+                repo_availability_verified = True
             else:
-                repo_dirs = [d for d in repo_dirs if isinstance(d, str)]
-                if repo_dirs:
-                    repo_availability_verified = True
-                else:
-                    logger.debug(
-                        "Repo availability scan returned no directories; "
-                        "cannot verify availability of history-derived prereleases"
-                    )
+                logger.debug(
+                    "Repo availability scan returned no usable directories; "
+                    "cannot verify availability of history-derived prereleases"
+                )
             deleted_dirs = self._get_deleted_prerelease_dirs_from_history(
                 history_entries
             )
+            if repo_availability_verified and not force_refresh:
+                history_active_dirs = [
+                    directory
+                    for directory in active_dirs
+                    if directory not in deleted_dirs
+                ]
+                cached_repo_dir_set = set(repo_dirs)
+                missing_history_dirs = [
+                    directory
+                    for directory in history_active_dirs
+                    if directory not in cached_repo_dir_set
+                ]
+                if missing_history_dirs:
+                    logger.debug(
+                        "History-derived prereleases are missing from the cached "
+                        "repository directory listing; refreshing availability before "
+                        "treating them as deleted: %s",
+                        ", ".join(missing_history_dirs),
+                    )
+                    try:
+                        refreshed_repo_dirs = self.cache_manager.get_repo_directories(
+                            "",
+                            force_refresh=True,
+                            github_token=self.config.get("GITHUB_TOKEN"),
+                            allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
+                        )
+                    except (
+                        requests.RequestException,
+                        OSError,
+                        ValueError,
+                        TypeError,
+                    ) as exc:
+                        logger.debug(
+                            "Fresh repo availability scan failed; preserving "
+                            "history-derived active prereleases: %s",
+                            exc,
+                        )
+                        refreshed_repo_dirs = []
+                    refreshed_repo_dirs = _normalize_repo_directory_listing(
+                        refreshed_repo_dirs, source="fresh availability scan"
+                    )
+                    if refreshed_repo_dirs:
+                        repo_dirs = refreshed_repo_dirs
+                    else:
+                        logger.debug(
+                            "Fresh repo availability scan returned no usable directories; "
+                            "preserving history-derived active prereleases"
+                        )
+                        repo_availability_verified = False
+
             if repo_availability_verified:
                 repo_dir_set = set(repo_dirs)
                 matching_repo_dirs = [
@@ -2738,6 +2789,9 @@ class FirmwareReleaseDownloader(BaseDownloader):
 
             cleaned_up = False
 
+            # Names left on disk after cleanup are the only valid targets for the
+            # managed prerelease/latest pointer. Removal failures remain valid targets.
+            valid_latest_target_names: set[str] = set()
             try:
                 # Check for matching pre-release directories
                 with os.scandir(prerelease_dir) as it:
@@ -2745,7 +2799,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
                         if entry.is_symlink():
                             if entry.name == LATEST_POINTER_NAME:
                                 logger.debug(
-                                    "Skipping expected symlink in prerelease folder: %s",
+                                    "Validating expected symlink in prerelease folder: %s",
                                     entry.name,
                                 )
                             else:
@@ -2782,9 +2836,17 @@ class FirmwareReleaseDownloader(BaseDownloader):
                                                 logger.error(
                                                     f"Error removing superseded prerelease {entry.name}: {e}"
                                                 )
+                                                valid_latest_target_names.add(
+                                                    entry.name
+                                                )
+                                        else:
+                                            valid_latest_target_names.add(entry.name)
 
                                     except ValueError:
                                         continue
+                self._cleanup_invalid_prerelease_latest_pointer(
+                    prerelease_dir, valid_latest_target_names
+                )
             except FileNotFoundError:
                 return False
 
@@ -2793,6 +2855,30 @@ class FirmwareReleaseDownloader(BaseDownloader):
         except (OSError, ValueError) as e:
             logger.error(f"Error cleaning up superseded prereleases: {e}")
             return False
+
+    def _cleanup_invalid_prerelease_latest_pointer(
+        self, base_dir: str, retained_names: set[str]
+    ) -> None:
+        """Remove a managed prerelease ``latest`` symlink when it is dangling or stale.
+
+        Non-symlink entries named ``latest`` are preserved. The symlink target must be
+        a retained prerelease directory name and must still exist as a directory.
+        """
+        link_path = os.path.join(base_dir, LATEST_POINTER_NAME)
+        if not os.path.islink(link_path):
+            return
+        try:
+            target = os.readlink(link_path)
+        except OSError:
+            remove_latest_pointer(base_dir)
+            return
+        target_name = os.path.basename(target.rstrip(os.sep))
+        if target != target_name or target_name not in retained_names:
+            remove_latest_pointer(base_dir)
+            return
+        target_path = os.path.join(base_dir, target_name)
+        if not os.path.isdir(target_path):
+            remove_latest_pointer(base_dir)
 
     # ==================================================================
     # Firmware-nightly: rolling build published at firmware-nightly/

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -189,6 +189,10 @@ class DownloadOrchestrator:
         # Single-run only: cleared after _log_prerelease_summary()
         self.firmware_prerelease_summary: Optional[Dict[str, Any]] = None
         self.latest_available_firmware_prerelease_dir: Optional[str] = None
+        # Run-scoped availability state. False means no availability-aware prerelease
+        # scan has completed yet; True means latest_available_firmware_prerelease_dir
+        # is authoritative for this run, including an explicit None (none available).
+        self.firmware_prerelease_availability_checked = False
         # Run-scoped nightly build-id: set after successful nightly processing.
         self.latest_firmware_nightly_build_id: Optional[str] = None
         # Run-scoped nightly transaction state. Reported outcomes are derived
@@ -241,6 +245,7 @@ class DownloadOrchestrator:
         start_time = time.time()
         self.wifi_skipped = False
         self.latest_available_firmware_prerelease_dir = None
+        self.firmware_prerelease_availability_checked = False
         self.latest_firmware_nightly_build_id = None
         self.nightly_run_state = NightlyRunState.UNCHECKED
         self._pending_nightly_build_id = None
@@ -874,6 +879,7 @@ class DownloadOrchestrator:
         # Reset the selected releases at the start of each run
         self.firmware_releases_selected = None
         self.latest_available_firmware_prerelease_dir = None
+        self.firmware_prerelease_availability_checked = False
 
         if not self.config.get("SAVE_FIRMWARE", False):
             logger.info("Firmware downloads are disabled in configuration")
@@ -1004,6 +1010,12 @@ class DownloadOrchestrator:
                     prerelease_summary,
                 ) = self.firmware_downloader.download_repo_prerelease_firmware(
                     latest_release.tag_name, force_refresh=False
+                )
+                self.firmware_prerelease_availability_checked = coerce_bool(
+                    self.config.get(
+                        "CHECK_FIRMWARE_PRERELEASES",
+                        self.config.get("CHECK_PRERELEASES", False),
+                    )
                 )
                 self.latest_available_firmware_prerelease_dir = active_dir
                 if prerelease_summary:
@@ -2551,16 +2563,20 @@ class DownloadOrchestrator:
 
         self.firmware_prerelease_summary = None
 
-        history_entries = (
-            summary.get("available_history_entries")
-            or summary.get("history_entries")
-            or []
-        )
+        if "available_history_entries" in summary:
+            history_entries = summary.get("available_history_entries") or []
+        else:
+            history_entries = summary.get("history_entries") or []
         clean_latest_release = summary.get("clean_latest_release")
         expected_version = summary.get("expected_version")
 
         if not history_entries:
-            logger.debug("Skipping prerelease summary: missing history_entries")
+            if "available_history_entries" in summary:
+                logger.debug(
+                    "Skipping prerelease summary: no verified available prereleases"
+                )
+            else:
+                logger.debug("Skipping prerelease summary: missing history_entries")
             return
         if not isinstance(clean_latest_release, str):
             logger.debug(
@@ -2971,7 +2987,11 @@ class DownloadOrchestrator:
         elif active_dir:
             firmware_prerelease = active_dir
 
-        if latest_firmware_release and firmware_prerelease is None:
+        if (
+            latest_firmware_release
+            and firmware_prerelease is None
+            and not self.firmware_prerelease_availability_checked
+        ):
             clean_latest_release, expected_version = (
                 self._derive_firmware_prerelease_admission_floor(
                     latest_firmware_release

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -22,7 +22,10 @@ from fetchtastic.constants import (
     RELEASE_SCAN_COUNT,
 )
 from fetchtastic.download.cache import CacheManager
-from fetchtastic.download.firmware import FirmwareReleaseDownloader
+from fetchtastic.download.firmware import (
+    FirmwareReleaseDownloader,
+    _normalize_repo_directory_listing,
+)
 from fetchtastic.download.interfaces import Asset, DownloadResult, Release
 from fetchtastic.download.version import VersionManager
 
@@ -4136,6 +4139,21 @@ class TestFirmwarePrereleaseBaselineDerivation:
 class TestPrereleaseAvailabilityVerification:
     """Tests for prerelease repo availability verification (force_refresh and fallback reuse)."""
 
+    def test_repo_directory_listing_normalization_filters_invalid_entries(self):
+        assert _normalize_repo_directory_listing(
+            ["firmware-2.8.0.aaaaaaa", None, 42], source="test"
+        ) == ["firmware-2.8.0.aaaaaaa"]
+
+    def test_repo_directory_listing_normalization_rejects_non_list(self):
+        with patch("fetchtastic.download.firmware.logger") as mock_logger:
+            assert (
+                _normalize_repo_directory_listing(
+                    {"name": "firmware-2.8.0.aaaaaaa"}, source="test"
+                )
+                == []
+            )
+        mock_logger.debug.assert_called_once()
+
     def test_second_scan_uses_force_refresh_false_by_default(
         self, downloader, tmp_path
     ):
@@ -4169,6 +4187,175 @@ class TestPrereleaseAvailabilityVerification:
         # Should call get_repo_directories once (availability scan) with force_refresh=False
         assert mock_get_dirs.call_count == 1
         assert mock_get_dirs.call_args[1].get("force_refresh") is False
+
+    def test_missing_history_dirs_force_refresh_before_pruning(
+        self, downloader, tmp_path
+    ):
+        """A cached root listing cannot veto newer commit-history prereleases."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+        active_dirs = [
+            "firmware-2.7.27.d250d89",
+            "firmware-2.8.0.b00d76f",
+            "firmware-2.8.0.8adc7c3",
+            "firmware-2.8.0.c800fc8",
+        ]
+        history_entries = [
+            {
+                "identifier": directory.removeprefix("firmware-"),
+                "directory": directory,
+                "status": "active",
+                "added_at": f"2026-08-01T0{index}:00:00Z",
+            }
+            for index, directory in enumerate(active_dirs)
+        ]
+
+        with (
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(active_dirs[-1], history_entries),
+            ),
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                side_effect=[["firmware-2.7.25.oldcache"], active_dirs],
+            ) as mock_get_dirs,
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ) as download_assets,
+        ):
+            result = downloader.download_repo_prerelease_firmware("v2.7.26.54e0d8d")
+
+        assert mock_get_dirs.call_count == 2
+        assert mock_get_dirs.call_args_list[0].kwargs["force_refresh"] is False
+        assert mock_get_dirs.call_args_list[1].kwargs["force_refresh"] is True
+        downloaded_dirs = [call.args[0] for call in download_assets.call_args_list]
+        assert set(downloaded_dirs) == set(active_dirs)
+        assert result[2] == active_dirs[-1]
+
+    def test_failed_fresh_availability_scan_preserves_history_dirs(
+        self, downloader, tmp_path
+    ):
+        """An inconclusive refresh fails open to fresh history instead of deleting candidates."""
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+        active_dir = "firmware-2.8.0.c800fc8"
+        history_entries = [
+            {
+                "identifier": "2.8.0.c800fc8",
+                "directory": active_dir,
+                "status": "active",
+                "added_at": "2026-08-01T04:00:00Z",
+            }
+        ]
+
+        with (
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(active_dir, history_entries),
+            ),
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                side_effect=[["firmware-2.7.25.oldcache"], []],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ) as download_assets,
+        ):
+            result = downloader.download_repo_prerelease_firmware("v2.7.26.54e0d8d")
+
+        download_assets.assert_called_once()
+        assert download_assets.call_args.args[0] == active_dir
+        assert result[2] == active_dir
+
+    @pytest.mark.parametrize(
+        "refresh_result",
+        [None, {"name": "firmware-2.8.0.c800fc8"}],
+    )
+    def test_invalid_fresh_availability_response_preserves_history_dirs(
+        self, downloader, tmp_path, refresh_result
+    ):
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+        active_dir = "firmware-2.8.0.c800fc8"
+        history_entries = [
+            {
+                "identifier": "2.8.0.c800fc8",
+                "directory": active_dir,
+                "status": "active",
+            }
+        ]
+
+        with (
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(active_dir, history_entries),
+            ),
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                side_effect=[["firmware-2.7.25.oldcache"], refresh_result],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ) as download_assets,
+            patch("fetchtastic.download.firmware.logger") as mock_logger,
+        ):
+            result = downloader.download_repo_prerelease_firmware("v2.7.26.54e0d8d")
+
+        download_assets.assert_called_once()
+        assert download_assets.call_args.args[0] == active_dir
+        assert result[2] == active_dir
+        assert any(
+            "preserving history-derived active prereleases" in call.args[0]
+            for call in mock_logger.debug.call_args_list
+            if call.args
+        )
+
+    def test_fresh_availability_exception_preserves_history_dirs(
+        self, downloader, tmp_path
+    ):
+        downloader.config["CHECK_FIRMWARE_PRERELEASES"] = True
+        downloader.download_dir = str(tmp_path)
+        active_dir = "firmware-2.8.0.c800fc8"
+        history_entries = [
+            {
+                "identifier": "2.8.0.c800fc8",
+                "directory": active_dir,
+                "status": "active",
+            }
+        ]
+
+        with (
+            patch(
+                "fetchtastic.download.firmware.PrereleaseHistoryManager.get_latest_active_prerelease_from_history",
+                return_value=(active_dir, history_entries),
+            ),
+            patch.object(
+                downloader.cache_manager,
+                "get_repo_directories",
+                side_effect=[
+                    ["firmware-2.7.25.oldcache"],
+                    requests.RequestException("temporary API failure"),
+                ],
+            ),
+            patch.object(
+                downloader,
+                "_download_prerelease_assets",
+                return_value=([], [], False),
+            ) as download_assets,
+        ):
+            result = downloader.download_repo_prerelease_firmware("v2.7.26.54e0d8d")
+
+        download_assets.assert_called_once()
+        assert result[2] == active_dir
 
     def test_second_scan_uses_force_refresh_true_when_requested(
         self, downloader, tmp_path
@@ -4713,10 +4900,10 @@ class TestPrereleaseAvailabilityVerification:
     # Tests for expected-symlink warning suppression in cleanup
     # =========================================================================
 
-    def test_cleanup_superseded_prereleases_silently_skips_latest_symlink(
+    def test_cleanup_superseded_prereleases_removes_dangling_latest_symlink(
         self, downloader, tmp_path
     ):
-        """The expected 'latest' symlink in prerelease folder should not produce a warning."""
+        """Removing a superseded prerelease also removes its now-dangling latest pointer."""
         downloader.download_dir = str(tmp_path)
         prerelease_dir = tmp_path / FIRMWARE_DIR_NAME / FIRMWARE_PRERELEASES_DIR_NAME
         prerelease_dir.mkdir(parents=True)
@@ -4725,28 +4912,136 @@ class TestPrereleaseAvailabilityVerification:
         old_prerelease.mkdir()
         latest_link = prerelease_dir / LATEST_POINTER_NAME
         try:
-            latest_link.symlink_to(old_prerelease, target_is_directory=True)
+            latest_link.symlink_to(old_prerelease.name, target_is_directory=True)
         except (OSError, NotImplementedError):
             pytest.skip("Symlinks not supported on this platform")
-        original_target = latest_link.readlink()
 
-        with (
-            patch.object(
-                downloader,
-                "_get_release_storage_tag",
-                return_value="v2.7.22",
-                create=True,
-            ),
-            patch.object(log_utils, "logger") as mock_logger,
-        ):
+        with patch.object(log_utils, "logger") as mock_logger:
             downloader.cleanup_superseded_prereleases("v2.7.22")
 
         assert not any(
             LATEST_POINTER_NAME in str(call)
             for call in mock_logger.warning.call_args_list
         )
+        assert not latest_link.is_symlink()
+        assert not latest_link.exists()
+
+    def test_cleanup_superseded_prereleases_preserves_latest_when_removal_fails(
+        self, downloader, tmp_path
+    ):
+        """A failed removal leaves the directory as a valid latest-pointer target."""
+        downloader.download_dir = str(tmp_path)
+        prerelease_dir = tmp_path / FIRMWARE_DIR_NAME / FIRMWARE_PRERELEASES_DIR_NAME
+        prerelease_dir.mkdir(parents=True)
+        retained = prerelease_dir / "firmware-2.7.20.aaaaaaa"
+        retained.mkdir()
+        latest_link = prerelease_dir / LATEST_POINTER_NAME
+        try:
+            latest_link.symlink_to(retained.name, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("Symlinks not supported on this platform")
+
+        with patch(
+            "fetchtastic.download.firmware.shutil.rmtree",
+            side_effect=OSError("busy"),
+        ):
+            cleaned = downloader.cleanup_superseded_prereleases("v2.7.22")
+
+        assert cleaned is False
+        assert retained.is_dir()
         assert latest_link.is_symlink()
-        assert latest_link.readlink() == original_target
+        assert latest_link.readlink().as_posix() == retained.name
+
+    def test_cleanup_superseded_prereleases_preserves_valid_latest_symlink(
+        self, downloader, tmp_path
+    ):
+        """A latest pointer to a retained prerelease remains intact."""
+        downloader.download_dir = str(tmp_path)
+        prerelease_dir = tmp_path / FIRMWARE_DIR_NAME / FIRMWARE_PRERELEASES_DIR_NAME
+        prerelease_dir.mkdir(parents=True)
+        retained = prerelease_dir / "firmware-2.8.0.aaaaaaa"
+        retained.mkdir()
+        latest_link = prerelease_dir / LATEST_POINTER_NAME
+        try:
+            latest_link.symlink_to(retained.name, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("Symlinks not supported on this platform")
+
+        downloader.cleanup_superseded_prereleases("v2.7.26")
+
+        assert latest_link.is_symlink()
+        assert latest_link.readlink().as_posix() == retained.name
+
+    def test_cleanup_invalid_prerelease_latest_pointer_preserves_regular_entry(
+        self, downloader, tmp_path
+    ):
+        latest_path = tmp_path / LATEST_POINTER_NAME
+        latest_path.mkdir()
+
+        downloader._cleanup_invalid_prerelease_latest_pointer(
+            str(tmp_path), {LATEST_POINTER_NAME}
+        )
+
+        assert latest_path.is_dir()
+        assert not latest_path.is_symlink()
+
+    def test_cleanup_invalid_prerelease_latest_pointer_removes_unsafe_target(
+        self, downloader, tmp_path
+    ):
+        retained = tmp_path / "firmware-2.8.0.aaaaaaa"
+        retained.mkdir()
+        latest_path = tmp_path / LATEST_POINTER_NAME
+        try:
+            latest_path.symlink_to(retained.resolve(), target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("Symlinks not supported on this platform")
+
+        downloader._cleanup_invalid_prerelease_latest_pointer(
+            str(tmp_path), {retained.name}
+        )
+
+        assert not latest_path.is_symlink()
+
+    def test_cleanup_invalid_prerelease_latest_pointer_removes_missing_target(
+        self, downloader, tmp_path
+    ):
+        latest_path = tmp_path / LATEST_POINTER_NAME
+        target_name = "firmware-2.8.0.missing"
+        try:
+            latest_path.symlink_to(target_name, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("Symlinks not supported on this platform")
+
+        downloader._cleanup_invalid_prerelease_latest_pointer(
+            str(tmp_path), {target_name}
+        )
+
+        assert not latest_path.is_symlink()
+
+    def test_cleanup_invalid_prerelease_latest_pointer_handles_readlink_error(
+        self, downloader, tmp_path
+    ):
+        latest_path = tmp_path / LATEST_POINTER_NAME
+        target = tmp_path / "firmware-2.8.0.aaaaaaa"
+        target.mkdir()
+        try:
+            latest_path.symlink_to(target.name, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("Symlinks not supported on this platform")
+
+        with (
+            patch(
+                "fetchtastic.download.firmware.os.readlink", side_effect=OSError("race")
+            ),
+            patch(
+                "fetchtastic.download.firmware.remove_latest_pointer"
+            ) as remove_pointer,
+        ):
+            downloader._cleanup_invalid_prerelease_latest_pointer(
+                str(tmp_path), {target.name}
+            )
+
+        remove_pointer.assert_called_once_with(str(tmp_path))
 
     # =========================================================================
     # Tests for summary/latest consistency (log_prerelease_summary chronology)

--- a/tests/test_download_orchestrator.py
+++ b/tests/test_download_orchestrator.py
@@ -443,6 +443,7 @@ class TestDownloadOrchestrator:
 
         orchestrator._process_firmware_downloads()
 
+        assert orchestrator.firmware_prerelease_availability_checked is True
         orchestrator.firmware_downloader.get_releases.assert_called_once()
         orchestrator.firmware_downloader.is_release_complete.assert_called_once_with(
             mock_release
@@ -2725,6 +2726,29 @@ class TestDownloadOrchestrator:
 
         orchestrator.firmware_downloader.log_prerelease_summary.assert_called_once()
 
+    def test_log_prerelease_summary_respects_verified_empty_availability(
+        self, orchestrator
+    ):
+        """Verified empty availability must not fall back to stale history entries."""
+        orchestrator.firmware_prerelease_summary = {
+            "history_entries": [
+                {
+                    "directory": "firmware-2.8.0.c800fc8",
+                    "identifier": "2.8.0.c800fc8",
+                    "status": "active",
+                }
+            ],
+            "available_history_entries": [],
+            "clean_latest_release": "v2.7.26.54e0d8d",
+            "expected_version": "2.7.27",
+        }
+        orchestrator.firmware_downloader.log_prerelease_summary = Mock()
+
+        orchestrator._log_prerelease_summary()
+
+        orchestrator.firmware_downloader.log_prerelease_summary.assert_not_called()
+        assert orchestrator.firmware_prerelease_summary is None
+
     def test_log_prerelease_summary_prefers_available_entries(self, orchestrator):
         """_log_prerelease_summary should omit missing active dirs after availability filtering."""
         available_entries = [{"directory": "firmware-2.7.23.7be5426"}]
@@ -2910,6 +2934,25 @@ class TestDownloadOrchestrator:
 
         assert versions["firmware_prerelease"] == "1.0.1.abcdef"
 
+    def test_get_latest_versions_respects_verified_no_prerelease(self, orchestrator):
+        """Verified no-prerelease state must suppress history fallback."""
+        orchestrator.android_releases = []
+        orchestrator.desktop_releases = []
+        orchestrator.latest_available_firmware_prerelease_dir = None
+        orchestrator.firmware_prerelease_availability_checked = True
+        orchestrator.firmware_downloader.get_latest_release_tag = Mock(
+            return_value="v2.7.26.54e0d8d"
+        )
+        history_lookup = (
+            orchestrator.prerelease_manager.get_latest_active_prerelease_from_history
+        )
+        history_lookup.return_value = ("firmware-2.8.0.c800fc8", [])
+
+        versions = orchestrator.get_latest_versions()
+
+        assert versions["firmware_prerelease"] is None
+        history_lookup.assert_not_called()
+
     def test_get_latest_versions_prefers_available_prerelease_dir(self, orchestrator):
         """Verified available prerelease dir should win over stale commit-history latest."""
         orchestrator.android_releases = []
@@ -2992,6 +3035,7 @@ class TestDownloadOrchestrator:
         """Stale pipeline state must be cleared at the start of a subsequent run."""
         orchestrator.wifi_skipped = True
         orchestrator.latest_available_firmware_prerelease_dir = "firmware-2.0.0.stale"
+        orchestrator.firmware_prerelease_availability_checked = True
         orchestrator._process_firmware_downloads = Mock()
         orchestrator._process_client_app_downloads = Mock()
         orchestrator._retry_failed_downloads = Mock()
@@ -3003,6 +3047,7 @@ class TestDownloadOrchestrator:
 
         assert orchestrator.wifi_skipped is False
         assert orchestrator.latest_available_firmware_prerelease_dir is None
+        assert orchestrator.firmware_prerelease_availability_checked is False
 
     def test_run_download_pipeline_wifi_only_not_connected(self, orchestrator):
         """Pipeline should skip when WIFI_ONLY and not connected."""


### PR DESCRIPTION
## Summary by Sourcery

Improve prerelease firmware reconciliation and cleanup of latest pointers to avoid deleting valid history entries or leaving stale symlinks.

Bug Fixes:
- Prevent cached repository listings from causing active history-derived prerelease builds to be incorrectly treated as deleted.
- Ensure failed fresh availability scans do not remove prerelease candidates discovered from history.
- Remove dangling or stale prerelease latest symlinks while preserving valid pointers to retained prereleases.

Enhancements:
- Add tracking of retained prerelease directories and a helper for validating and cleaning up the managed latest symlink.
- Extend prerelease download and cleanup tests to cover history reconciliation and latest pointer behaviors.