### PR TITLE
Refresh rolling firmware nightly source on every enabled check

### DIFF
--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -2832,9 +2832,12 @@ class FirmwareReleaseDownloader(BaseDownloader):
         """
         if not self._nightlies_enabled():
             return []
+        # firmware-nightly/ is a rolling directory that upstream replaces in place.
+        # A cached Contents response can therefore describe a superseded generation,
+        # so enabled nightly checks must read the live listing each run.
         contents = self.cache_manager.get_repo_contents(
             FIRMWARE_NIGHTLY_SOURCE_DIR,
-            force_refresh=False,
+            force_refresh=True,
             github_token=self.config.get("GITHUB_TOKEN"),
             allow_env_token=self.config.get("ALLOW_ENV_TOKEN", True),
         )

--- a/tests/test_firmware_nightlies.py
+++ b/tests/test_firmware_nightlies.py
@@ -333,8 +333,10 @@ def test_fetch_firmware_nightlies_queries_firmware_nightly_dir(
     fetch()
     mock_cache_manager.get_repo_contents.assert_called_once()
     call_args = mock_cache_manager.get_repo_contents.call_args
-    # The first positional arg must be the source directory name.
+    # The rolling upstream directory is replaced in place, so each enabled check
+    # must bypass the long-lived repository-contents cache.
     assert call_args.args[0] == source_dir
+    assert call_args.kwargs["force_refresh"] is True
 
 
 def test_listing_contains_release_manifest(downloader, mock_cache_manager):


### PR DESCRIPTION
## Summary by Sourcery

Always refresh the rolling firmware nightly source directory on each enabled check to avoid using stale cached listings.

Bug Fixes:
- Ensure firmware nightly checks bypass cached repository contents and always read the live rolling directory listing.

Tests:
- Extend firmware nightly downloader tests to assert that repository contents are fetched with force refresh enabled for the rolling nightly directory.