### PR TITLE
Remove firmware beta retention from client app prerelease cleanup

### DIFF
--- a/src/fetchtastic/download/client_app.py
+++ b/src/fetchtastic/download/client_app.py
@@ -1081,6 +1081,12 @@ class MeshtasticClientAppDownloader(BaseDownloader):
         keep_limit_override: int | None = None,
         keep_last_beta: bool = False,
     ) -> None:
+        """Remove client-app prereleases that are no longer retained.
+
+        ``keep_last_beta`` is deprecated compatibility input. ``KEEP_LAST_BETA``
+        controls firmware retention only and intentionally has no effect here.
+        """
+        del keep_last_beta
         if not cached_releases:
             return
         app_dir = os.path.join(self.download_dir, APP_DIR_NAME)
@@ -1133,23 +1139,6 @@ class MeshtasticClientAppDownloader(BaseDownloader):
 
         expected_stable = _safe_tags(stable_releases[:keep_limit], "release")
         expected_prerelease = _safe_tags(prerelease_releases, "prerelease")
-        if keep_last_beta:
-            latest_prerelease = next(
-                (
-                    release
-                    for release in sorted(
-                        cached_releases,
-                        key=lambda item: item.published_at or "",
-                        reverse=True,
-                    )
-                    if self._is_client_app_prerelease(release)
-                ),
-                None,
-            )
-            if latest_prerelease:
-                expected_prerelease.update(
-                    _safe_tags([latest_prerelease], "prerelease")
-                )
         self._remove_unexpected_entries(
             app_dir, expected_stable | {APK_PRERELEASES_DIR_NAME}
         )

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -2828,9 +2828,6 @@ class DownloadOrchestrator:
             app_cleanup_downloader.cleanup_old_versions(
                 app_keep,
                 cached_releases=cached_app_releases,
-                keep_last_beta=self.config.get(
-                    "KEEP_LAST_BETA", DEFAULT_KEEP_LAST_BETA
-                ),
             )
             if (
                 self.config.get("SAVE_DESKTOP_APP", False)

--- a/tests/test_download_orchestrator.py
+++ b/tests/test_download_orchestrator.py
@@ -691,7 +691,6 @@ class TestDownloadOrchestrator:
         mock_android.cleanup_old_versions.assert_called_once_with(
             2,
             cached_releases=orchestrator.android_releases,
-            keep_last_beta=False,
         )
         mock_firmware.cleanup_old_versions.assert_called_once()
 

--- a/tests/test_unified_storage_cleanup.py
+++ b/tests/test_unified_storage_cleanup.py
@@ -101,6 +101,36 @@ def test_stable_release_supersedes_matching_prerelease_dirs(tmp_path):
     assert next_expected.exists()
 
 
+def test_stable_release_removes_matching_prerelease_despite_firmware_beta_pref(
+    tmp_path,
+):
+    """Client cleanup is independent of the firmware-only KEEP_LAST_BETA preference."""
+    dl = _make_downloader(tmp_path)
+    prerelease_base = tmp_path / APP_DIR_NAME / "prerelease"
+    leftover = prerelease_base / "v3.1.0-open.5"
+    leftover.mkdir(parents=True)
+    (leftover / "androidApp-google-release.apk").write_bytes(b"apk")
+
+    dl.cleanup_old_versions(
+        keep_limit=1,
+        cached_releases=[
+            Release(
+                tag_name="v3.1.0",
+                prerelease=False,
+                published_at="2026-07-29T00:00:00Z",
+            ),
+            Release(
+                tag_name="v3.1.0-open.5",
+                prerelease=True,
+                published_at="2026-07-27T00:00:00Z",
+            ),
+        ],
+        keep_last_beta=True,
+    )
+
+    assert not leftover.exists()
+
+
 def test_unknown_non_version_entries_under_app_are_preserved(tmp_path):
     dl = _make_downloader(tmp_path)
     unknown_dir = tmp_path / APP_DIR_NAME / "manual-files"


### PR DESCRIPTION
## Summary by Sourcery

Ensure client app prerelease cleanup is independent of firmware beta retention settings and consistently removes superseded prerelease directories.

Bug Fixes:
- Prevent client app prerelease directories from being retained due to the firmware KEEP_LAST_BETA preference, ensuring superseded prereleases are cleaned up.

Enhancements:
- Simplify client app cleanup logic by removing keep_last_beta handling and aligning orchestrator calls and tests with the new behaviour.

Tests:
- Add a test verifying that a stable client app release removes leftover prerelease directories even when KEEP_LAST_BETA is enabled.
- Update orchestrator cleanup tests to reflect removal of keep_last_beta from client app cleanup calls.