### PR TITLE
Bump version to 0.11.3 and update linter dependencies

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -19,24 +19,24 @@ runtimes:
 lint:
   enabled:
     - pinact@4.1.1
-    - grype@0.116.1
-    - renovate@44.7.1
+    - grype@0.118.0
+    - renovate@44.69.11
     - shellcheck@0.11.0
-    - shfmt@3.13.1
+    - shfmt@3.14.1
     - gitleaks@8.30.1
     - codespell@2.4.3
     - actionlint@1.7.12
     - bandit@1.9.4
     - black@26.5.1
-    - checkov@3.3.9
+    - checkov@3.3.16
     - git-diff-check
-    - isort@8.0.1
+    - isort@9.0.1
     - markdownlint@0.49.1
     - osv-scanner@2.4.0
     - prettier@3.9.6
-    - ruff@0.16.1
+    - ruff@0.16.6
     - taplo@0.10.0
-    - trufflehog@3.95.9
+    - trufflehog@3.97.4
     - yamllint@1.38.0
 actions:
   disabled:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fetchtastic"
-version = "0.11.2"
+version = "0.11.3"
 authors = [{ name = "Jeremiah K", email = "jeremiahk@gmx.com" }]
 description = "Meshtastic Firmware and APK Downloader"
 readme = "README.md"

--- a/src/fetchtastic/cli.py
+++ b/src/fetchtastic/cli.py
@@ -33,9 +33,7 @@ from fetchtastic.utils import (
     display_banner,
 )
 from fetchtastic.utils import get_api_request_summary as _get_api_request_summary
-from fetchtastic.utils import (
-    reset_api_tracking,
-)
+from fetchtastic.utils import reset_api_tracking
 
 get_api_request_summary = _get_api_request_summary
 

--- a/src/fetchtastic/download/cache.py
+++ b/src/fetchtastic/download/cache.py
@@ -511,9 +511,7 @@ class CacheManager:
             )
             return []
 
-    def get_nightly_index(
-        self, *, force_refresh: bool = False
-    ) -> dict[str, Any]:
+    def get_nightly_index(self, *, force_refresh: bool = False) -> dict[str, Any]:
         """
         Fetch and parse nightly.meshtastic.org/index.json.
 
@@ -595,9 +593,7 @@ class CacheManager:
         Raises:
             ValueError: If ``target_id`` is not a valid nightly target id.
         """
-        if not isinstance(target_id, str) or not _NIGHTLY_TARGET_ID_RX.match(
-            target_id
-        ):
+        if not isinstance(target_id, str) or not _NIGHTLY_TARGET_ID_RX.match(target_id):
             raise ValueError(f"Unsafe nightly target id: {target_id!r}")
         return self._fetch_nightly_json(
             f"{FIRMWARE_NIGHTLY_BASE_URL}/firmware-{target_id}.mt.json",
@@ -649,7 +645,9 @@ class CacheManager:
         # caller's failure semantics are correct.
         captured: list[BaseException] = []
 
-        def fetcher() -> Any:  # Any: returns dict[str, Any] on success, [] on transport failure
+        def fetcher() -> (
+            Any
+        ):  # Any: returns dict[str, Any] on success, [] on transport failure
             try:
                 return self._http_get_json_with_retry(
                     url,
@@ -739,6 +737,7 @@ class CacheManager:
         across the release's many target-manifest requests. When no session is
         supplied, this helper owns a short-lived session and closes it on exit.
         """
+
         def request_json(active_session: requests.Session) -> dict[str, Any]:
             attempt = 0
             delay = DEFAULT_BACKOFF_FACTOR

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -44,7 +44,6 @@ from fetchtastic.constants import (
     FIRMWARE_NIGHTLY_HELPER_BASE_URL,
     FIRMWARE_NIGHTLY_HELPER_SCRIPTS,
     FIRMWARE_NIGHTLY_MANIFEST_PATTERN,
-    FIRMWARE_NIGHTLY_SOURCE_DIR,
     FIRMWARE_PRERELEASES_DIR_NAME,
     FIRMWARE_RELEASE_HISTORY_JSON_FILE,
     LATEST_FIRMWARE_NIGHTLY_JSON_FILE,
@@ -2975,9 +2974,9 @@ class FirmwareReleaseDownloader(BaseDownloader):
         # build still works.
         commit = index.get("commit")
         commit_pinned = (
-            isinstance(commit, str) and bool(commit) and all(
-                c in "0123456789abcdef" for c in commit.lower()
-            )
+            isinstance(commit, str)
+            and bool(commit)
+            and all(c in "0123456789abcdef" for c in commit.lower())
             and len(commit) >= 7
         )
 
@@ -2985,9 +2984,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
             version, force_refresh=True
         )
         if not isinstance(release, dict) or not release:
-            raise ValueError(
-                f"firmware-nightly release manifest missing for {version}"
-            )
+            raise ValueError(f"firmware-nightly release manifest missing for {version}")
         targets = release.get("targets")
         if not isinstance(targets, list) or not targets:
             raise ValueError(
@@ -3697,9 +3694,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
             try:
                 hasher = hashlib.md5(usedforsecurity=False)
                 with open(target_path, "rb") as md5_file:
-                    for chunk in iter(
-                        lambda: md5_file.read(DEFAULT_CHUNK_SIZE), b""
-                    ):
+                    for chunk in iter(lambda: md5_file.read(DEFAULT_CHUNK_SIZE), b""):
                         hasher.update(chunk)
                 actual_md5 = hasher.hexdigest()
             except OSError as exc:

--- a/tests/test_cache_nightly.py
+++ b/tests/test_cache_nightly.py
@@ -78,14 +78,18 @@ def _enqueue(mocker, *responses) -> None:
     )
 
 
-def _cache(monkeypatch, tmp_path, base_url: str = "https://nightly.meshtastic.org") -> CacheManager:
+def _cache(
+    monkeypatch, tmp_path, base_url: str = "https://nightly.meshtastic.org"
+) -> CacheManager:
     return CacheManager(cache_dir=str(tmp_path))
 
 
 # ---------- happy path ----------
 
 
-def test_get_nightly_index_returns_parsed_payload(mocker, monkeypatch, tmp_path) -> None:
+def test_get_nightly_index_returns_parsed_payload(
+    mocker, monkeypatch, tmp_path
+) -> None:
     _enqueue(mocker, _FakeResponse(200, INDEX_BODY))
     cm = _cache(monkeypatch, tmp_path)
     out = cm.get_nightly_index(force_refresh=True)
@@ -249,7 +253,9 @@ def test_get_nightly_index_uses_cache_within_ttl(mocker, monkeypatch, tmp_path) 
     assert second == INDEX_BODY
 
 
-def test_get_nightly_index_force_refresh_re_reads(mocker, monkeypatch, tmp_path) -> None:
+def test_get_nightly_index_force_refresh_re_reads(
+    mocker, monkeypatch, tmp_path
+) -> None:
     _enqueue(
         mocker,
         _FakeResponse(200, INDEX_BODY),
@@ -288,9 +294,7 @@ def test_target_manifest_cache_survives_generic_five_minute_ttl(
     assert calls == 1
 
 
-def test_target_manifest_cache_remains_bounded(
-    monkeypatch, tmp_path
-) -> None:
+def test_target_manifest_cache_remains_bounded(monkeypatch, tmp_path) -> None:
     """The longer target-manifest cache still refreshes after one day."""
     updated = {**TARGET_BODY, "build_epoch": TARGET_BODY["build_epoch"] + 1}
     responses = iter([_FakeResponse(200, TARGET_BODY), _FakeResponse(200, updated)])

--- a/tests/test_firmware_nightlies.py
+++ b/tests/test_firmware_nightlies.py
@@ -165,29 +165,50 @@ def _make_nightly_target_bodies(
     for board in boards:
         if board == "rak4631":
             files = [
-                {"name": f"firmware-rak4631-{build}.uf2",
-                 "md5": "11111111111111111111111111111111", "bytes": 490_000},
-                {"name": f"firmware-rak4631-{build}.hex",
-                 "md5": "22222222222222222222222222222222", "bytes": 610_000},
-                {"name": f"firmware-rak4631-{build}-ota.zip",
-                 "md5": "33333333333333333333333333333333", "bytes": 769_000},
+                {
+                    "name": f"firmware-rak4631-{build}.uf2",
+                    "md5": "11111111111111111111111111111111",
+                    "bytes": 490_000,
+                },
+                {
+                    "name": f"firmware-rak4631-{build}.hex",
+                    "md5": "22222222222222222222222222222222",
+                    "bytes": 610_000,
+                },
+                {
+                    "name": f"firmware-rak4631-{build}-ota.zip",
+                    "md5": "33333333333333333333333333333333",
+                    "bytes": 769_000,
+                },
                 # The build manifest inventories this debug output, but the
                 # nightly publish job packages ELFs separately and does not
                 # copy them to the public bucket root.
-                {"name": f"firmware-rak4631-{build}.elf",
-                 "md5": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bytes": 2_400_000},
+                {
+                    "name": f"firmware-rak4631-{build}.elf",
+                    "md5": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "bytes": 2_400_000,
+                },
             ]
         elif board == "tbeam":
             files = [
-                {"name": f"firmware-tbeam-{build}.bin",
-                 "md5": "44444444444444444444444444444444", "bytes": 1_100_000},
-                {"name": f"firmware-tbeam-{build}.factory.bin",
-                 "md5": "55555555555555555555555555555555", "bytes": 1_050_000},
+                {
+                    "name": f"firmware-tbeam-{build}.bin",
+                    "md5": "44444444444444444444444444444444",
+                    "bytes": 1_100_000,
+                },
+                {
+                    "name": f"firmware-tbeam-{build}.factory.bin",
+                    "md5": "55555555555555555555555555555555",
+                    "bytes": 1_050_000,
+                },
             ]
         else:  # heltec-v3
             files = [
-                {"name": f"firmware-heltec-v3-{build}.bin",
-                 "md5": "66666666666666666666666666666666", "bytes": 1_150_000},
+                {
+                    "name": f"firmware-heltec-v3-{build}.bin",
+                    "md5": "66666666666666666666666666666666",
+                    "bytes": 1_150_000,
+                },
             ]
         bodies[f"{board}-{build}"] = {
             "version": build,
@@ -464,13 +485,17 @@ def test_fetch_firmware_nightlies_queries_nightly_manifests(
     # Index and release manifest are both fetched with force_refresh=True so
     # the in-place upstream replacement is observed each enabled check.
     mock_cache_manager.get_nightly_index.assert_called_once()
-    assert mock_cache_manager.get_nightly_index.call_args.kwargs["force_refresh"] is True
+    assert (
+        mock_cache_manager.get_nightly_index.call_args.kwargs["force_refresh"] is True
+    )
     mock_cache_manager.get_nightly_release_manifest.assert_called_once_with(
         BUILD_2_8_0, force_refresh=True
     )
     target_calls = mock_cache_manager.get_nightly_target_manifest.call_args_list
     assert target_calls
-    assert all(call.kwargs.get("force_refresh", False) is False for call in target_calls)
+    assert all(
+        call.kwargs.get("force_refresh", False) is False for call in target_calls
+    )
     assert len({id(call.kwargs["session"]) for call in target_calls}) == 1
 
 
@@ -603,9 +628,7 @@ def test_fetch_firmware_nightlies_appends_helper_scripts_pinned_to_commit(
 
     by_name = {e["name"]: e for e in entries}
     for script_name in FIRMWARE_NIGHTLY_HELPER_SCRIPTS:
-        assert script_name in by_name, (
-            f"{script_name} missing from listing"
-        )
+        assert script_name in by_name, f"{script_name} missing from listing"
         entry = by_name[script_name]
         # URL is pinned to the firmware repo's commit SHA.
         assert entry["download_url"] == (
@@ -634,9 +657,7 @@ def test_fetch_firmware_nightlies_omits_helpers_when_commit_missing_or_malformed
         mock_cache_manager = Mock(spec=CacheManager)
         mock_cache_manager.cache_dir = downloader.cache_manager.cache_dir
         mock_cache_manager.get_cache_file_path.side_effect = (
-            lambda file_name: os.path.join(
-                mock_cache_manager.cache_dir, file_name
-            )
+            lambda file_name: os.path.join(mock_cache_manager.cache_dir, file_name)
         )
         mock_cache_manager.get_nightly_index = Mock(return_value=index_body)
         mock_cache_manager.get_nightly_release_manifest = Mock(
@@ -650,9 +671,9 @@ def test_fetch_firmware_nightlies_omits_helpers_when_commit_missing_or_malformed
         entries = downloader.fetch_firmware_nightlies()
         names = {e["name"] for e in entries}
         for script_name in FIRMWARE_NIGHTLY_HELPER_SCRIPTS:
-            assert script_name not in names, (
-                f"{script_name} should be omitted when commit is {bad_commit!r}"
-            )
+            assert (
+                script_name not in names
+            ), f"{script_name} should be omitted when commit is {bad_commit!r}"
 
 
 def test_helper_scripts_selected_by_device_pattern(downloader, mock_cache_manager):
@@ -678,9 +699,9 @@ def test_helper_scripts_selected_by_device_pattern(downloader, mock_cache_manage
 
     selected_names = {e["name"] for e in selected}
     for script_name in FIRMWARE_NIGHTLY_HELPER_SCRIPTS:
-        assert script_name in selected_names, (
-            f"{script_name} not selected by 'device-' pattern; got {sorted(selected_names)}"
-        )
+        assert (
+            script_name in selected_names
+        ), f"{script_name} not selected by 'device-' pattern; got {sorted(selected_names)}"
 
 
 def test_helper_scripts_omitted_from_selection_without_device_pattern(
@@ -710,9 +731,7 @@ def test_helper_scripts_omitted_from_selection_without_device_pattern(
     assert "device-update.sh" not in selected_names
 
 
-def test_fetch_firmware_nightlies_raises_on_bad_target(
-    downloader, mock_cache_manager
-):
+def test_fetch_firmware_nightlies_raises_on_bad_target(downloader, mock_cache_manager):
     """A target with missing 'board' rejects the whole listing."""
     index_body = _make_nightly_index_body()
     release_body = {
@@ -1934,9 +1953,7 @@ def test_download_nightly_asset_md5_mismatch_fails_non_retryable(
     """A downloaded file whose MD5 doesn't match expected_md5 must fail non-retryably."""
     payload = b"corrupted-bytes"
     wrong_md5 = "0" * 32
-    entry = _contents_entry(
-        "firmware-tbeam-2.8.0.f52e2ea.bin", size=len(payload)
-    )
+    entry = _contents_entry("firmware-tbeam-2.8.0.f52e2ea.bin", size=len(payload))
     entry["expected_md5"] = wrong_md5
     target = downloader.get_nightly_target_path(BUILD_2_8_0, entry["name"], create=True)
     if os.path.exists(target):
@@ -1962,15 +1979,11 @@ def test_download_nightly_asset_md5_mismatch_fails_non_retryable(
     assert not os.path.exists(target)
 
 
-def test_download_nightly_asset_md5_match_succeeds(
-    downloader, mock_cache_manager
-):
+def test_download_nightly_asset_md5_match_succeeds(downloader, mock_cache_manager):
     """A downloaded file whose MD5 matches expected_md5 must succeed."""
     payload = b"good-bytes"
     expected = hashlib.md5(payload, usedforsecurity=False).hexdigest()
-    entry = _contents_entry(
-        "firmware-tbeam-2.8.0.f52e2ea.bin", size=len(payload)
-    )
+    entry = _contents_entry("firmware-tbeam-2.8.0.f52e2ea.bin", size=len(payload))
     entry["expected_md5"] = expected
     target = downloader.get_nightly_target_path(BUILD_2_8_0, entry["name"], create=True)
     if os.path.exists(target):
@@ -2676,9 +2689,7 @@ def test_should_process_nightly_same_identity_all_valid_skips(
     assert should(entries, BUILD_2_8_0) is False
 
 
-def test_should_process_nightly_enforces_manifest_md5(
-    downloader, cache_manager
-):
+def test_should_process_nightly_enforces_manifest_md5(downloader, cache_manager):
     """Same-build validation must pass the upstream MD5 into the validator."""
     tracking_path = cache_manager.get_cache_file_path(
         constants.LATEST_FIRMWARE_NIGHTLY_JSON_FILE

--- a/tests/test_firmware_nightlies.py
+++ b/tests/test_firmware_nightlies.py
@@ -642,38 +642,36 @@ def test_fetch_firmware_nightlies_appends_helper_scripts_pinned_to_commit(
         assert entry["size"] is None
 
 
+@pytest.mark.parametrize("bad_commit", [None, "", "not-a-sha", "abc"])
 def test_fetch_firmware_nightlies_omits_helpers_when_commit_missing_or_malformed(
-    downloader, mock_cache_manager
+    downloader, mock_cache_manager, bad_commit
 ):
     """When index.json has no usable commit, helpers are omitted (not fetched stale)."""
     from fetchtastic.constants import FIRMWARE_NIGHTLY_HELPER_SCRIPTS
 
-    for bad_commit in (None, "", "not-a-sha", "abc"):
-        index_body = _make_nightly_index_body()
-        index_body["commit"] = bad_commit
-        release_body = _make_nightly_release_body()
-        target_bodies = _make_nightly_target_bodies()
+    index_body = _make_nightly_index_body()
+    index_body["commit"] = bad_commit
+    release_body = _make_nightly_release_body()
+    target_bodies = _make_nightly_target_bodies()
 
-        mock_cache_manager = Mock(spec=CacheManager)
-        mock_cache_manager.cache_dir = downloader.cache_manager.cache_dir
-        mock_cache_manager.get_cache_file_path.side_effect = (
-            lambda file_name: os.path.join(mock_cache_manager.cache_dir, file_name)
-        )
-        mock_cache_manager.get_nightly_index = Mock(return_value=index_body)
-        mock_cache_manager.get_nightly_release_manifest = Mock(
-            return_value=release_body
-        )
-        mock_cache_manager.get_nightly_target_manifest = Mock(
-            side_effect=lambda target_id, **_: target_bodies[target_id]
-        )
-        downloader.cache_manager = mock_cache_manager
+    mock_cache_manager = Mock(spec=CacheManager)
+    mock_cache_manager.cache_dir = downloader.cache_manager.cache_dir
+    mock_cache_manager.get_cache_file_path.side_effect = lambda file_name: os.path.join(
+        mock_cache_manager.cache_dir, file_name
+    )
+    mock_cache_manager.get_nightly_index = Mock(return_value=index_body)
+    mock_cache_manager.get_nightly_release_manifest = Mock(return_value=release_body)
+    mock_cache_manager.get_nightly_target_manifest = Mock(
+        side_effect=lambda target_id, **_: target_bodies[target_id]
+    )
+    downloader.cache_manager = mock_cache_manager
 
-        entries = downloader.fetch_firmware_nightlies()
-        names = {e["name"] for e in entries}
-        for script_name in FIRMWARE_NIGHTLY_HELPER_SCRIPTS:
-            assert (
-                script_name not in names
-            ), f"{script_name} should be omitted when commit is {bad_commit!r}"
+    entries = downloader.fetch_firmware_nightlies()
+    names = {e["name"] for e in entries}
+    for script_name in FIRMWARE_NIGHTLY_HELPER_SCRIPTS:
+        assert (
+            script_name not in names
+        ), f"{script_name} should be omitted when commit is {bad_commit!r}"
 
 
 def test_helper_scripts_selected_by_device_pattern(downloader, mock_cache_manager):


### PR DESCRIPTION
## Summary by Sourcery

Release version 0.11.3 with refreshed linter dependencies and formatting updates.

Enhancements:
- Update the project’s linting and security tool dependencies to newer releases.
- Apply formatting and lint-driven cleanup across source code and tests.

Build:
- Bump the package version from 0.11.2 to 0.11.3.

Tests:
- Refine nightly firmware tests, including parameterized validation of malformed commits and formatting updates.