### PR TITLE
Harden firmware and repository cleanup deletion boundaries

### DIFF
--- a/src/fetchtastic/download/files.py
+++ b/src/fetchtastic/download/files.py
@@ -425,6 +425,12 @@ def _safe_rmtree(path_to_remove: str, base_dir: str, item_name: str) -> bool:
             return True
 
         real_target = os.path.realpath(path_to_remove)
+        if real_target == real_base_dir:
+            logger.warning(
+                "Skipping removal of %s because it is the managed base directory",
+                path_to_remove,
+            )
+            return False
         if not _is_within_base(real_base_dir, real_target):
             logger.warning(
                 "Skipping removal of %s because it resolves outside the base directory",

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -9,7 +9,6 @@ import hashlib
 import json
 import os
 import re
-import shutil
 import zipfile
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple, cast
@@ -1662,7 +1661,8 @@ class FirmwareReleaseDownloader(BaseDownloader):
                                 "Removing firmware directory: %s",
                                 entry.path,
                             )
-                            shutil.rmtree(entry.path)
+                            if not _safe_rmtree(entry.path, firmware_dir, entry.name):
+                                continue
                             logger.info("Removed old firmware version: %s", entry.name)
                         except OSError as e:
                             logger.error(
@@ -2915,7 +2915,15 @@ class FirmwareReleaseDownloader(BaseDownloader):
                                         if dir_tuple <= release_tuple:
                                             prerelease_path = entry.path
                                             try:
-                                                shutil.rmtree(prerelease_path)
+                                                if not _safe_rmtree(
+                                                    prerelease_path,
+                                                    prerelease_dir,
+                                                    entry.name,
+                                                ):
+                                                    valid_latest_target_names.add(
+                                                        entry.name
+                                                    )
+                                                    continue
                                                 logger.info(
                                                     f"Removed superseded prerelease: {entry.name}"
                                                 )

--- a/src/fetchtastic/download/firmware.py
+++ b/src/fetchtastic/download/firmware.py
@@ -1565,8 +1565,8 @@ class FirmwareReleaseDownloader(BaseDownloader):
                 existing_versions = {
                     entry.name
                     for entry in entries
-                    if entry.is_dir()
-                    and not entry.is_symlink()
+                    if not entry.is_symlink()
+                    and entry.is_dir()
                     and entry.name
                     not in {
                         FIRMWARE_PRERELEASES_DIR_NAME,

--- a/src/fetchtastic/download/repository.py
+++ b/src/fetchtastic/download/repository.py
@@ -8,7 +8,6 @@ from the meshtastic.github.io repository.
 import json
 import os
 import re
-import shutil
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin, urlparse
 
@@ -25,6 +24,7 @@ from fetchtastic.constants import (
 from fetchtastic.log_utils import logger
 
 from .base import BaseDownloader
+from .files import _safe_rmtree
 from .interfaces import DownloadResult, Release
 
 
@@ -410,15 +410,25 @@ class RepositoryDownloader(BaseDownloader):
                     entry_display = _format_entry_path(entry.path)
                     try:
                         if entry.is_file() or entry.is_symlink():
-                            os.remove(entry.path)
-                            logger.info("Removed file: %s", entry_display)
-                            self._cleanup_summary["removed_files"] += 1
+                            if _safe_rmtree(entry.path, repo_dir, entry_display):
+                                logger.info("Removed file: %s", entry_display)
+                                self._cleanup_summary["removed_files"] += 1
+                            else:
+                                self._cleanup_summary["errors"].append(
+                                    f"{entry_display}: removal failed"
+                                )
+                                had_errors = True
                         elif entry.is_dir():
-                            shutil.rmtree(entry.path)
-                            logger.info("Removed directory: %s", entry_display)
-                            self._cleanup_summary["removed_dirs"] += 1
+                            if _safe_rmtree(entry.path, repo_dir, entry_display):
+                                logger.info("Removed directory: %s", entry_display)
+                                self._cleanup_summary["removed_dirs"] += 1
+                            else:
+                                self._cleanup_summary["errors"].append(
+                                    f"{entry_display}: removal failed"
+                                )
+                                had_errors = True
                     except OSError as e:
-                        logger.error("Error removing %s: %s", entry_display, e)
+                        logger.error("Error inspecting %s: %s", entry_display, e)
                         self._cleanup_summary["errors"].append(f"{entry_display}: {e}")
                         had_errors = True
 

--- a/src/fetchtastic/download/repository.py
+++ b/src/fetchtastic/download/repository.py
@@ -409,7 +409,7 @@ class RepositoryDownloader(BaseDownloader):
                 for entry in it:
                     entry_display = _format_entry_path(entry.path)
                     try:
-                        if entry.is_file() or entry.is_symlink():
+                        if entry.is_symlink() or entry.is_file():
                             if _safe_rmtree(entry.path, repo_dir, entry_display):
                                 logger.info("Removed file: %s", entry_display)
                                 self._cleanup_summary["removed_files"] += 1

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -505,9 +505,9 @@ class TestFirmwareReleaseDownloader:
 
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader
     ):
         """Test cleanup of old firmware versions."""
         # Setup filesystem mocks
@@ -559,8 +559,8 @@ class TestFirmwareReleaseDownloader:
         downloader.cleanup_old_versions(keep_limit=2)
 
         # Should remove version not in the keep set (v1.0.0)
-        mock_rmtree.assert_called_once()
-        args = mock_rmtree.call_args[0][0]
+        mock_safe_rmtree.assert_called_once()
+        args = mock_safe_rmtree.call_args[0][0]
         assert "v1.0.0" in args
         expected_limit = self._expected_cleanup_fetch_limit(
             keep_limit=2, keep_last_beta=False
@@ -569,9 +569,9 @@ class TestFirmwareReleaseDownloader:
 
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_unsafe_tags(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader
     ):
         """Test cleanup when release tags contain unsafe characters."""
         mock_exists.return_value = True
@@ -601,17 +601,17 @@ class TestFirmwareReleaseDownloader:
         downloader.cleanup_old_versions(keep_limit=2)
 
         # Should remove v2.0.0 since only v1.0.0 is safe
-        mock_rmtree.assert_called_once()
-        args = mock_rmtree.call_args[0][0]
+        mock_safe_rmtree.assert_called_once()
+        args = mock_safe_rmtree.call_args[0][0]
         assert "v2.0.0" in args
         assert "v1.0.0" not in args
         # Warning is logged but caplog testing is optional
 
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_keep_zero(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader
     ):
         """Test cleanup with keep_limit=0 removes all versions."""
         # Setup filesystem mocks
@@ -644,17 +644,17 @@ class TestFirmwareReleaseDownloader:
             keep_limit=0, keep_last_beta=False
         )
         downloader.get_releases.assert_called_once_with(limit=expected_limit)
-        assert mock_rmtree.call_count == 2
-        calls = mock_rmtree.call_args_list
+        assert mock_safe_rmtree.call_count == 2
+        calls = mock_safe_rmtree.call_args_list
         removed_paths = {call[0][0] for call in calls}
         assert any("v1.0.0" in path for path in removed_paths)
         assert any("v2.0.0" in path for path in removed_paths)
 
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_negative_keep_limit(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader
     ):
         """Test cleanup with negative keep_limit skips cleanup."""
         # Setup filesystem mocks
@@ -684,13 +684,13 @@ class TestFirmwareReleaseDownloader:
         # Should not call get_releases or rmtree for negative keep_limit
         downloader.get_releases.assert_not_called()
         mock_scandir.assert_not_called()
-        mock_rmtree.assert_not_called()
+        mock_safe_rmtree.assert_not_called()
 
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_skips_when_keep_set_mismatched(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader
     ):
         """Skip cleanup when expected tags do not match existing directories."""
         mock_exists.return_value = True
@@ -716,13 +716,13 @@ class TestFirmwareReleaseDownloader:
 
         downloader.cleanup_old_versions(keep_limit=2)
 
-        mock_rmtree.assert_not_called()
+        mock_safe_rmtree.assert_not_called()
 
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_all_unsafe_tags(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader, mocker
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader, mocker
     ):
         """Cleanup should bail when no safe tags are available to keep."""
         # Force the firmware directory to appear present.
@@ -742,7 +742,7 @@ class TestFirmwareReleaseDownloader:
         downloader.cleanup_old_versions(keep_limit=2)
 
         # No filesystem deletion should happen when the keep set is empty.
-        mock_rmtree.assert_not_called()
+        mock_safe_rmtree.assert_not_called()
         mock_scandir.assert_not_called()
         assert mock_logger.warning.called
 
@@ -1233,9 +1233,9 @@ class TestFirmwareReleaseDownloader:
         downloader.download.assert_not_called()
 
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_superseded_prereleases(
-        self, mock_rmtree, mock_scandir, downloader
+        self, mock_safe_rmtree, mock_scandir, downloader
     ):
         """Test cleanup of superseded prereleases."""
 
@@ -1274,13 +1274,13 @@ class TestFirmwareReleaseDownloader:
         result = downloader.cleanup_superseded_prereleases("v2.0.0")
 
         assert result is True
-        assert mock_rmtree.call_count == 2
+        assert mock_safe_rmtree.call_count == 2
 
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_keeps_prerelease_tags(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader
     ):
         """Test cleanup retains prerelease-tagged releases in the keep set."""
         mock_exists.return_value = True
@@ -1317,13 +1317,15 @@ class TestFirmwareReleaseDownloader:
 
         downloader.cleanup_old_versions(keep_limit=2)
 
-        mock_rmtree.assert_called_once_with("/mock/firmware/v2.7.15.567b8ea-alpha")
+        mock_safe_rmtree.assert_called_once_with(
+            "/mock/firmware/v2.7.15.567b8ea-alpha", ANY, "v2.7.15.567b8ea-alpha"
+        )
 
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_matches_channel_suffix_bases(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader
     ):
         """Ensure base tags are matched even when releases use channel suffixes."""
         mock_exists.return_value = True
@@ -1352,7 +1354,9 @@ class TestFirmwareReleaseDownloader:
 
         downloader.cleanup_old_versions(keep_limit=1)
 
-        mock_rmtree.assert_called_once_with(entry_remove.path)
+        mock_safe_rmtree.assert_called_once_with(
+            entry_remove.path, ANY, entry_remove.name
+        )
 
     def test_get_prerelease_tracking_file(self, downloader):
         """Test prerelease tracking file path generation."""
@@ -1485,9 +1489,9 @@ class TestFirmwareReleaseDownloader:
     @pytest.mark.unit
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_adds_beta_tag(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader
     ):
         """Most recent beta is kept when keep_last_beta is enabled."""
         mock_exists.return_value = True
@@ -1533,7 +1537,7 @@ class TestFirmwareReleaseDownloader:
             cached_releases=[stable, beta],
         )
 
-        mock_rmtree.assert_called_once_with(entry_old.path)
+        mock_safe_rmtree.assert_called_once_with(entry_old.path, ANY, entry_old.name)
 
     @pytest.mark.unit
     @patch("os.path.exists")
@@ -1620,14 +1624,14 @@ class TestFirmwareReleaseDownloader:
         with (
             patch("fetchtastic.download.firmware.logger.warning") as mock_warning,
             patch("fetchtastic.download.firmware.logger.debug") as mock_debug,
-            patch("fetchtastic.download.firmware.shutil.rmtree") as mock_rmtree,
+            patch("fetchtastic.download.firmware._safe_rmtree") as mock_safe_rmtree,
         ):
             downloader.cleanup_old_versions(keep_limit=0, cached_releases=[])
 
         mock_warning.assert_not_called()
         assert not any(
             call.args and call.args[0] == mock_latest.path
-            for call in mock_rmtree.call_args_list
+            for call in mock_safe_rmtree.call_args_list
         )
         debug_messages = [c[0][0] for c in mock_debug.call_args_list]
         assert not any(
@@ -1662,9 +1666,9 @@ class TestFirmwareReleaseDownloader:
 
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_latest_dir_does_not_trip_mismatch_guard(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader
     ):
         """A non-symlink latest directory is ignored by the mismatch guard and preserved."""
         mock_exists.return_value = True
@@ -1704,7 +1708,7 @@ class TestFirmwareReleaseDownloader:
             "Preserving non-symlink latest entry that may block latest pointer creation: %s",
             mock_latest.path,
         )
-        mock_rmtree.assert_not_called()
+        mock_safe_rmtree.assert_not_called()
 
     def test_update_latest_pointer_for_release_coerces_false_string(self, downloader):
         downloader.config["CREATE_LATEST_SYMLINKS"] = "false"
@@ -2022,9 +2026,9 @@ class TestFirmwareReleaseDownloader:
     @pytest.mark.core_downloads
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_keeps_most_recent_beta(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader
     ):
         """Test that KEEP_LAST_BETA ensures most recent beta is kept."""
         mock_exists.return_value = True
@@ -2089,8 +2093,8 @@ class TestFirmwareReleaseDownloader:
         downloader.cleanup_old_versions(keep_limit=1, keep_last_beta=True)
 
         # Only v1.9.0 should be removed
-        assert mock_rmtree.call_count == 1
-        mock_rmtree.assert_called_once_with("/mock/firmware/v1.9.0")
+        assert mock_safe_rmtree.call_count == 1
+        mock_safe_rmtree.assert_called_once_with("/mock/firmware/v1.9.0", ANY, "v1.9.0")
         expected_limit = self._expected_cleanup_fetch_limit(
             keep_limit=1, keep_last_beta=True
         )
@@ -2100,9 +2104,9 @@ class TestFirmwareReleaseDownloader:
     @pytest.mark.core_downloads
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_without_keep_last_beta(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader
     ):
         """Test cleanup without KEEP_LAST_BETA uses normal logic."""
         mock_exists.return_value = True
@@ -2140,8 +2144,8 @@ class TestFirmwareReleaseDownloader:
         downloader.cleanup_old_versions(keep_limit=1, keep_last_beta=False)
 
         # v1.9.0 should be removed
-        assert mock_rmtree.call_count == 1
-        mock_rmtree.assert_called_once_with("/mock/firmware/v1.9.0")
+        assert mock_safe_rmtree.call_count == 1
+        mock_safe_rmtree.assert_called_once_with("/mock/firmware/v1.9.0", ANY, "v1.9.0")
         expected_limit = self._expected_cleanup_fetch_limit(
             keep_limit=1, keep_last_beta=False
         )
@@ -2522,13 +2526,13 @@ class TestFirmwareUncoveredBranches:
     # Lines 1322-1333: Cleanup error handling
     @patch("os.path.exists")
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_old_versions_rmtree_error(
-        self, mock_rmtree, mock_scandir, mock_exists, downloader, mocker
+        self, mock_safe_rmtree, mock_scandir, mock_exists, downloader, mocker
     ):
         """Test cleanup when rmtree raises OSError."""
         mock_exists.return_value = True
-        mock_rmtree.side_effect = OSError("Permission denied")
+        mock_safe_rmtree.return_value = False
 
         entry = Mock()
         entry.name = "v0.9.0"
@@ -2550,10 +2554,10 @@ class TestFirmwareUncoveredBranches:
 
         downloader.cleanup_old_versions(keep_limit=1)
 
-        mock_logger.error.assert_any_call(
-            "Error removing old firmware version %s: %s",
-            "v0.9.0",
-            ANY,
+        mock_safe_rmtree.assert_called_once_with(entry.path, ANY, entry.name)
+        assert not any(
+            call.args and call.args[0] == "Removed old firmware version: %s"
+            for call in mock_logger.info.call_args_list
         )
 
     # Lines 1348-1349: Cleanup outer error handling
@@ -3260,13 +3264,17 @@ class TestFirmwareUncoveredBranches:
                 "get_release_tuple",
                 return_value=(2, 0, 0),
             ),
-            patch("shutil.rmtree", side_effect=OSError("Permission denied")),
+            patch(
+                "fetchtastic.download.firmware._safe_rmtree", return_value=False
+            ) as mock_safe_rmtree,
             patch("fetchtastic.download.firmware.logger") as mock_logger,
         ):
             result = downloader.cleanup_superseded_prereleases("v2.0.0")
 
-        # Should log error and continue
-        mock_logger.error.assert_called()
+        # The containment helper owns filesystem error logging; cleanup keeps the
+        # failed directory eligible as a valid latest target.
+        mock_safe_rmtree.assert_called_once_with(mock_entry.path, ANY, mock_entry.name)
+        mock_logger.error.assert_not_called()
         assert result is False  # No successful cleanup
 
     # Lines 1348-1350: Cleanup scandir error at outer level
@@ -3377,9 +3385,9 @@ class TestFirmwarePrereleaseBaselineDerivation:
         assert release_tuple != (2, 7, 15)
 
     @patch("os.scandir")
-    @patch("shutil.rmtree")
+    @patch("fetchtastic.download.firmware._safe_rmtree")
     def test_cleanup_superseded_prereleases_hash_suffixed_tag(
-        self, mock_rmtree, mock_scandir, downloader
+        self, mock_safe_rmtree, mock_scandir, downloader
     ):
         """cleanup_superseded_prereleases should use (2, 7, 22) as baseline from v2.7.22.96dd647."""
         mock_prerelease_keep = Mock()
@@ -3403,7 +3411,11 @@ class TestFirmwarePrereleaseBaselineDerivation:
         result = downloader.cleanup_superseded_prereleases("v2.7.22.96dd647")
 
         assert result is True
-        mock_rmtree.assert_called_once_with("/mock/prerelease/firmware-2.7.22.deadbee")
+        mock_safe_rmtree.assert_called_once_with(
+            "/mock/prerelease/firmware-2.7.22.deadbee",
+            ANY,
+            "firmware-2.7.22.deadbee",
+        )
 
     # =========================================================================
     # Tests for deterministic prerelease directory sorting (review fix 1)
@@ -4942,7 +4954,7 @@ class TestPrereleaseAvailabilityVerification:
             pytest.skip("Symlinks not supported on this platform")
 
         with patch(
-            "fetchtastic.download.firmware.shutil.rmtree",
+            "fetchtastic.download.files.shutil.rmtree",
             side_effect=OSError("busy"),
         ):
             cleaned = downloader.cleanup_superseded_prereleases("v2.7.22")

--- a/tests/test_download_firmware.py
+++ b/tests/test_download_firmware.py
@@ -7,7 +7,7 @@ import os
 import zipfile
 from pathlib import Path
 from typing import ClassVar
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
 import requests
@@ -1577,6 +1577,35 @@ class TestFirmwareReleaseDownloader:
             "Skipping unsafe beta release tag during cleanup: %s",
             beta.tag_name,
         )
+
+    def test_cleanup_old_versions_inventory_checks_symlink_before_directory(
+        self, downloader
+    ):
+        """Firmware cleanup should not stat a symlink target while inventorying versions."""
+        entry = Mock()
+        entry.name = "v1.0.0"
+        entry.path = "/mock/firmware/v1.0.0"
+        entry.is_symlink.return_value = True
+        entry.is_dir.side_effect = OSError("target metadata denied")
+
+        scandir = MagicMock()
+        scandir.__enter__.return_value = [entry]
+        scandir.__exit__.return_value = False
+
+        downloader.get_releases = Mock(return_value=[Release(tag_name="v2.0.0")])
+        downloader.collect_non_revoked_releases = Mock(
+            return_value=([Release(tag_name="v2.0.0")], [Release(tag_name="v2.0.0")], 1)
+        )
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.scandir", return_value=scandir),
+            patch("fetchtastic.download.firmware._safe_rmtree") as safe_rmtree,
+        ):
+            downloader.cleanup_old_versions(keep_limit=1)
+
+        entry.is_dir.assert_not_called()
+        safe_rmtree.assert_not_called()
 
     @pytest.mark.unit
     @patch("os.path.exists")

--- a/tests/test_files_operations.py
+++ b/tests/test_files_operations.py
@@ -26,6 +26,7 @@ from fetchtastic.download.files import (
     _is_release_complete,
     _matches_exclude,
     _prepare_for_redownload,
+    _safe_rmtree,
     _sanitize_path_component,
     safe_extract_path,
     strip_unwanted_chars,
@@ -878,6 +879,20 @@ class TestPrepareForRedownload:
 
         # File should still exist since cleanup failed
         assert main_file.exists()
+
+
+class TestSafeRmtree:
+    """Test containment checks for destructive cleanup."""
+
+    def test_refuses_to_remove_managed_base_directory(self, tmp_path):
+        base = tmp_path / "managed-root"
+        base.mkdir()
+        sentinel = base / "keep.txt"
+        sentinel.write_text("keep")
+
+        assert _safe_rmtree(str(base), str(base), base.name) is False
+        assert base.is_dir()
+        assert sentinel.is_file()
 
 
 class TestSafeExtractPath:

--- a/tests/test_repository_downloader.py
+++ b/tests/test_repository_downloader.py
@@ -204,6 +204,89 @@ class TestRepositoryDownloader:
             result = downloader.clean_repository_directory()
             assert result is True
 
+    def test_clean_repository_directory_continues_after_metadata_error(self, tmp_path):
+        """An unreadable entry should not prevent cleanup of later entries."""
+        downloader = RepositoryDownloader({"DOWNLOAD_DIR": str(tmp_path)})
+        repo_dir = Path(tmp_path) / FIRMWARE_DIR_NAME / REPO_DOWNLOADS_DIR
+        repo_dir.mkdir(parents=True)
+
+        unreadable = MagicMock()
+        unreadable.path = str(repo_dir / "unreadable")
+        unreadable.is_file.side_effect = OSError("metadata denied")
+
+        removable = MagicMock()
+        removable.path = str(repo_dir / "keep-going.txt")
+        removable.is_file.return_value = True
+        removable.is_symlink.return_value = False
+
+        scandir = MagicMock()
+        scandir.__enter__.return_value = [unreadable, removable]
+        scandir.__exit__.return_value = False
+
+        with (
+            patch(
+                "fetchtastic.download.repository.os.scandir",
+                return_value=scandir,
+            ),
+            patch(
+                "fetchtastic.download.repository._safe_rmtree",
+                return_value=True,
+            ) as safe_rmtree,
+        ):
+            assert downloader.clean_repository_directory() is False
+
+        safe_rmtree.assert_called_once_with(
+            removable.path,
+            str(repo_dir),
+            "keep-going.txt",
+        )
+        summary = downloader.get_cleanup_summary()
+        assert summary["removed_files"] == 1
+        assert summary["removed_dirs"] == 0
+        assert summary["success"] is False
+        assert summary["errors"] == ["unreadable: metadata denied"]
+
+    def test_clean_repository_directory_continues_after_rejected_removal(
+        self, tmp_path
+    ):
+        """A rejected removal should be reported without stopping later cleanup."""
+        downloader = RepositoryDownloader({"DOWNLOAD_DIR": str(tmp_path)})
+        repo_dir = Path(tmp_path) / FIRMWARE_DIR_NAME / REPO_DOWNLOADS_DIR
+        repo_dir.mkdir(parents=True)
+
+        blocked = MagicMock()
+        blocked.path = str(repo_dir / "blocked.txt")
+        blocked.is_file.return_value = True
+        blocked.is_symlink.return_value = False
+
+        removable = MagicMock()
+        removable.path = str(repo_dir / "remove.txt")
+        removable.is_file.return_value = True
+        removable.is_symlink.return_value = False
+
+        scandir = MagicMock()
+        scandir.__enter__.return_value = [blocked, removable]
+        scandir.__exit__.return_value = False
+
+        with (
+            patch(
+                "fetchtastic.download.repository.os.scandir",
+                return_value=scandir,
+            ),
+            patch(
+                "fetchtastic.download.repository._safe_rmtree",
+                side_effect=[False, True],
+            ) as safe_rmtree,
+        ):
+            assert downloader.clean_repository_directory() is False
+
+        assert safe_rmtree.call_count == 2
+        summary = downloader.get_cleanup_summary()
+        assert summary["removed_files"] == 1
+        assert summary["removed_dirs"] == 0
+        assert summary["success"] is False
+        assert summary["errors"] == ["blocked.txt: removal failed"]
+
     def test_get_latest_release_tag(self, repository_downloader):
         """Test getting latest release tag."""
         tag = repository_downloader.get_latest_release_tag()

--- a/tests/test_repository_downloader.py
+++ b/tests/test_repository_downloader.py
@@ -204,6 +204,42 @@ class TestRepositoryDownloader:
             result = downloader.clean_repository_directory()
             assert result is True
 
+    def test_clean_repository_directory_checks_symlink_before_target_type(
+        self, tmp_path
+    ):
+        """Cleanup should unlink symlinks without stat'ing their targets first."""
+        downloader = RepositoryDownloader({"DOWNLOAD_DIR": str(tmp_path)})
+        repo_dir = Path(tmp_path) / FIRMWARE_DIR_NAME / REPO_DOWNLOADS_DIR
+        repo_dir.mkdir(parents=True)
+
+        symlink_entry = MagicMock()
+        symlink_entry.path = str(repo_dir / "external-link")
+        symlink_entry.is_symlink.return_value = True
+        symlink_entry.is_file.side_effect = OSError("target metadata denied")
+
+        scandir = MagicMock()
+        scandir.__enter__.return_value = [symlink_entry]
+        scandir.__exit__.return_value = False
+
+        with (
+            patch(
+                "fetchtastic.download.repository.os.scandir",
+                return_value=scandir,
+            ),
+            patch(
+                "fetchtastic.download.repository._safe_rmtree",
+                return_value=True,
+            ) as safe_rmtree,
+        ):
+            assert downloader.clean_repository_directory() is True
+
+        symlink_entry.is_file.assert_not_called()
+        safe_rmtree.assert_called_once_with(
+            symlink_entry.path,
+            str(repo_dir),
+            "external-link",
+        )
+
     def test_clean_repository_directory_continues_after_metadata_error(self, tmp_path):
         """An unreadable entry should not prevent cleanup of later entries."""
         downloader = RepositoryDownloader({"DOWNLOAD_DIR": str(tmp_path)})
@@ -212,6 +248,7 @@ class TestRepositoryDownloader:
 
         unreadable = MagicMock()
         unreadable.path = str(repo_dir / "unreadable")
+        unreadable.is_symlink.return_value = False
         unreadable.is_file.side_effect = OSError("metadata denied")
 
         removable = MagicMock()


### PR DESCRIPTION
## Overview

Cleanup code had several direct filesystem-removal paths with slightly different safety and error handling. This routes those removals through the existing containment-aware helper and tightens the helper itself so cleanup cannot escape or delete the managed root.

## Key Changes

- Route firmware release, firmware prerelease, and repository cleanup removals through `_safe_rmtree`.
- Require every removal target to stay below its expected managed directory.
- Explicitly refuse removal when the resolved target is the managed root itself.
- Handle symlinks as links before checking the target's file/directory metadata, avoiding unnecessary traversal or stat failures on the target.
- Continue cleanup after individual metadata or removal failures instead of aborting the whole pass.
- Preserve a prerelease as a valid `latest` target when its removal fails, so cleanup doesn't report a state that wasn't actually achieved.
- Keep cleanup accounting accurate: only successful removals count as removed.
- Add regression coverage for root deletion attempts, symlink ordering, containment rejection, metadata failures, and normal successful removals.

This does not change which releases cleanup intends to keep or remove. It hardens the filesystem boundary and failure semantics around those existing decisions.