### PR TITLE
Fix firmware retention when storage layouts don't match

### DIFF
--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1401,10 +1401,13 @@ class FirmwareReleaseDownloader(BaseDownloader):
         Remove firmware version directories not present in the latest `keep_limit` releases
         (full releases only).
 
-        This mirrors legacy behavior by keeping only the newest release tags (alpha/beta)
-        returned by GitHub API (bounded by `keep_limit`). Any local version
-        directories not in that set are removed. Special directories "prerelease" and
-        "repo-dls" are always preserved.
+        This mirrors legacy behavior by keeping the newest release tags returned by
+        GitHub API, bounded by `keep_limit`. When the local directory layout does not
+        match that keep set, cleanup is conservative: only stale release bases recorded
+        in Fetchtastic release history are eligible for removal, while untracked local
+        directories and retained alternate layouts without a canonical directory are
+        preserved. Special directories "prerelease", "nightlies", and "repo-dls" are
+        always preserved.
 
         Parameters:
             keep_limit (int): Maximum number of most-recent version directories to retain;
@@ -1586,18 +1589,27 @@ class FirmwareReleaseDownloader(BaseDownloader):
                         and name != self._get_comparable_base_tag(name)
                     ]
 
-                if (
+                shape_mismatch = bool(
                     keep_limit > 0
                     and existing_versions
                     and (
                         keep_base_names.isdisjoint(existing_base_names)
-                        or bool(unmatched_channel_dirs)
+                        or unmatched_channel_dirs
                     )
-                ):
+                )
+                tracked_base_names: set[str] = set()
+                existing_canonical_bases = {
+                    self._get_comparable_base_tag(name)
+                    for name in existing_versions
+                    if name in release_tags_to_keep
+                }
+                if shape_mismatch:
+                    tracked_base_names = self._get_tracked_release_base_names()
                     logger.warning(
-                        "Skipping firmware cleanup: keep set does not match existing directories."
+                        "Firmware cleanup keep set does not fully match existing directories; "
+                        "pruning only previously tracked stale releases."
                     )
-                    return
+
                 for entry in entries:
                     if entry.name in {
                         FIRMWARE_PRERELEASES_DIR_NAME,
@@ -1624,6 +1636,27 @@ class FirmwareReleaseDownloader(BaseDownloader):
                             continue
                         if preserve_legacy_base_dirs and entry.name in keep_base_names:
                             continue
+
+                        entry_base_name = self._get_comparable_base_tag(entry.name)
+                        if shape_mismatch:
+                            if (
+                                entry_base_name in keep_base_names
+                                and entry_base_name not in existing_canonical_bases
+                            ):
+                                logger.info(
+                                    "Preserving firmware directory for retained release during "
+                                    "storage-layout reconciliation: %s",
+                                    entry.name,
+                                )
+                                continue
+                            if entry_base_name not in tracked_base_names:
+                                logger.info(
+                                    "Preserving untracked firmware directory during cleanup "
+                                    "reconciliation: %s",
+                                    entry.name,
+                                )
+                                continue
+
                         try:
                             logger.debug(
                                 "Removing firmware directory: %s",
@@ -1722,6 +1755,37 @@ class FirmwareReleaseDownloader(BaseDownloader):
         """
         patterns = self.config.get("SELECTED_PRERELEASE_ASSETS") or []
         return patterns if isinstance(patterns, list) else [str(patterns)]
+
+    def _get_tracked_release_base_names(self) -> set[str]:
+        """Return sanitized firmware base tags from valid release-history entries.
+
+        During storage-layout reconciliation, history is used only to limit
+        deletion to release bases Fetchtastic previously observed upstream. Missing,
+        malformed, or internally inconsistent entries provide no deletion evidence.
+        """
+        try:
+            history = self.cache_manager.read_json(self.release_history_path) or {}
+        except (OSError, ValueError, TypeError):
+            return set()
+        if not isinstance(history, dict):
+            return set()
+        entries = history.get("entries")
+        if not isinstance(entries, dict):
+            return set()
+
+        tracked: set[str] = set()
+        for key, value in entries.items():
+            if not isinstance(key, str) or not isinstance(value, dict):
+                continue
+            tag = value.get("tag_name")
+            if not isinstance(tag, str) or not tag or tag != key:
+                continue
+            try:
+                safe_tag = self._sanitize_required(tag, "release history tag")
+            except ValueError:
+                continue
+            tracked.add(self._get_comparable_base_tag(safe_tag))
+        return tracked
 
     def _get_comparable_base_tag(self, name: str) -> str:
         """

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1774,6 +1774,7 @@ class FirmwareReleaseDownloader(BaseDownloader):
             return set()
 
         tracked: set[str] = set()
+        version_manager = VersionManager()
         for key, value in entries.items():
             if not isinstance(key, str) or not isinstance(value, dict):
                 continue
@@ -1784,7 +1785,14 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 safe_tag = self._sanitize_required(tag, "release history tag")
             except ValueError:
                 continue
-            tracked.add(self._get_comparable_base_tag(safe_tag))
+            base_tag = self._get_comparable_base_tag(safe_tag)
+            normalized = version_manager.normalize_version(base_tag)
+            release_tuple = (
+                getattr(normalized, "release", ()) if normalized is not None else ()
+            )
+            if len(release_tuple) < 3:
+                continue
+            tracked.add(base_tag)
         return tracked
 
     def _get_comparable_base_tag(self, name: str) -> str:

--- a/tests/test_cleanup_retention_reconciliation.py
+++ b/tests/test_cleanup_retention_reconciliation.py
@@ -123,3 +123,46 @@ def test_tracked_alternate_layout_is_pruned_after_canonical_dir_exists(
 
     assert canonical.is_dir()
     assert not alternate.exists()
+
+
+def test_non_version_history_tag_cannot_authorize_reconciliation_deletion(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    firmware_dir = _firmware_dir(downloader)
+    local_only = firmware_dir / "notes"
+    local_only.mkdir()
+    (firmware_dir / "v1.0.0").mkdir()
+    assert downloader.cache_manager.atomic_write_json(
+        downloader.release_history_path,
+        {"entries": {"notes": {"tag_name": "notes"}}},
+    )
+
+    downloader.cleanup_old_versions(
+        1,
+        cached_releases=[Release(tag_name="v3.0.0")],
+    )
+
+    assert local_only.is_dir()
+
+
+def test_hash_suffixed_history_tag_still_authorizes_stale_release_cleanup(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    firmware_dir = _firmware_dir(downloader)
+    stale = firmware_dir / "v2.7.25.104df5f"
+    stale.mkdir()
+    assert downloader.cache_manager.atomic_write_json(
+        downloader.release_history_path,
+        {
+            "entries": {
+                "v2.7.25.104df5f": {"tag_name": "v2.7.25.104df5f"}
+            }
+        },
+    )
+
+    downloader.cleanup_old_versions(
+        1,
+        cached_releases=[Release(tag_name="v3.0.0")],
+    )
+
+    assert not stale.exists()

--- a/tests/test_cleanup_retention_reconciliation.py
+++ b/tests/test_cleanup_retention_reconciliation.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+
+import pytest
+
+from fetchtastic.constants import FIRMWARE_DIR_NAME
+from fetchtastic.download.cache import CacheManager
+from fetchtastic.download.firmware import FirmwareReleaseDownloader
+from fetchtastic.download.interfaces import Release
+
+
+@pytest.fixture
+def downloader(tmp_path: Path) -> FirmwareReleaseDownloader:
+    cache_manager = CacheManager(cache_dir=str(tmp_path / "cache"))
+    return FirmwareReleaseDownloader(
+        {
+            "DOWNLOAD_DIR": str(tmp_path / "downloads"),
+            "FILTER_REVOKED_RELEASES": False,
+            "ADD_CHANNEL_SUFFIXES_TO_DIRECTORIES": False,
+        },
+        cache_manager,
+    )
+
+
+def _firmware_dir(downloader: FirmwareReleaseDownloader) -> Path:
+    path = Path(downloader.download_dir) / FIRMWARE_DIR_NAME
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def test_tracked_stale_release_is_pruned_when_keep_set_is_disjoint(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    firmware_dir = _firmware_dir(downloader)
+    stale = firmware_dir / "v1.0.0"
+    stale.mkdir()
+    assert downloader.cache_manager.atomic_write_json(
+        downloader.release_history_path,
+        {"entries": {"v1.0.0": {"tag_name": "v1.0.0"}}},
+    )
+
+    downloader.cleanup_old_versions(
+        1,
+        cached_releases=[Release(tag_name="v3.0.0")],
+    )
+
+    assert not stale.exists()
+
+
+def test_untracked_release_is_preserved_when_keep_set_is_disjoint(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    firmware_dir = _firmware_dir(downloader)
+    local_only = firmware_dir / "v1.0.0"
+    local_only.mkdir()
+
+    downloader.cleanup_old_versions(
+        1,
+        cached_releases=[Release(tag_name="v3.0.0")],
+    )
+
+    assert local_only.is_dir()
+
+
+@pytest.mark.parametrize(
+    "history_entry",
+    ["corrupt", {}, {"tag_name": "v9.9.9"}],
+)
+def test_malformed_history_cannot_authorize_reconciliation_deletion(
+    downloader: FirmwareReleaseDownloader, history_entry: object
+) -> None:
+    firmware_dir = _firmware_dir(downloader)
+    local_only = firmware_dir / "v1.0.0"
+    local_only.mkdir()
+    assert downloader.cache_manager.atomic_write_json(
+        downloader.release_history_path,
+        {"entries": {"v1.0.0": history_entry}},
+    )
+
+    downloader.cleanup_old_versions(
+        1,
+        cached_releases=[Release(tag_name="v3.0.0")],
+    )
+
+    assert local_only.is_dir()
+
+
+def test_retained_release_layout_is_preserved_until_canonical_dir_exists(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    firmware_dir = _firmware_dir(downloader)
+    channel_dir = firmware_dir / "v3.0.0-alpha"
+    channel_dir.mkdir()
+    assert downloader.cache_manager.atomic_write_json(
+        downloader.release_history_path,
+        {"entries": {"v3.0.0": {"tag_name": "v3.0.0"}}},
+    )
+
+    downloader.cleanup_old_versions(
+        1,
+        cached_releases=[Release(tag_name="v3.0.0")],
+    )
+
+    assert channel_dir.is_dir()
+
+
+def test_tracked_alternate_layout_is_pruned_after_canonical_dir_exists(
+    downloader: FirmwareReleaseDownloader,
+) -> None:
+    firmware_dir = _firmware_dir(downloader)
+    canonical = firmware_dir / "v3.0.0"
+    alternate = firmware_dir / "v3.0.0-alpha"
+    canonical.mkdir()
+    alternate.mkdir()
+    assert downloader.cache_manager.atomic_write_json(
+        downloader.release_history_path,
+        {"entries": {"v3.0.0": {"tag_name": "v3.0.0"}}},
+    )
+
+    downloader.cleanup_old_versions(
+        1,
+        cached_releases=[Release(tag_name="v3.0.0")],
+    )
+
+    assert canonical.is_dir()
+    assert not alternate.exists()


### PR DESCRIPTION
## Overview

Firmware cleanup can encounter different directory layouts across upgrades or configuration changes — for example channel-suffixed directories locally while the current keep set uses canonical release names.

The old mismatch guard avoided accidental deletion by skipping cleanup entirely. This keeps that conservative behavior where needed while still allowing Fetchtastic to remove stale releases it can positively identify as managed.

## Key Changes

- Reconcile mismatched firmware directory layouts instead of abandoning the entire cleanup pass.
- Delete stale directories only when valid release history proves Fetchtastic previously tracked that release.
- Preserve untracked/local directories when there isn't enough evidence to remove them.
- Preserve an alternate layout for a retained release until its canonical directory exists.
- Allow the old tracked alternate layout to be removed once the canonical retained directory is present.
- Require release-history deletion evidence to be a valid release version; arbitrary or malformed history entries cannot authorize filesystem deletion.
- Continue to preserve `prerelease`, `nightlies`, `repo-dls`, and the existing special cleanup entries.
- Add regression coverage for disjoint keep sets, malformed history, local-only directories, alternate layouts, and real hash-suffixed release tags.

The intent is conservative reconciliation: clean up what Fetchtastic can prove is stale, and leave anything ambiguous alone.