### PR TITLE
Expose stale Android snapshot state and configure retention

### DIFF
--- a/src/fetchtastic/download/client_app.py
+++ b/src/fetchtastic/download/client_app.py
@@ -1877,6 +1877,21 @@ class MeshtasticClientAppDownloader(BaseDownloader):
                 error_type=error_type,
             )
 
+    def has_local_snapshot_builds(self) -> bool:
+        """Return whether the managed snapshot tree contains a valid snapshot build."""
+        base_dir = os.path.join(self.download_dir, APP_DIR_NAME, APP_SNAPSHOTS_DIR_NAME)
+        if not self._is_safe_managed_dir(base_dir):
+            return False
+        try:
+            with os.scandir(base_dir) as entries:
+                return any(
+                    entry.is_dir(follow_symlinks=False)
+                    and _parse_snapshot_vc_from_dirname(entry.name) is not None
+                    for entry in entries
+                )
+        except OSError:
+            return False
+
     def cleanup_superseded_snapshots(self) -> int:
         """Remove old snapshot dirs beyond the retention limit. Returns count deleted."""
         base_dir = os.path.join(self.download_dir, APP_DIR_NAME, APP_SNAPSHOTS_DIR_NAME)

--- a/src/fetchtastic/download/orchestrator.py
+++ b/src/fetchtastic/download/orchestrator.py
@@ -406,6 +406,18 @@ class DownloadOrchestrator:
                 return
 
             self.client_app_downloader.migrate_legacy_layout()
+            snapshots_enabled = coerce_bool(
+                self.config.get("CHECK_APP_SNAPSHOTS", False)
+            )
+            if (
+                not snapshots_enabled
+                and self.client_app_downloader.has_local_snapshot_builds()
+            ):
+                logger.info(
+                    "Android snapshot downloads are disabled; existing app/snapshots "
+                    "builds will not refresh. Run 'fetchtastic setup app' to enable them."
+                )
+
             logger.info("Scanning client app releases")
             app_releases = self._ensure_client_app_releases()
             if not app_releases:
@@ -575,7 +587,7 @@ class DownloadOrchestrator:
                 self.client_app_downloader.cleanup_superseded_snapshots()
 
             # --- Snapshot Debug Builds (rolling "snapshot" tag) ---
-            if coerce_bool(self.config.get("CHECK_APP_SNAPSHOTS", False)):
+            if snapshots_enabled:
                 logger.info("Checking for Android snapshot debug builds...")
                 snapshot_release = self.client_app_downloader.fetch_snapshot_release()
                 handled_snapshot = self.client_app_downloader.handle_snapshots(

--- a/src/fetchtastic/setup_config.py
+++ b/src/fetchtastic/setup_config.py
@@ -23,6 +23,7 @@ from fetchtastic.client_app_config import normalize_client_app_config
 from fetchtastic.constants import (
     CONFIG_FILE_NAME,
     CRON_COMMAND_TIMEOUT_SECONDS,
+    DEFAULT_APP_SNAPSHOT_VERSIONS_TO_KEEP,
     DEFAULT_APP_VERSIONS_TO_KEEP,
     DEFAULT_CHECK_APP_PRERELEASES,
     DEFAULT_CHECK_APP_SNAPSHOTS,
@@ -1205,15 +1206,30 @@ def _setup_downloads(
 def _setup_client_app(
     config: Dict[str, Any], _is_first_run: bool, default_versions: int
 ) -> Dict[str, Any]:
-    """
-    Normalize client app version retention.
-
-    The prompt is now handled in _setup_downloads. This function ensures the
-    config keys are consistent for backward compatibility.
-    """
+    """Normalize client-app retention and configure snapshot retention when enabled."""
     if "APP_VERSIONS_TO_KEEP" not in config:
         config["APP_VERSIONS_TO_KEEP"] = default_versions
-    return normalize_client_app_config(config)
+    normalize_client_app_config(config)
+
+    if _coerce_bool(config.get("CHECK_APP_SNAPSHOTS", DEFAULT_CHECK_APP_SNAPSHOTS)):
+        current_keep = int(
+            config.get(
+                "APP_SNAPSHOT_VERSIONS_TO_KEEP",
+                DEFAULT_APP_SNAPSHOT_VERSIONS_TO_KEEP,
+            )
+        )
+        snapshot_keep_input = _safe_input(
+            f"How many Android snapshot builds would you like to keep? "
+            f"(current: {current_keep}): ",
+            default=str(current_keep),
+        ).strip()
+        parsed_keep = _parse_non_negative_int(snapshot_keep_input)
+        if parsed_keep is not None and parsed_keep >= 1:
+            config["APP_SNAPSHOT_VERSIONS_TO_KEEP"] = parsed_keep
+        else:
+            print("Invalid value — keeping current value. Minimum is 1.")
+
+    return config
 
 
 def _setup_android(

--- a/tests/test_setup_config_extended.py
+++ b/tests/test_setup_config_extended.py
@@ -334,6 +334,92 @@ def test_setup_downloads_apk_snapshot_enabled(mocker):
 
 @pytest.mark.configuration
 @pytest.mark.unit
+def test_setup_client_app_prompts_for_snapshot_retention(monkeypatch):
+    config = {
+        "SAVE_CLIENT_APPS": True,
+        "SAVE_APKS": True,
+        "SELECTED_APP_ASSETS": ["androidApp-google-universal-debug-*.apk"],
+        "CHECK_APP_SNAPSHOTS": True,
+        "APP_SNAPSHOT_VERSIONS_TO_KEEP": 1,
+    }
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "3")
+
+    result = setup_config._setup_client_app(
+        config, _is_first_run=False, default_versions=3
+    )
+
+    assert result["APP_SNAPSHOT_VERSIONS_TO_KEEP"] == 3
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+@pytest.mark.parametrize("existing_value", [None, 0, -2, "not-a-number"])
+def test_setup_client_app_normalizes_invalid_existing_snapshot_retention(
+    monkeypatch, existing_value
+):
+    config = {
+        "SAVE_CLIENT_APPS": True,
+        "SAVE_APKS": True,
+        "SELECTED_APP_ASSETS": ["androidApp-google-universal-debug-*.apk"],
+        "CHECK_APP_SNAPSHOTS": True,
+        "APP_SNAPSHOT_VERSIONS_TO_KEEP": existing_value,
+    }
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+
+    result = setup_config._setup_client_app(
+        config, _is_first_run=False, default_versions=3
+    )
+
+    assert result["APP_SNAPSHOT_VERSIONS_TO_KEEP"] == 1
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+@pytest.mark.parametrize("entered_value", ["0", "-1", "not-a-number"])
+def test_setup_client_app_rejects_invalid_snapshot_retention_input(
+    monkeypatch, capsys, entered_value
+):
+    config = {
+        "SAVE_CLIENT_APPS": True,
+        "SAVE_APKS": True,
+        "SELECTED_APP_ASSETS": ["androidApp-google-universal-debug-*.apk"],
+        "CHECK_APP_SNAPSHOTS": True,
+        "APP_SNAPSHOT_VERSIONS_TO_KEEP": 4,
+    }
+    monkeypatch.setattr("builtins.input", lambda _prompt="": entered_value)
+
+    result = setup_config._setup_client_app(
+        config, _is_first_run=False, default_versions=3
+    )
+
+    assert result["APP_SNAPSHOT_VERSIONS_TO_KEEP"] == 4
+    assert "Invalid value" in capsys.readouterr().out
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
+def test_setup_client_app_preserves_snapshot_retention_when_disabled(monkeypatch):
+    config = {
+        "SAVE_CLIENT_APPS": True,
+        "SAVE_APKS": True,
+        "SELECTED_APP_ASSETS": ["androidApp-google-release.apk"],
+        "CHECK_APP_SNAPSHOTS": False,
+        "APP_SNAPSHOT_VERSIONS_TO_KEEP": 4,
+    }
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": (_ for _ in ()).throw(AssertionError("unexpected prompt")),
+    )
+
+    result = setup_config._setup_client_app(
+        config, _is_first_run=False, default_versions=3
+    )
+
+    assert result["APP_SNAPSHOT_VERSIONS_TO_KEEP"] == 4
+
+
+@pytest.mark.configuration
+@pytest.mark.unit
 def test_setup_downloads_desktop_no_snapshot_prompt(mocker):
     """Desktop-only client app selection must not trigger a snapshot prompt."""
     config = {}

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 
 from fetchtastic.client_app_config import normalize_client_app_config
 from fetchtastic.constants import (
@@ -1109,6 +1110,101 @@ def test_orch_snapshot_disabled_skips_entirely(tmp_path, cache_manager):
     orch.client_app_downloader.fetch_snapshot_release = Mock(return_value=None)
     orch._process_client_app_downloads()
     orch.client_app_downloader.fetch_snapshot_release.assert_not_called()
+
+
+@pytest.mark.integration
+def test_orch_snapshot_disabled_reports_existing_snapshot_state_before_empty_release_return(
+    tmp_path,
+):
+    """Existing snapshots are reported even when client release discovery is empty."""
+    orch = _make_orchestrator_for_snapshots(tmp_path, CHECK_APP_SNAPSHOTS=False)
+    snapshot_dir = (
+        Path(orch.client_app_downloader.download_dir)
+        / APP_DIR_NAME
+        / APP_SNAPSHOTS_DIR_NAME
+        / "20260711-030352-29321457"
+    )
+    snapshot_dir.mkdir(parents=True)
+    orch._ensure_client_app_releases = Mock(return_value=[])
+    orch.client_app_downloader.fetch_snapshot_release = Mock(return_value=None)
+
+    with patch("fetchtastic.download.orchestrator.logger") as mock_logger:
+        orch._process_client_app_downloads()
+
+    orch.client_app_downloader.fetch_snapshot_release.assert_not_called()
+    assert any(
+        "snapshot downloads are disabled" in call.args[0].lower()
+        for call in mock_logger.info.call_args_list
+        if call.args
+    )
+
+
+@pytest.mark.integration
+def test_orch_snapshot_disabled_reports_existing_snapshot_state_before_release_error(
+    tmp_path,
+):
+    """Existing snapshots are reported even when client release discovery fails."""
+    orch = _make_orchestrator_for_snapshots(tmp_path, CHECK_APP_SNAPSHOTS=False)
+    snapshot_dir = (
+        Path(orch.client_app_downloader.download_dir)
+        / APP_DIR_NAME
+        / APP_SNAPSHOTS_DIR_NAME
+        / "29321457"
+    )
+    snapshot_dir.mkdir(parents=True)
+    orch._ensure_client_app_releases = Mock(
+        side_effect=requests.RequestException("release API unavailable")
+    )
+
+    with patch("fetchtastic.download.orchestrator.logger") as mock_logger:
+        orch._process_client_app_downloads()
+
+    assert any(
+        "snapshot downloads are disabled" in call.args[0].lower()
+        for call in mock_logger.info.call_args_list
+        if call.args
+    )
+    mock_logger.error.assert_called_once()
+
+
+@pytest.mark.integration
+def test_orch_snapshot_disabled_ignores_unmanaged_child_directories(tmp_path):
+    """Unrelated directories under app/snapshots do not trigger stale-state warnings."""
+    orch = _make_orchestrator_for_snapshots(tmp_path, CHECK_APP_SNAPSHOTS=False)
+    snapshot_root = (
+        Path(orch.client_app_downloader.download_dir)
+        / APP_DIR_NAME
+        / APP_SNAPSHOTS_DIR_NAME
+    )
+    (snapshot_root / "partial-download").mkdir(parents=True)
+    orch._ensure_client_app_releases = Mock(return_value=[])
+
+    with patch("fetchtastic.download.orchestrator.logger") as mock_logger:
+        orch._process_client_app_downloads()
+
+    assert not any(
+        "snapshot downloads are disabled" in call.args[0].lower()
+        for call in mock_logger.info.call_args_list
+        if call.args
+    )
+
+
+@pytest.mark.unit
+def test_has_local_snapshot_builds_without_snapshot_directory_returns_false(downloader):
+    assert downloader.has_local_snapshot_builds() is False
+
+
+@pytest.mark.unit
+def test_has_local_snapshot_builds_handles_scan_error(downloader, tmp_path):
+    snapshot_root = (
+        Path(downloader.download_dir) / APP_DIR_NAME / APP_SNAPSHOTS_DIR_NAME
+    )
+    snapshot_root.mkdir(parents=True)
+
+    with patch(
+        "fetchtastic.download.client_app.os.scandir", side_effect=OSError("race")
+    ):
+        assert downloader.has_local_snapshot_builds() is False
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary by Sourcery

Configure Android snapshot retention during client app setup and surface stale local snapshot state when snapshot checks are disabled.

New Features:
- Prompt for Android snapshot build retention when snapshot checks are enabled and store the selected value in configuration.
- Log when Android snapshot downloads are disabled but existing local snapshot builds are present so users can re-enable checks if desired.

Tests:
- Add unit tests for client app setup to cover snapshot retention prompting and preservation when checks are disabled.
- Add integration test ensuring orchestrator reports existing snapshot state when snapshot downloads are disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change exposes stale Android snapshot state and adds configurable snapshot retention. It also adds coverage for enabled and disabled snapshot workflows.

- **Features**
  - When snapshot checks are disabled, the orchestrator detects existing local snapshot directories.
  - The orchestrator logs that existing snapshots will not be refreshed and provides setup guidance.
  - Client-app setup prompts for the number of snapshot versions to retain when snapshot downloads are enabled.
  - Retention values must keep at least one build.
  - Invalid retention input uses the default value.

- **Fixes**
  - Disabled snapshot downloads no longer trigger release fetching for existing snapshots.
  - Existing retention settings remain unchanged when snapshot downloads are disabled.

- **Refactors**
  - Client-app configuration is normalized before snapshot settings are applied.
  - Added tests for snapshot retention and disabled snapshot checks.

No breaking changes or migration steps are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->