### PR TITLE
Fix firmware prerelease cleanup version parsing

### DIFF
--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -2789,8 +2789,9 @@ class FirmwareReleaseDownloader(BaseDownloader):
             # Get version tuple for comparison
             version_manager = VersionManager()
             release_tuple = version_manager.get_release_tuple(clean_release_tag)
-            if not release_tuple:
+            if release_tuple is None or len(release_tuple) < 3:
                 return False
+            release_tuple = release_tuple[:3]
 
             # Path to prerelease directory
             prerelease_dir = os.path.join(
@@ -2823,15 +2824,21 @@ class FirmwareReleaseDownloader(BaseDownloader):
                         if entry.name.startswith(FIRMWARE_DIR_PREFIX):
                             dir_name = entry.name[len(FIRMWARE_DIR_PREFIX) :]
 
-                            # Extract version from directory name
                             if "." in dir_name:
                                 parts = dir_name.split(".")
                                 if len(parts) >= 3:
                                     try:
-                                        dir_major, dir_minor, dir_patch = map(
-                                            int, parts[:3]
+                                        parsed_dir_tuple = (
+                                            version_manager.get_release_tuple(dir_name)
                                         )
-                                        dir_tuple = (dir_major, dir_minor, dir_patch)
+                                        if (
+                                            parsed_dir_tuple is None
+                                            or len(parsed_dir_tuple) < 3
+                                        ):
+                                            raise ValueError(
+                                                "unparsable prerelease version"
+                                            )
+                                        dir_tuple = parsed_dir_tuple[:3]
 
                                         # Check if this prerelease is superseded
                                         if dir_tuple <= release_tuple:
@@ -2853,7 +2860,26 @@ class FirmwareReleaseDownloader(BaseDownloader):
                                             valid_latest_target_names.add(entry.name)
 
                                     except ValueError:
+                                        logger.debug(
+                                            "Preserving unparsable firmware prerelease "
+                                            "directory: %s",
+                                            entry.name,
+                                        )
+                                        valid_latest_target_names.add(entry.name)
                                         continue
+                                else:
+                                    logger.debug(
+                                        "Preserving unparsable firmware prerelease "
+                                        "directory: %s",
+                                        entry.name,
+                                    )
+                                    valid_latest_target_names.add(entry.name)
+                            else:
+                                logger.debug(
+                                    "Preserving unparsable firmware prerelease directory: %s",
+                                    entry.name,
+                                )
+                                valid_latest_target_names.add(entry.name)
                 self._cleanup_invalid_prerelease_latest_pointer(
                     prerelease_dir, valid_latest_target_names
                 )

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -2781,17 +2781,22 @@ class FirmwareReleaseDownloader(BaseDownloader):
             bool: `True` if any prerelease directories were removed, `False` otherwise.
         """
         try:
-            # Strip the 'v' prefix if present
-            clean_release_tag = latest_release_tag.lstrip("vV")
-            if not clean_release_tag:
-                return False
-
-            # Get version tuple for comparison
             version_manager = VersionManager()
-            release_tuple = version_manager.get_release_tuple(clean_release_tag)
-            if release_tuple is None or len(release_tuple) < 3:
+
+            def semantic_triplet(value: str) -> Optional[Tuple[int, int, int]]:
+                """Return major/minor/patch only when the full version is parseable."""
+                normalized = version_manager.normalize_version(value)
+                release = getattr(normalized, "release", ()) if normalized else ()
+                if len(release) < 3:
+                    return None
+                return (int(release[0]), int(release[1]), int(release[2]))
+
+            # Cleanup is destructive, so do not use get_release_tuple() here: its
+            # numeric-prefix fallback intentionally accepts partially parseable strings.
+            # Require the complete baseline to normalize before authorizing deletion.
+            release_tuple = semantic_triplet(latest_release_tag)
+            if release_tuple is None:
                 return False
-            release_tuple = release_tuple[:3]
 
             # Path to prerelease directory
             prerelease_dir = os.path.join(
@@ -2828,17 +2833,11 @@ class FirmwareReleaseDownloader(BaseDownloader):
                                 parts = dir_name.split(".")
                                 if len(parts) >= 3:
                                     try:
-                                        parsed_dir_tuple = (
-                                            version_manager.get_release_tuple(dir_name)
-                                        )
-                                        if (
-                                            parsed_dir_tuple is None
-                                            or len(parsed_dir_tuple) < 3
-                                        ):
+                                        dir_tuple = semantic_triplet(dir_name)
+                                        if dir_tuple is None:
                                             raise ValueError(
                                                 "unparsable prerelease version"
                                             )
-                                        dir_tuple = parsed_dir_tuple[:3]
 
                                         # Check if this prerelease is superseded
                                         if dir_tuple <= release_tuple:

--- a/tests/test_cleanup_prerelease_versions.py
+++ b/tests/test_cleanup_prerelease_versions.py
@@ -89,3 +89,25 @@ def test_incomplete_release_baseline_does_not_prune_prereleases(
 
     assert downloader.cleanup_superseded_prereleases("v2.7") is False
     assert candidate.is_dir()
+
+
+def test_numeric_prefix_with_unparsed_suffix_is_preserved(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    prerelease_dir = _prerelease_dir(downloader)
+    malformed = prerelease_dir / "firmware-2.7.12-garbage"
+    malformed.mkdir()
+
+    assert downloader.cleanup_superseded_prereleases("v2.7.12") is False
+    assert malformed.is_dir()
+
+
+def test_malformed_release_baseline_does_not_prune_prereleases(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    prerelease_dir = _prerelease_dir(downloader)
+    candidate = prerelease_dir / "firmware-2.7.12.abcdef1"
+    candidate.mkdir()
+
+    assert downloader.cleanup_superseded_prereleases("v2.7.12-garbage") is False
+    assert candidate.is_dir()

--- a/tests/test_cleanup_prerelease_versions.py
+++ b/tests/test_cleanup_prerelease_versions.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import pytest
+
+from fetchtastic.constants import FIRMWARE_DIR_NAME, FIRMWARE_PRERELEASES_DIR_NAME
+from fetchtastic.download.cache import CacheManager
+from fetchtastic.download.firmware import FirmwareReleaseDownloader
+
+
+@pytest.fixture
+def downloader(tmp_path: Path) -> FirmwareReleaseDownloader:
+    return FirmwareReleaseDownloader(
+        {"DOWNLOAD_DIR": str(tmp_path / "downloads")},
+        CacheManager(cache_dir=str(tmp_path / "cache")),
+    )
+
+
+def _prerelease_dir(downloader: FirmwareReleaseDownloader) -> Path:
+    path = (
+        Path(downloader.download_dir)
+        / FIRMWARE_DIR_NAME
+        / FIRMWARE_PRERELEASES_DIR_NAME
+    )
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def test_v_prefixed_prerelease_directory_is_removed_when_superseded(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    prerelease_dir = _prerelease_dir(downloader)
+    superseded = prerelease_dir / "firmware-v2.7.12.abcdef1"
+    superseded.mkdir()
+
+    assert downloader.cleanup_superseded_prereleases("v2.7.12") is True
+    assert not superseded.exists()
+
+
+def test_unparsable_prerelease_directory_is_preserved(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    prerelease_dir = _prerelease_dir(downloader)
+    unparsable = prerelease_dir / "firmware-preview-build"
+    unparsable.mkdir()
+
+    assert downloader.cleanup_superseded_prereleases("v2.7.12") is False
+    assert unparsable.is_dir()
+
+
+def test_short_unparsable_prerelease_remains_valid_latest_target(
+    downloader: FirmwareReleaseDownloader, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    prerelease_dir = _prerelease_dir(downloader)
+    retained = prerelease_dir / "firmware-v2.8"
+    retained.mkdir()
+    observed: set[str] = set()
+
+    def capture_retained(_base_dir: str, retained_names: set[str]) -> None:
+        observed.update(retained_names)
+
+    monkeypatch.setattr(
+        downloader,
+        "_cleanup_invalid_prerelease_latest_pointer",
+        capture_retained,
+    )
+
+    assert downloader.cleanup_superseded_prereleases("v2.7.12") is False
+    assert retained.is_dir()
+    assert retained.name in observed
+
+
+def test_numeric_build_suffix_does_not_change_semver_supersession(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    prerelease_dir = _prerelease_dir(downloader)
+    superseded = prerelease_dir / "firmware-2.7.12.1"
+    superseded.mkdir()
+
+    assert downloader.cleanup_superseded_prereleases("v2.7.12") is True
+    assert not superseded.exists()
+
+
+def test_incomplete_release_baseline_does_not_prune_prereleases(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    prerelease_dir = _prerelease_dir(downloader)
+    candidate = prerelease_dir / "firmware-2.7.12.abcdef1"
+    candidate.mkdir()
+
+    assert downloader.cleanup_superseded_prereleases("v2.7") is False
+    assert candidate.is_dir()

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -3187,7 +3187,7 @@ class TestFirmwareUncoveredBranches:
         """Test when version tuple can't be extracted."""
         with patch.object(
             VersionManager,
-            "get_release_tuple",
+            "normalize_version",
             return_value=None,
         ):
             result = downloader.cleanup_superseded_prereleases("v1.2.3")
@@ -3389,10 +3389,10 @@ class TestFirmwarePrereleaseBaselineDerivation:
         mock_prerelease_keep.path = "/mock/prerelease/firmware-2.7.23.abcdef1"
 
         mock_prerelease_remove = Mock()
-        mock_prerelease_remove.name = "firmware-2.7.22.oldhash"
+        mock_prerelease_remove.name = "firmware-2.7.22.deadbee"
         mock_prerelease_remove.is_symlink.return_value = False
         mock_prerelease_remove.is_dir.return_value = True
-        mock_prerelease_remove.path = "/mock/prerelease/firmware-2.7.22.oldhash"
+        mock_prerelease_remove.path = "/mock/prerelease/firmware-2.7.22.deadbee"
 
         mock_scandir.return_value.__enter__.return_value = [
             mock_prerelease_keep,
@@ -3403,7 +3403,7 @@ class TestFirmwarePrereleaseBaselineDerivation:
         result = downloader.cleanup_superseded_prereleases("v2.7.22.96dd647")
 
         assert result is True
-        mock_rmtree.assert_called_once_with("/mock/prerelease/firmware-2.7.22.oldhash")
+        mock_rmtree.assert_called_once_with("/mock/prerelease/firmware-2.7.22.deadbee")
 
     # =========================================================================
     # Tests for deterministic prerelease directory sorting (review fix 1)


### PR DESCRIPTION
## Overview

Firmware prerelease cleanup was making deletion decisions from loosely parsed version strings. `VersionManager.get_release_tuple()` intentionally accepts a leading numeric version, which is useful elsewhere but too permissive for cleanup — a malformed name such as `2.7.12-garbage` could be treated as `2.7.12` and removed as superseded.

This tightens that path so both the release baseline and prerelease directory must fully normalize before they can participate in cleanup.

## Key Changes

- Compare prereleases by semantic major/minor/patch after full version normalization.
- Continue to support `v`-prefixed versions, numeric build suffixes, and Meshtastic hash-suffixed builds.
- Preserve malformed or incomplete prerelease directory names instead of guessing what version they represent.
- Refuse to prune anything when the release baseline itself is incomplete or malformed.
- Keep preserved directories valid for the prerelease `latest` pointer.
- Add regression coverage for malformed numeric-prefix names as well as the supported version forms.

This only changes superseded-prerelease cleanup. Firmware discovery, downloads, selection, retention settings, and release handling are unchanged.